### PR TITLE
Let Travis also execute "skipped" tests

### DIFF
--- a/pascals-triangle/pascals_triangle_test.py
+++ b/pascals-triangle/pascals_triangle_test.py
@@ -1,5 +1,6 @@
 from pascals_triangle import triangle, row, is_triangle
 
+import os
 import unittest
 
 class PascalsTriangleTest(unittest.TestCase):
@@ -7,33 +8,33 @@ class PascalsTriangleTest(unittest.TestCase):
         ans = ['1', '1 1', '1 2 1', '1 3 3 1', '1 4 6 4 1']
         self.assertEqual(ans, triangle(4))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_triangle2(self):
         ans = ['1', '1 1', '1 2 1', '1 3 3 1', '1 4 6 4 1', '1 5 10 10 5 1',
                '1 6 15 20 15 6 1']
         self.assertEqual(ans, triangle(6))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_is_triangle_true(self):
         inp = ['1', '1 1', '1 2 1', '1 3 3 1', '1 4 6 4 1', '1 5 10 10 5 1']
         self.assertEqual(True, is_triangle(inp))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_is_triangle_false(self):
         inp = ['1', '1 1', '1 2 1', '1 4 4 1']
         self.assertEqual(False, is_triangle(inp))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_row1(self):
         ans = '1'
         self.assertEqual(ans, row(0))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_row2(self):
         ans = '1 2 1'
         self.assertEqual(ans, row(2))
 
-    @unittest.skip("Not implemented yet")
+    @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_row3(self):
         ans = '1 7 21 35 35 21 7 1'
         self.assertEqual(ans, row(7))

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -53,6 +53,7 @@ def assignment_name(test_file):
 
 
 def main():
+    os.environ['NO_SKIP'] = '1'  # execute all tests including "@skipped" ones
     failures = []
     for test_file in glob.glob('./*/*_test.py'):
         name = assignment_name(test_file)


### PR DESCRIPTION
Several test suites use the 'unittest.skip' decorator to allow
students to progressively implement features in their solutions.
So far, Travis, too, skipped the decorated test cases, with the result
that these went entirely untested.

This commit fixes this in two steps:
1. The Travis test script will now set the environment variable
   'NO_SKIP'.
2. The unittest.skip decorator is replaced by the unittest.skipUnless
   decorator that will skip tests as usual, unless 'NO_SKIP' is set.
