### PR TITLE
Make rna-transcription exercise compatible with Python3

### DIFF
--- a/rna-transcription/example.py
+++ b/rna-transcription/example.py
@@ -1,4 +1,9 @@
-from string import maketrans
+import sys
+
+if sys.version_info[0] == 2:
+    from string import maketrans
+else:
+    maketrans = str.maketrans
 
 
 class DNA(object):

--- a/rna-transcription/rna_transcription_test.py
+++ b/rna-transcription/rna_transcription_test.py
@@ -1,9 +1,5 @@
-try:
-    import dna
-except ImportError:
-    raise SystemExit('Could not find dna.py. Does it exist?')
-
 import unittest
+import dna
 
 
 class DNATests(unittest.TestCase):


### PR DESCRIPTION
I have also removed the buggy ImportError handling in the test script.
