### PR TITLE
Make ocr-numbers exercise compatible with Python3

### DIFF
--- a/ocr-numbers/example.py
+++ b/ocr-numbers/example.py
@@ -1,16 +1,17 @@
 def number(g):
-    if not g or len(g) < 4 or any(len(r)!=len(g[0]) for r in g):
+    if not g or len(g) < 4 or any(len(r) != len(g[0]) for r in g):
         raise ValueError('Ill-formed grid')
-    if g == [" _ ","| |","|_|","   "]:
+    if g == [" _ ", "| |", "|_|", "   "]:
         return '0'
-    elif g == ["   ","  |","  |","   "]:
+    elif g == ["   ", "  |", "  |", "   "]:
         return '1'
     else:
         return '?'
 
+
 def grid(n):
     if n == '0':
-        return [" _ ","| |","|_|","   "]
+        return [" _ ", "| |", "|_|", "   "]
     elif n == '1':
-        return ["   ","  |","  |","   "]
+        return ["   ", "  |", "  |", "   "]
     raise ValueError('Unknown digit')

--- a/ocr-numbers/ocr_test.py
+++ b/ocr-numbers/ocr_test.py
@@ -1,56 +1,57 @@
-try:
-    from ocr import number, grid
-except ImportError:
-    raise SystemExit('Could not find ocr.py. Does it exist?')
+"""Tests for the ocr-numbers exercise
+
+Implementation note:
+Both ocr.grid and ocr.number should validate their input
+and raise ValueErrors with meaningful error messages
+if necessary.
+"""
 
 import os
 import unittest
 
+from ocr import grid, number
+
+
 class OcrTest(unittest.TestCase):
+
     def test_0(self):
-        self.assertEqual('0', number([" _ ","| |","|_|","   "]))
+        self.assertEqual('0', number([" _ ", "| |", "|_|", "   "]))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_1(self):
-        self.assertEqual('1', number(["   ","  |","  |","   "]))
+        self.assertEqual('1', number(["   ", "  |", "  |", "   "]))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_garbage(self):
-        self.assertEqual('?', number([" _ "," _|","  |","   "]))
+        self.assertEqual('?', number([" _ ", " _|", "  |", "   "]))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_last_line_nonblank(self):
-        self.assertEqual('?', number(["   ","  |","  |","| |"]))
+        self.assertEqual('?', number(["   ", "  |", "  |", "| |"]))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_unknown_char(self):
-        self.assertEqual('?', number([" - "," _|"," X|","   "]))
+        self.assertEqual('?', number([" - ", " _|", " X|", "   "]))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_too_short_row(self):
-        with self.assertRaises(ValueError) as context:
-            number(["   "," _|"," |","   "])
-        self.assertEqual(context.exception.message, 'Ill-formed grid')
+        self.assertRaises(ValueError, number, ["   ", " _|", " |", "   "])
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_insufficient_rows(self):
-        with self.assertRaises(ValueError) as context:
-            number(["   "," _|"," X|"])
-        self.assertEqual(context.exception.message, 'Ill-formed grid')
+        self.assertRaises(ValueError, number, ["   ", " _|", " X|"])
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_grid0(self):
-        self.assertEqual([" _ ","| |","|_|","   "], grid('0'))
+        self.assertEqual([" _ ", "| |", "|_|", "   "], grid('0'))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_grid1(self):
-        self.assertEqual(["   ","  |","  |","   "], grid('1'))
+        self.assertEqual(["   ", "  |", "  |", "   "], grid('1'))
 
     @unittest.skipUnless('NO_SKIP' in os.environ, "Not implemented yet")
     def test_invalid_digit(self):
-        with self.assertRaises(ValueError) as context:
-            grid('2')
-        self.assertEqual(context.exception.message, 'Unknown digit')
+        self.assertRaises(ValueError, grid, '2')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `assertRaises`-context-assertions had necessarily to be changed because this syntax was removed with Python3. They were replaced by simple `assertRaises` in compliance with https://github.com/exercism/xpython/issues/30. A comment in the test suite specifies that raised exceptions must include error messages.

The other changes are formatting changes introduced by a run of autopep8.
