### PR TITLE
Make hexadecimal exercise compatible with Python3

### DIFF
--- a/hexadecimal/example.py
+++ b/hexadecimal/example.py
@@ -1,12 +1,10 @@
+from functools import reduce
+
+
 def hexa(s):
     s = s.lower()
     if set(s) - set('0123456789abcdef'):
         raise ValueError('Invalid hexadecimal string')
     l = [ord(c) - ord('a') + 10 if c in 'abcdef' else ord(c) - ord('0')
-            for c in s]
-    return reduce(lambda x,y:x*16 + y, l, 0)
-
-if __name__ == '__main__':
-    print hexa('19ACE')
-    print hexa('100')
-    print hexa('dead')
+         for c in s]
+    return reduce(lambda x, y: x * 16 + y, l, 0)

--- a/hexadecimal/hexadecimal_test.py
+++ b/hexadecimal/hexadecimal_test.py
@@ -1,11 +1,13 @@
-# To avoid trivial solutions, try to solve this problem without the 
+# To avoid trivial solutions, try to solve this problem without the
 # function int(s, base=16)
 
 from hexadecimal import hexa
 
 import unittest
 
+
 class HexadecimalTest(unittest.TestCase):
+
     def test_valid_hexa1(self):
         self.assertEqual(1, hexa('1'))
 


### PR DESCRIPTION
Apart from the additional `functools.reduce` import for Python3, this commit removes the print statements from the example implementation as they weren't necessary for the solution.
