### PR TITLE
octal: Adopt functional style

### DIFF
--- a/octal/example.py
+++ b/octal/example.py
@@ -1,13 +1,11 @@
-class Octal(object):
-    def __init__(self, octal_string):
-        self.digits = self.__validate(octal_string)
+def parse_octal(digits):
+    digits = _validate_octal(digits)
+    return sum(int(digit) * 8 ** i
+               for (i, digit) in enumerate(reversed(digits)))
 
-    def __validate(self, s):
-        for char in s:
-            if not '0' <= char < '8':
-                raise ValueError("Invalid octal digit: " + char)
-        return s
 
-    def to_decimal(self):
-        return sum(int(digit) * 8 ** i
-                   for (i, digit) in enumerate(reversed(self.digits)))
+def _validate_octal(digits):
+    for d in digits:
+        if not '0' <= d < '8':
+            raise ValueError("Invalid octal digit: " + d)
+    return digits

--- a/octal/octal_test.py
+++ b/octal/octal_test.py
@@ -1,44 +1,44 @@
 """Tests for the octal exercise
 
 Implementation note:
-If an instance of the Octal class is initialized with an invalid string,
-it must raise a ValueError with a meaningful error message.
+If the string supplied to parse_octal cannot be parsed as an octal number
+your program should raise a ValueError with a meaningful error message.
 """
 import unittest
 
-from octal import Octal
+from octal import parse_octal
 
 
 class OctalTest(unittest.TestCase):
     def test_octal_1_is_decimal_1(self):
-        self.assertEqual(1, Octal("1").to_decimal())
+        self.assertEqual(1, parse_octal("1"))
 
     def test_octal_10_is_decimal_8(self):
-        self.assertEqual(8, Octal("10").to_decimal())
+        self.assertEqual(8, parse_octal("10"))
 
     def test_octal_17_is_decimal_15(self):
-        self.assertEqual(15, Octal("17").to_decimal())
+        self.assertEqual(15, parse_octal("17"))
 
     def test_octal_130_is_decimal_88(self):
-        self.assertEqual(88, Octal("130").to_decimal())
+        self.assertEqual(88, parse_octal("130"))
 
     def test_octal_2047_is_decimal_1063(self):
-        self.assertEqual(1063, Octal("2047").to_decimal())
+        self.assertEqual(1063, parse_octal("2047"))
 
     def test_octal_1234567_is_decimal_342391(self):
-        self.assertEqual(342391, Octal("1234567").to_decimal())
+        self.assertEqual(342391, parse_octal("1234567"))
 
     def test_8_is_seen_as_invalid(self):
-        self.assertRaises(ValueError, Octal, "8")
+        self.assertRaises(ValueError, parse_octal, "8")
 
     def test_invalid_octal_is_recognized(self):
-        self.assertRaises(ValueError, Octal, "carrot")
+        self.assertRaises(ValueError, parse_octal, "carrot")
 
     def test_6789_is_seen_as_invalid(self):
-        self.assertRaises(ValueError, Octal, "6789")
+        self.assertRaises(ValueError, parse_octal, "6789")
 
     def test_valid_octal_formatted_string_011_is_decimal_9(self):
-        self.assertEqual(9, Octal("011").to_decimal())
+        self.assertEqual(9, parse_octal("011"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As discussed in #79.

The original Octal.to_decimal method is replaced by the parse_octal
function which seems more aptly named.
