### PR TITLE
robot-name: Narrow constraints for robot names

### DIFF
--- a/robot-name/robot_name_test.py
+++ b/robot-name/robot_name_test.py
@@ -4,7 +4,7 @@ from robot import Robot
 
 
 class RobotTest(unittest.TestCase):
-    name_re = r'\w{2}\d{3}'
+    name_re = r'^[A-Z]{2}\d{3}$'
 
     def test_has_name(self):
         self.assertRegexpMatches(Robot().name, self.name_re)


### PR DESCRIPTION
The previous version of the regex that checks the robot names would also
accept names that didn't quite fit the pattern of the README. Wrong but
accepted robot names were:
- "12345"
- "AB123xyz"

This commit changes the regex to catch bad robot names like these.
