### PR TITLE
Update nucleotide_count_test.py

### DIFF
--- a/nucleotide-count/nucleotide_count_test.py
+++ b/nucleotide-count/nucleotide_count_test.py
@@ -26,10 +26,7 @@ class DNATest(unittest.TestCase):
 
     def test_counts_only_thymidine(self):
         self.assertEqual(1, count('GGGGGTAACCCGG', 'T'))
-
-    def test_dna_has_no_uracil(self):
-        self.assertEqual(0, count('GATTACA', 'U'))
-
+        
     def test_validates_nucleotides(self):
         with self.assertRaises(ValueError):
             count("GACT", 'X')


### PR DESCRIPTION
Removed test_dna_has_no_uracil for a couple of reasons
- The module is named dna.py and in the README.md we see that DNA does not contain uracil only RNA does
- If 'U' is added to the dictionary it causes test_counts_all_nucleotides, test_empty_dna_string_has_no_nucleotides, and test_repetitive_sequence_has_only_guanosine to fail.
- I believe that counting for 'U' should also throw a ValueError

As of now the only solution I could think of was to add the following:
if nucleotype is 'U': return 0 
which seems inelegant to me.

Hope this helps,

Oniwa
