### PR TITLE
Slightly different input in test_irregular_matrix

### DIFF
--- a/saddle-points/saddle_points_test.py
+++ b/saddle-points/saddle_points_test.py
@@ -12,22 +12,23 @@ from saddle_points import saddle_points
 
 class SaddlePointTest(unittest.TestCase):
     def test_one_saddle(self):
-        inp = [[9,8,7],[5,3,2],[6,6,7]]
-        self.assertEqual(set([(1,0)]), saddle_points(inp))
+        inp = [[9, 8, 7], [5, 3, 2], [6, 6, 7]]
+        self.assertEqual(set([(1, 0)]), saddle_points(inp))
 
     def test_no_saddle(self):
-        self.assertEqual(set(), saddle_points([[2,1],[1,2]]))
+        self.assertEqual(set(), saddle_points([[2, 1], [1, 2]]))
 
     def test_mult_saddle(self):
-        inp = [[5,3,5,4],[6,4,7,3],[5,1,5,3]]
-        ans = set([(0,0),(0,2),(2,0),(2,2)])
+        inp = [[5, 3, 5, 4], [6, 4, 7, 3], [5, 1, 5, 3]]
+        ans = set([(0, 0), (0, 2), (2, 0), (2, 2)])
         self.assertEqual(ans, saddle_points(inp))
 
     def test_empty_matrix(self):
         self.assertEqual(set(), saddle_points([]))
 
     def test_irregular_matrix(self):
-        self.assertRaises(ValueError, saddle_points, [[1,2,3],[2,3],[3,2,1]])
+        inp = [[3, 2, 1], [0, 1], [2, 1, 0]]
+        self.assertRaises(ValueError, saddle_points, inp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
First I wanted to add another one test case, but I think it's better to just tweak the existing one.

Problem was, that first iteration of my solution, which you can see here:
http://exercism.io/submissions/79295d1e2a18156d8faf3326
passed all test, but it wasn't checking for irregularity of matrix at all. It was just catching
IndexError when checking if some max value in row is also min value in its column.
It is design error - I know, but as long as max value in longest row isn't on the right - this
method wouldn't recognize that matrix is irregular.
In case of situation that someone else repeats this error in future, I propose this test case change. :)

Also taking the opportunity, I added few whitespaces in compliance with PEP8.
