### PR TITLE
Expect more naive tokenization in the wordcount problem

### DIFF
--- a/word-count/example.py
+++ b/word-count/example.py
@@ -1,17 +1,9 @@
 from collections import Counter
-import re
-
-
-WORD_RE = re.compile(r'\w+')
 
 
 def word_count(text):
     """Return a Counter object that maps from the words contained in
     the phrase to their respective counts
     """
-    return Counter(_words(text))
-
-
-def _words(text):
-    """Yield all the words, i.e. alphanumeric sequences, in the text """
-    return (match.group() for match in WORD_RE.finditer(text.lower()))
+    return Counter(text.split())
+    

--- a/word-count/word_count_test.py
+++ b/word-count/word_count_test.py
@@ -22,22 +22,35 @@ class WordCountTests(unittest.TestCase):
             word_count('one fish two fish red fish blue fish')
         )
 
-    def test_ignore_punctuation(self):
+    def test_preserves_punctuation(self):
         self.assertEqual(
-            {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1},
+            {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, ':': 2, 'javascript!!&@$%^&': 1},
             word_count('car : carpet as java : javascript!!&@$%^&')
         )
 
     def test_include_numbers(self):
         self.assertEqual(
             {'testing': 2, '1': 1, '2': 1},
-            word_count('testing, 1, 2 testing')
+            word_count('testing 1 2 testing')
         )
 
-    def test_normalize_case(self):
+    def test_mixed_case(self):
         self.assertEqual(
-            {'go': 3},
+            {'go': 1, 'Go': 1, 'GO': 1},
             word_count('go Go GO')
+        )
+        
+    def test_multiple_spaces(self):
+      self.assertEqual(
+          {'wait': 1, 'for': 1, 'it': 1},
+          word_count('wait for       it')
+      )
+        
+    def test_newlines(self):
+        self.assertEqual(
+            {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2, 
+            'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
+            word_count('rah rah ah ah ah\nroma roma ma\nga ga oh la la\nwant your bad romance')
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
I checked out [the tutorial this problem was taken from](http://tour.golang.org/#43), and they do simple tokenization with no special handling of case or punctuation. I think this is the more natural way of doing it. 

(The problem with trying to strip punctuation is that holy cow language is complicated. Ideally you would remove the period from "complicated." at the end of that sentence, but aren't the apostrophes in "'tis" or "bitchin'" or "isn't" parts of those words? And then there are unicode combining characters...)

If this looks okay, I'm happy to make the same change for other languages.
