### PR TITLE
hamming: Reimplement adhering to standard definition

### DIFF
--- a/hamming/example.py
+++ b/hamming/example.py
@@ -1,10 +1,2 @@
-import sys
-
-if sys.version_info[0] == 2:
-    from itertools import izip_longest as zip_longest
-else:
-    from itertools import zip_longest
-
-
-def hamming(s1, s2):
-    return sum(1 for a, b in zip_longest(s1, s2) if a != b)
+def distance(s1, s2):
+    return sum(a != b for a, b in zip(s1, s2))

--- a/hamming/hamming_test.py
+++ b/hamming/hamming_test.py
@@ -1,41 +1,30 @@
 import unittest
 
-from hamming import hamming
+import hamming
 
-# If the sequences have different lengths, assume the shorter one is extended
-# with nucleotides in such a way to guarantee the extra nucleotides are all
-# different between the two strands.
 
-class hammingdecimalTest(unittest.TestCase):
-    def test_hamming_empty(self):
-        self.assertEqual(0, hamming('',''))
+class HammingTest(unittest.TestCase):
 
-    def test_hamming_onenucleotide_same(self):
-        self.assertEqual(0, hamming('A','A'))
+    def test_no_difference_between_identical_strands(self):
+        self.assertEqual(0, hamming.distance('A', 'A'))
 
-    def test_hamming_onenucleotide_different(self):
-        self.assertEqual(1, hamming('A','G'))
+    def test_complete_hamming_distance_of_for_single_nucleotide_strand(self):
+        self.assertEqual(1, hamming.distance('A', 'G'))
 
-    def test_hamming_short1(self):
-        self.assertEqual(1, hamming('AT','CT'))
+    def test_complete_hamming_distance_of_for_small_strand(self):
+        self.assertEqual(2, hamming.distance('AG', 'CT'))
 
-    def test_hamming_short2(self):
-        self.assertEqual(2, hamming('AG','CT'))
+    def test_small_hamming_distance(self):
+        self.assertEqual(1, hamming.distance('AT', 'CT'))
 
-    def test_hamming_large(self):
-        self.assertEqual(4, hamming('GGATCG','CCTGCG'))
+    def test_small_hamming_distance_in_longer_strand(self):
+        self.assertEqual(1, hamming.distance('GGACG', 'GGTCG'))
 
-    def test_hamming_small(self):
-        self.assertEqual(1, hamming('GGACGA','GGTCGA'))
+    def test_large_hamming_distance(self):
+        self.assertEqual(4, hamming.distance('GATACA', 'GCATAA'))
 
-    def test_hamming_very_long(self):
-        self.assertEqual(9, hamming('GGACGGATTCTG','AGGACGGATTCT'))
-
-    def test_hamming_different_length1(self):
-        self.assertEqual(4, hamming('AAGCTAC','ACGTT'))
-
-    def test_hamming_different_length2(self):
-        self.assertEqual(5, hamming('AAGCTAC','ACGTTACGTC'))
+    def test_hamming_distance_in_very_long_strand(self):
+        self.assertEqual(9, hamming.distance('GGACGGATTCTG', 'AGGACGGATTCT'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As noted in https://github.com/exercism/exercism.io/issues/1867 the
exercise didn't adhere to the standard definition of the Hamming
distance which applies only to strings of the same length.

The following changes are made to fix the problem:
- The example solution is changed to respect the standard definition.
- Test cases for strings of differing lengths are removed.

This commit also contains the following additional changes:
- Some stylistic improvements for the test suite
- The name of the function is changed from 'hamming' to 'distance'
  resulting in a qualified name of 'hamming.distance'.

Fixes https://github.com/exercism/xpython/issues/115
