### PR TITLE
Add back tests for Hamming distance of unequal strings, expect 'None'.

### DIFF
--- a/hamming/hamming_test.py
+++ b/hamming/hamming_test.py
@@ -26,6 +26,11 @@ class HammingTest(unittest.TestCase):
     def test_hamming_distance_in_very_long_strand(self):
         self.assertEqual(9, hamming.distance('GGACGGATTCTG', 'AGGACGGATTCT'))
 
+    def test_hamming_distance_unequal_strings_1(self):
+        self.assertIsNone(hamming.distance('AAA', 'AAAG'))
+
+    def test_hamming_distance_unequal_strings_2(self):
+        self.assertIsNone(hamming.distance('AAAG', 'AAA'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Seems a shame to lose the tests. "None" seems a reasonable answer for an undefined results here.
