### PR TITLE
Update bob tests to handle input ending in whitespace

### DIFF
--- a/bob/bob_test.py
+++ b/bob/bob_test.py
@@ -109,5 +109,10 @@ class BobTests(unittest.TestCase):
             'Whatever.', bob.hey('         hmmmmmmm...')
         )
 
+    def test_ends_with_whitespace(self):
+        self.assertEqual(
+            'Sure.', bob.hey('What if we end with whitespace?   ')
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/bob/example.py
+++ b/bob/example.py
@@ -1,4 +1,6 @@
 def hey(stimulus):
+    stimulus = stimulus.strip()
+
     if _is_silence(stimulus):
         return 'Fine. Be that way!'
     elif _is_shouting(stimulus):
@@ -10,7 +12,7 @@ def hey(stimulus):
 
 
 def _is_silence(stimulus):
-    return stimulus.strip() == ''
+    return stimulus == ''
 
 
 def _is_shouting(stimulus):


### PR DESCRIPTION
While nit-picking, I noticed a lot of users were failing to acknowledge the case where valid input ends with whitespace. Stripping at the wrong time would result in bob responding to a valid question (for example) with "Whatever."

This PR adds a test for this scenario. The `example.py` file was also incorrectly handling this type of input, so I have corrected that file as well.

As a small note, the first commit in this PR fixes a minor formatting mistake (whitespace trailing a function).
