### PR TITLE
crypto-square: Reimplement according to updated README

### DIFF
--- a/crypto-square/crypto_square_test.py
+++ b/crypto-square/crypto_square_test.py
@@ -1,40 +1,29 @@
 import unittest
 
-from crypto_square import encode, decode
+from crypto_square import encode
 
 
 class CryptoSquareTest(unittest.TestCase):
-    def test_empty_plain(self):
+
+    def test_empty_string(self):
         self.assertEqual('', encode(''))
 
     def test_perfect_square(self):
-        self.assertEqual('wliod drwe', encode('WorldWide'))
+        self.assertEqual('ac bd', encode('ABCD'))
 
-    def test_almost_perfect_square(self):
-        self.assertEqual('oasny selde', encode('One day less'))
+    def test_small_imperfect_square(self):
+        self.assertEqual('tis hsy ie sa', encode('This is easy!'))
 
-    def test_punctuation(self):
+    def test_punctuation_and_numbers(self):
         msg = "1, 2, 3, Go! Go, for God's sake!"
-        ciph = '1gga2 ook3f degos ors'
+        ciph = '1gga 2ook 3fde gos ors'
         self.assertEqual(ciph, encode(msg))
 
     def test_long_string(self):
-        msg = "Be who you are and say what you feel, because those who mind "\
-              "don't matter and those who matter don't mind."
-        ciph = 'betcw tttne ayahm htdwn ouoao ehdus mtsro sfeit edyae tnewo '\
-               'oyehd rhnuw lodao tahbs onmmr aeend ai'
+        msg = ("If man was meant to stay on the ground, god would have given "
+               "us roots.")
+        ciph = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau"
         self.assertEqual(ciph, encode(msg))
-
-    def test_decode(self):
-        ciph = 'woree iorhu ssmtp eefei aiafn ildjs ulenf eotse vdoor iecey '\
-               'nfima trott tenyu hhytd'
-        msg = 'wheneveryoufindyourselfonthesideofthemajorityitistimetopausea'\
-              'ndreflect'
-        self.assertEqual(msg, decode(ciph))
-
-    def test_encode_decode(self):
-        msg = 'tensioniswhoyouthinkyoushouldberelaxationiswhoyouare'
-        self.assertEqual(msg, decode(encode(msg)))
 
 
 if __name__ == '__main__':

--- a/crypto-square/example.py
+++ b/crypto-square/example.py
@@ -1,41 +1,18 @@
-import math
+from math import ceil, sqrt
+import sys
+
+if sys.version_info[0] == 2:
+    from itertools import izip_longest as zip_longest
+else:
+    from itertools import zip_longest
 
 
 def encode(msg):
     msg = _cleanse(msg)
-    sqrsz = int(math.sqrt(len(msg)))
-    if sqrsz * sqrsz < len(msg):
-        sqrsz += 1
-
-    cols = [msg[i1::sqrsz] for i1 in range(sqrsz)]
-    cols_str = ''.join(cols)
-    return ' '.join(cols_str[i1:i1 + 5] for i1 in range(0, len(cols_str), 5))
-
-
-def decode(ciph):
-    ciph = _cleanse(ciph)
-    sqrsz = int(math.sqrt(len(ciph)))
-    if sqrsz * sqrsz < len(ciph):
-        sqrsz += 1
-    colsz, nbr_full_cols = divmod(len(ciph), sqrsz)
-
-    # The matrix produced by the plaintext is in general irregular, and the
-    # last row is usually shorter than the others. Extract this row first
-    full_cols_str = ciph[:(colsz + 1) * nbr_full_cols]
-    partial_cols_str = ciph[(colsz + 1) * nbr_full_cols:]
-    last_row = full_cols_str[colsz::colsz + 1]
-
-    # Compute the string of all concatenated columns of the colsz X sqrsz
-    # matrix consisting of the first colsz rows of the plaintext (irregular)
-    # matrix
-    trimmed_full_cols = [full_cols_str[i1:i1 + colsz]
-                         for i1 in range(0, len(full_cols_str), colsz + 1)]
-    partial_cols = [partial_cols_str[i1:i1 + colsz]
-                    for i1 in range(0, len(partial_cols_str), colsz)]
-    uniform_cols_str = ''.join(trimmed_full_cols + partial_cols)
-
-    other_rows = [uniform_cols_str[i1::colsz] for i1 in range(colsz)]
-    return ''.join(other_rows + [last_row])
+    square_size = int(ceil(sqrt(len(msg))))
+    square = _chunks_of(msg, square_size)
+    return ' '.join([''.join(col)
+                     for col in zip_longest(*square, fillvalue='')])
 
 
 def _cleanse(s):
@@ -44,8 +21,7 @@ def _cleanse(s):
     return ''.join([c for c in s if c.isalnum()]).lower()
 
 
-if __name__ == '__main__':
-    msg = 'ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots'
-    ciph = 'imtgd vsfea rwerm ayoog oanou uiont nnlvt wttdd esaoh ghnss eoau'
-    print(encode(msg))
-    print(decode(ciph))
+def _chunks_of(s, n):
+    if len(s) <= n:
+        return [s]
+    return [s[:n]] + _chunks_of(s[n:], n)


### PR DESCRIPTION
As pointed out in https://github.com/exercism/x-common/pull/28
the tests used to require output chunked into groups of 5 characters.

This commit changes the test suite and example implementation to
alleviate this.
- The encode function in the example implementation is rewritten to
  behave according to the new requirements.
- The decode function is removed because there is no mention of it in
  the README and because it cannot completely restore the original
  string.
- The test suite is changed to contain several test cases of increasing
  difficulty.

Fixes https://github.com/exercism/xpython/issues/130
