### PR TITLE
queen-attack: Use '_'s instead of 'O's for empty squares

### DIFF
--- a/queen-attack/example.py
+++ b/queen-attack/example.py
@@ -2,7 +2,7 @@ def board(pos1, pos2):
     validate_position(pos1, pos2)
     x1, y1 = pos1
     x2, y2 = pos2
-    b = [['0']*8 for i in range(8)]
+    b = [['_'] * 8 for i in range(8)]
     b[x1][y1] = 'W'
     b[x2][y2] = 'B'
     return [''.join(r) for r in b]

--- a/queen-attack/queen_attack_test.py
+++ b/queen-attack/queen_attack_test.py
@@ -5,13 +5,13 @@ from queen_attack import board, can_attack
 
 class QueenAttackTest(unittest.TestCase):
     def test_board1(self):
-        ans = ['00000000', '00000000', '000W0000', '00000000',
-               '00000000', '000000B0', '00000000', '00000000']
+        ans = ['________', '________', '___W____', '________',
+               '________', '______B_', '________', '________']
         self.assertEqual(ans, board((2, 3), (5, 6)))
 
     def test_board2(self):
-        ans = ['000000W0', '0000000B', '00000000', '00000000',
-               '00000000', '00000000', '00000000', '00000000']
+        ans = ['______W_', '_______B', '________', '________',
+               '________', '________', '________', '________']
         self.assertEqual(ans, board((0, 6), (1, 7)))
 
     def test_attack_true1(self):


### PR DESCRIPTION
Closes https://github.com/exercism/xpython/issues/133
