### PR TITLE
ocr-numbers: make tests more readable and allow grid('2')

### DIFF
--- a/ocr-numbers/ocr_test.py
+++ b/ocr-numbers/ocr_test.py
@@ -12,37 +12,62 @@ import unittest
 from ocr import grid, number
 
 
+ZERO = [
+    " _ ",
+    "| |",
+    "|_|",
+    "   "
+]
+
+ONE = [
+    "   ",
+    "  |",
+    "  |",
+    "   "
+]
+
 class OcrTest(unittest.TestCase):
 
     def test_0(self):
-        self.assertEqual('0', number([" _ ", "| |", "|_|", "   "]))
+        self.assertEqual('0', number(ZERO))
 
     def test_1(self):
-        self.assertEqual('1', number(["   ", "  |", "  |", "   "]))
+        self.assertEqual('1', number(ONE))
 
     def test_garbage(self):
-        self.assertEqual('?', number([" _ ", " _|", "  |", "   "]))
+        self.assertEqual('?', number([" _ ",
+                                      " _|",
+                                      "  |",
+                                      "   "]))
 
     def test_last_line_nonblank(self):
-        self.assertEqual('?', number(["   ", "  |", "  |", "| |"]))
+        self.assertEqual('?', number(["   ",
+                                      "  |",
+                                      "  |",
+                                      "| |"]))
 
     def test_unknown_char(self):
-        self.assertEqual('?', number([" - ", " _|", " X|", "   "]))
+        self.assertEqual('?', number([" - ",
+                                      " _|",
+                                      " X|",
+                                      "   "]))
 
     def test_too_short_row(self):
-        self.assertRaises(ValueError, number, ["   ", " _|", " |", "   "])
+        self.assertRaises(ValueError, number, ["   ",
+                                               " _|",
+                                               " |",
+                                               "   "])
 
     def test_insufficient_rows(self):
-        self.assertRaises(ValueError, number, ["   ", " _|", " X|"])
+        self.assertRaises(ValueError, number, ["   ",
+                                               " _|",
+                                               " X|"])
 
     def test_grid0(self):
-        self.assertEqual([" _ ", "| |", "|_|", "   "], grid('0'))
+        self.assertEqual(ZERO, grid('0'))
 
     def test_grid1(self):
-        self.assertEqual(["   ", "  |", "  |", "   "], grid('1'))
-
-    def test_invalid_digit(self):
-        self.assertRaises(ValueError, grid, '2')
+        self.assertEqual(ONE, grid('1'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed the test_invalid_digit code to use 'a' instead of '2' as an invalid digit. This allows coders to extend their code to produce grids for all numbers 0 - 9, without failing the tests.

The formatting of the number grids in the tests has been modified, to make the tests easier to read.
