### PR TITLE
sum-of-multiples: Implemented issue #141

### DIFF
--- a/sum-of-multiples/example.py
+++ b/sum-of-multiples/example.py
@@ -1,13 +1,5 @@
-class SumOfMultiples(object):
-
-    def __init__(self, *args):
-        self.numbers = args if args else [3, 5]
-
-    def to(self, limit):
-        return sum(n
-                   for n in range(limit)
-                   if self.is_multiple(n))
-
-    def is_multiple(self, m):
-        return any(m % n == 0
-                   for n in self.numbers)
+def sum_of_multiples(limit, multiples=None):
+    if multiples is None:
+        multiples = [3, 5]
+    return sum(value for value in range(limit)
+               if any(value % multiple == 0 for multiple in multiples))

--- a/sum-of-multiples/sum_of_multiples_test.py
+++ b/sum-of-multiples/sum_of_multiples_test.py
@@ -1,26 +1,26 @@
 import unittest
 
-from sum_of_multiples import SumOfMultiples
+from sum_of_multiples import sum_of_multiples
 
 
 class SumOfMultiplesTest(unittest.TestCase):
     def test_sum_to_1(self):
-        self.assertEqual(0, SumOfMultiples().to(1))
+        self.assertEqual(0, sum_of_multiples(1))
 
     def test_sum_to_3(self):
-        self.assertEqual(3, SumOfMultiples().to(4))
+        self.assertEqual(3, sum_of_multiples(4))
 
     def test_sum_to_10(self):
-        self.assertEqual(23, SumOfMultiples().to(10))
+        self.assertEqual(23, sum_of_multiples(10))
 
     def test_sum_to_1000(self):
-        self.assertEqual(233168, SumOfMultiples().to(1000))
+        self.assertEqual(233168, sum_of_multiples(1000))
 
     def test_configurable_7_13_17_to_20(self):
-        self.assertEqual(51, SumOfMultiples(7, 13, 17).to(20))
+        self.assertEqual(51, sum_of_multiples(20, [7, 13, 17]))
 
     def test_configurable_43_47_to_10000(self):
-        self.assertEqual(2203160, SumOfMultiples(43, 47).to(10000))
+        self.assertEqual(2203160, sum_of_multiples(10000, [43, 47]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implemented issue #141 which requested that sum_of_multiples use a function rather than a class.

I implemented the multiples as a list because it made it easier to differentiate them from the limit when looking at the test file. In the example I set the default multiples to None to avoid a python gotcha with mutable default arguments.

http://docs.python-guide.org/en/latest/writing/gotchas/
