### PR TITLE
grains: Cleaned up Example

### DIFF
--- a/grains/example.py
+++ b/grains/example.py
@@ -3,7 +3,7 @@ def on_square(number):
 
 
 def total_after(square):
-    return sum([
+    return sum(
         on_square(n + 1) for n
-        in range(0, square)
-    ])
+        in range(square)
+    )


### PR DESCRIPTION
Implemented issue #141 which requested that sum_of_multiples use a function rather than a class.

I implemented the multiples as a list because it made it easier to differentiate them from the limit when looking at the test file. In the example I set the default multiples to None to avoid a python gotcha with mutable default arguments.

http://docs.python-guide.org/en/latest/writing/gotchas/
