### PR TITLE
fixes grade-school tests to enforce order

### DIFF
--- a/grade-school/example.py
+++ b/grade-school/example.py
@@ -13,7 +13,5 @@ class School(object):
         return self.db[level]
 
     def sort(self):
-        return {
-            grade: tuple(sorted(students))
-            for grade, students in self.db.items()
-        }
+        return sorted((grade, tuple(sorted(students)))
+                      for grade, students in self.db.items())

--- a/grade-school/grade_school_test.py
+++ b/grade-school/grade_school_test.py
@@ -1,3 +1,5 @@
+from collections import Sequence
+from types import GeneratorType
 import unittest
 
 from school import School
@@ -35,16 +37,28 @@ class SchoolTest(unittest.TestCase):
         self.assertEqual(set(), self.school.grade(1))
 
     def test_sort_school(self):
-        self.school.add("Jennifer", 4)
-        self.school.add("Kareem", 6)
-        self.school.add("Christopher", 4)
-        self.school.add("Kyle", 3)
-        sorted_students = {
-            3: ("Kyle",),
-            4: ("Christopher", "Jennifer",),
-            6: ("Kareem",)
-        }
-        self.assertEqual(sorted_students, self.school.sort())
+        students = [
+            (3, ("Kyle",)),
+            (4, ("Christopher", "Jennifer",)),
+            (6, ("Kareem",))
+        ]
+
+        for grade, students_in_grade in students:
+            for student in students_in_grade:
+                self.school.add(student, grade)
+
+        result = self.school.sort()
+
+        # Attempts to catch false positives
+        self.assertTrue(isinstance(result, Sequence) or
+                        isinstance(result, GeneratorType) or
+                        callable(getattr(result, '__reversed__', False)))
+
+        result_list = list(result.items() if hasattr(result, "items")
+                           else result)
+
+        self.assertEqual(result_list, students)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[The specification](https://github.com/exercism/x-common/blob/master/grade-school.md) for this exercise requires that the user's code return "a sorted list of all students in all grades". However, the previous test compared the result against a dictionary, which doesn't enforce that order. This PR addresses that. Works on Python 3.4 and 2.7 on my machine.

It should accept only ordered iterators that return tuples. This generator-based implementation also works:

``` python
def sort(self):
    for grade, students in self.db.items():
        yield (grade, tuple(sorted(students)))
```

I don't see how to express in the tests that this implementation also works. If so, LMK and I'll submit a new PR if that's the right thing to do..

closes #151. See that issue for design decisions implemented here.

Made possible by great feedback from @Dog and @sjakobi! Thanks, y'all!
