### PR TITLE
Bowling: Implement bowling exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -442,6 +442,14 @@
         "strings",
         "searching"
       ]
+    },
+    {
+      "slug": "bowling",
+      "difficulty": 6,
+      "topics": [
+        "Algorithms",
+        "Control-flow (loops)"
+      ]
     }
   ],
   "deprecated": [

--- a/exercises/bowling/bowling_test.py
+++ b/exercises/bowling/bowling_test.py
@@ -1,0 +1,180 @@
+import unittest
+from bowling import BowlingGame
+
+
+class BowlingTest(unittest.TestCase):
+    def test_should_be_able_to_score_a_game_with_all_zeros(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 0)
+
+    def test_should_be_able_to_score_a_game_with_no_strikes_or_spares(self):
+            rolls = [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 90)
+
+    def test_a_spare_followed_by_zeros_is_worth_ten_points(self):
+            rolls = [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 10)
+
+    def test_points_scored_in_the_roll_after_a_spare_are_counted_twice(self):
+            rolls = [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 16)
+
+    def test_consecutive_spares_each_get_a_one_roll_bonus(self):
+            rolls = [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 31)
+
+    def test_a_spare_in_the_last_frame_gets_a_one_roll_bonus_that_is_counted_once(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 17)
+
+    def test_a_strike_earns_ten_points_in_a_frame_with_a_single_roll(self):
+            rolls = [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 10)
+
+    def test_points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus(self):
+            rolls = [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 26)
+
+    def test_consecutive_strikes_each_get_the_two_roll_bonus(self):
+            rolls = [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 81)
+
+    def test_a_strike_in_the_last_frame_gets_a_two_roll_bonus_that_is_counted_once(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 18)
+
+    def test_rolling_a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 20)
+
+    def test_strikes_with_the_two_roll_bonus_do_not_get_bonus_rolls(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 30)
+
+    def test_a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 20)
+
+    def test_all_strikes_is_a_perfect_game(self):
+            rolls = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 300)
+
+    def test_rolls_can_not_score_negative_points(self):
+            rolls = []
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(-1)
+            self.assertEqual(str(cm.exception), 'Negative roll is invalid')
+
+    def test_a_roll_can_not_score_more_than_10_points(self):
+            rolls = []
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(11)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_two_rolls_in_a_frame_can_not_score_more_than_10_points(self):
+            rolls = [5]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(6)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_bonus_roll_after_a_strike_in_the_last_frame_can_not_score_more_than_10_points(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(11)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_two_bonus_rolls_after_a_strike_in_the_last_frame_can_not_score_more_than_10_points(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(6)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_two_bonus_rolls_after_a_strike_in_the_last_frame_can_score_more_than_10_points_if_one_is_a_strike(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6]
+            game = self._roll_many(rolls)
+            self.assertEqual(game.score(), 26)
+
+    def test_the_second_bonus_rolls_after_a_strike_in_the_last_frame_can_not_be_a_strike_if_the_first_one_is_not_a_strike(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(10)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_second_bonus_roll_after_a_strike_in_the_last_frame_can_not_score_than_10_points(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(11)
+            self.assertEqual(str(cm.exception), 'Pin count exceeds pins on the lane')
+
+    def test_an_unstarted_game_can_not_be_scored(self):
+            rolls = []
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.score()
+            self.assertEqual(str(cm.exception), 'Score cannot be taken until the end of the game')
+
+    def test_an_incomplete_game_can_not_be_scored(self):
+            rolls = [0, 0]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.score()
+            self.assertEqual(str(cm.exception), 'Score cannot be taken until the end of the game')
+
+    def test_cannot_roll_if_game_already_has_ten_frames(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.roll(0)
+            self.assertEqual(str(cm.exception), 'Cannot roll after game is over')
+
+    def test_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.score()
+            self.assertEqual(str(cm.exception), 'Score cannot be taken until the end of the game')
+
+    def test_both_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.score()
+            self.assertEqual(str(cm.exception), 'Score cannot be taken until the end of the game')
+
+    def test_bonus_roll_for_a_spare_in_the_last_frame_must_be_rolled_before_score_can_be_calculated(self):
+            rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
+            game = self._roll_many(rolls)
+            with self.assertRaises(Exception) as cm:
+                    game.score()
+            self.assertEqual(str(cm.exception), 'Score cannot be taken until the end of the game')
+
+    def _roll_many(self, rolls):
+            game = BowlingGame()
+            for pins in rolls:
+                    game.roll(pins)
+            return game
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/exercises/bowling/example.py
+++ b/exercises/bowling/example.py
@@ -1,0 +1,108 @@
+from enum import Enum
+
+
+class State(Enum):
+    OPEN = 1
+    SPARE = 2
+    STRIKE = 3
+
+
+class BowlingGame:
+    def __init__(self):
+        self._score = 0
+        self._roll = 1
+        self._frame_score = 0
+        self._current_frame = 1
+        self._max_frame_score = self._max_frames = 10
+        self._frame_states = []
+        self._game_finished = False
+        self._last_frame = False
+        self._rolls = []
+
+    def roll(self, pins):
+        if self._game_finished:
+            raise Exception('Cannot roll after game is over')
+        elif 0 <= pins <= 10:
+            self._last_frame = self._current_frame == self._max_frames
+            self._rolls.append(pins)
+            self._add_bonuses(pins)
+            self._frame_score += pins
+
+            if self._roll == 1:
+                self._roll += 1 if self._last_frame or not self._is_strike(pins) else 0
+                if self._is_strike(pins):
+                    self._frame_states.append(State.STRIKE)
+                    if not self._last_frame:
+                        self._next_frame()
+            elif self._roll == 2:
+                if self._last_frame and self._frame_states[-1] == State.STRIKE:
+                    if self._is_strike(pins):
+                        self._frame_states.append(State.STRIKE)
+                    self._roll += 1
+                elif self._is_spare():
+                    self._frame_states.append(State.SPARE)
+                    if self._last_frame:
+                        self._roll += 1
+                    else:
+                        self._next_frame()
+                elif self._is_valid_frame(limit=self._max_frame_score):
+                    self._frame_states.append(State.OPEN)
+                    if self._last_frame:
+                        self._score += self._frame_score
+                        self._game_finished = True
+                    else:
+                        self._next_frame()
+                else:
+                    raise Exception('Pin count exceeds pins on the lane')
+            elif self._roll == 3:
+                if self._is_valid_frame(last_roll=True):
+                    self._score += self._frame_score
+                    self._game_finished = True
+                else:
+                    raise Exception('Pin count exceeds pins on the lane')
+        elif pins < 0:
+            raise Exception('Negative roll is invalid')
+        else:
+            raise Exception('Pin count exceeds pins on the lane')
+
+    def _add_bonuses(self, pins):
+        if self._frame_states:
+            if self._frame_states[-1] == State.STRIKE and not self._last_frame:
+                self._score += pins
+            elif self._frame_states[-1] == State.SPARE:
+                self._score += pins if self._roll == 1 else 0
+
+            if len(self._frame_states) >= 2 and self._roll == 1 and \
+                    self._frame_states[-2] == self._frame_states[-1] == State.STRIKE:
+                self._score += pins if not self._last_frame else 3 * pins
+
+    def _next_frame(self):
+        self._current_frame += 1
+        self._score += self._frame_score
+        self._frame_score = 0
+        self._roll = 1
+
+    def _is_strike(self, pins):
+        return pins == self._max_frame_score
+
+    def _is_spare(self):
+        return self._frame_score == self._max_frame_score
+
+    def _is_valid_frame(self, limit=None, last_roll=False):
+        if last_roll:
+            if self._frame_states[-1] == State.SPARE:
+                return self._rolls[-1] <= self._max_frame_score
+            elif self._frame_states[-1] == State.STRIKE:
+                if self._frame_states[-2] == State.STRIKE:
+                    return self._rolls[-1] <= self._max_frame_score
+                else:
+                    return sum(self._rolls[-2:]) <= self._max_frame_score
+
+        else:
+            return self._frame_score <= limit
+
+    def score(self):
+        if not self._game_finished:
+            raise Exception('Score cannot be taken until the end of the game')
+        else:
+            return self._score


### PR DESCRIPTION
First PR (all going well) closes #421

Changes:
- Added exercises/bowling/bowling_test.py (generated from [x-common/exercises/bowling/canonical-data.json](https://github.com/exercism/x-common/blob/master/exercises/bowling/canonical-data.json))
- Added exercises/bowling/example.py
- Updated config.json to include exercise (using [xcsharp/config.json](https://github.com/exercism/xcsharp/blob/master/config.json) as a template)

Passing 28 unit tests using pytest:
![screenshot from 2017-03-05 16-10-54](https://cloud.githubusercontent.com/assets/12100141/23586440/c0336ca4-01cf-11e7-8a75-c12bc8c80cd2.png)

And using test/check-exercises.py:
![screenshot from 2017-03-05 16-13-27](https://cloud.githubusercontent.com/assets/12100141/23586450/e8160b28-01cf-11e7-966f-37a0730afa9b.png)

The test harness exceeded 99 characters on several lines, breaking pep8 compliance:
![screenshot from 2017-03-05 16-26-00](https://cloud.githubusercontent.com/assets/12100141/23586469/4fa843a0-01d0-11e7-8f4d-b66d50a86c16.png)

Test names were generated directly from the canonical-data.json description of the exercise, but I can amend these if need be.

Let me know if amendments need to be made to tests, example or commit message and I'll push necessary updates.