### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,10 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "f458c48a-4a05-4809-9168-8edd55179349",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (if-else statements)",
@@ -14,7 +17,10 @@
       ]
     },
     {
+      "uuid": "b6acda85-5f62-4d9c-bb4f-42b7a360355a",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (if-else statements)",
@@ -23,14 +29,20 @@
       ]
     },
     {
+      "uuid": "d1a98c79-d3cc-4035-baab-0e334d2b6a57",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bebf7ae6-1c35-48bc-926b-e053a975eb10",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -42,7 +54,10 @@
       ]
     },
     {
+      "uuid": "ca7c5ef1-5135-4fb4-8e68-669ef0f2a51a",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (if-else statements)",
@@ -54,7 +69,10 @@
       ]
     },
     {
+      "uuid": "8648fa0c-d85f-471b-a3ae-0f8c05222c89",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (if-else statements)",
@@ -68,7 +86,10 @@
       ]
     },
     {
+      "uuid": "04316811-0bc3-4377-8ff5-5a300ba41d61",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -79,35 +100,50 @@
       ]
     },
     {
+      "uuid": "22606e91-57f3-44cf-ab2d-94f6ee6402e8",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "009a80e2-7901-4d3b-9af2-cdcbcc0b49ae",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "505e7bdb-e18d-45fd-9849-0bf33492efd9",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a5aff23f-7829-403f-843a-d3312dca31e8",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4c408aab-80b9-475d-9c06-b01cd0fcd08f",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -116,392 +152,560 @@
       ]
     },
     {
+      "uuid": "913b6099-d75a-4c27-8243-476081752c31",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "43eaf8bd-0b4d-4ea9-850a-773f013325ef",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "83627e35-4689-4d9b-a81b-284c2c084466",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "aa4c2e85-b8f8-4309-9708-d8ff805054c2",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ca474c47-57bb-4995-bf9a-b6937479de29",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ad0192e6-7742-4922-a53e-791e25eb9ba3",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "02b91a90-244d-479e-a039-0e1d328c0be9",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6e0caa0a-6a1a-4f03-bf0f-e07711f4b069",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "038c7f7f-02f6-496f-9e16-9372621cc4cd",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2f86ce8e-47c7-4858-89fc-e7729feb0f2f",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "21624a3e-6e43-4c0e-94b0-dee5cdaaf2aa",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "42a2916c-ef03-44ac-b6d8-7eda375352c2",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "aadde1a8-ed7a-4242-bfc0-6dddfd382cf3",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "07481204-fe88-4aa2-995e-d40d1ae15070",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bffe2007-717a-44ee-b628-b9c86a5001e8",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f8303c4d-bbbb-495b-b61b-0f617f7c9a13",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a24e6d34-9952-44f4-a0cd-02c7fedb4875",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a3b24ef2-303a-494e-8804-e52a67ef406b",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "41dd9178-76b4-4f78-b71a-b5ff8d12645b",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a5bc16da-8d55-4840-9523-686aebbaaa7e",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "09b2f396-00d7-4d89-ac47-5c444e00dd99",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d081446b-f26b-41a2-ab7f-dd7f6736ecfe",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e8685468-8006-480f-87c6-6295700def38",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "cc5eb848-09bc-458c-8fb6-3a17687cb4eb",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7b53865e-a981-46e0-8e47-6f8e1f3854b3",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "77ee3b0e-a4e9-4257-bcfc-ff2c8f1477ab",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bf30b17f-6b71-4bb5-815a-88f8181b89ae",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b564927a-f08f-4287-9e8d-9bd5daa7081f",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6434cc19-1ea3-43dd-9580-72267ec76b80",
       "slug": "rail-fence-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a20924d2-fe6d-4714-879f-3239feb9d2f2",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "71c96c5f-f3b6-4358-a9c6-fc625e2edda2",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b7984882-65df-4993-a878-7872c776592a",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c23ae7a3-3095-4608-8720-ee9ce8938f26",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0d5b2a0e-31ff-4c8c-a155-0406f7dca3ae",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d41238ce-359c-4a9a-81ea-ca5d2c4bb50d",
       "slug": "twelve-days",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fa795dcc-d390-4e98-880c-6e8e638485e3",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "45229a7c-6703-4240-8287-16645881a043",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7e768b54-4591-4a30-9ddb-66ca13400ca3",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b280c252-5320-4e53-8294-1385d564eb02",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "af50bb9a-e400-49ce-966f-016c31720be1",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f384c6f8-987d-41a2-b504-e50506585526",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "98ca48ed-5818-442c-bce1-308c8b3b3b77",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7c2e93ae-d265-4481-b583-a496608c6031",
       "slug": "house",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f0bc144f-3226-4e53-93ee-e60316b29e31",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "dc6e61a2-e9b9-4406-ba5c-188252afbba1",
       "slug": "transpose",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "dcc0ee26-e384-4bd4-8c4b-613fa0bb8188",
       "slug": "poker",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7e1d90d5-dbc9-47e0-8e26-c3ff83b73c2b",
       "slug": "zebra-puzzle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4bebdd8d-a032-4993-85c5-7cc74fc89312",
       "slug": "rectangles",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a8288e93-93c5-4e0f-896c-2a376f6f6e5e",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "818c6472-b734-4ff4-8016-ce540141faec",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4899b2ef-675f-4d14-b68a-1a457de91276",
       "slug": "book-store",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ca7a8b16-e5d5-4211-84f0-2f8e35b4a665",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a7bc6837-59e4-46a1-89a2-a5aa44f5e66e",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "aa4332bd-fc38-47a4-8bff-e1b660798418",
       "slug": "variable-length-quantity",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a2ff75f9-8b2c-4c4b-975d-913711def9ab",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "integers",
@@ -509,7 +713,10 @@
       ]
     },
     {
+      "uuid": "459fda78-851e-4bb0-a416-953528f46bd7",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "classes",
@@ -520,7 +727,10 @@
       ]
     },
     {
+      "uuid": "ecc97fc6-2e72-4325-9b67-b56c83b13a91",
       "slug": "grep",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "files",
@@ -529,7 +739,10 @@
       ]
     },
     {
+      "uuid": "dc2917d5-aaa9-43d9-b9f4-a32919fdbe18",
       "slug": "word-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "strings",
@@ -537,21 +750,30 @@
       ]
     },
     {
+      "uuid": "66466141-485c-470d-b73b-0a3d5a957c3d",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "49377a3f-38ba-4d61-b94c-a54cfc9034d0",
       "slug": "tournament",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8cd58325-61fc-46fd-85f9-425b4c41f3de",
       "slug": "scale-generator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -559,26 +781,71 @@
       ]
     },
     {
+      "uuid": "c89243f3-703e-4fe0-8e43-f200eedf2825",
       "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
         "pattern matching"
       ]
+    },
+    {
+      "uuid": "e7351e8e-d3ff-4621-b818-cd55cf05bffd",
+      "slug": "accumulate",
+      "deprecated": true
+    },
+    {
+      "uuid": "105f25ec-7ce2-4797-893e-05e3792ebd91",
+      "slug": "nucleotide-count",
+      "deprecated": true
+    },
+    {
+      "uuid": "4094d27f-4d03-4308-9fd7-9f3de312afec",
+      "slug": "octal",
+      "deprecated": true
+    },
+    {
+      "uuid": "e1e1c7d7-c1d9-4027-b90d-fad573182419",
+      "slug": "pascals-triangle",
+      "deprecated": true
+    },
+    {
+      "uuid": "d85ec4f2-c201-4eff-9f3a-831a0cc38e8d",
+      "slug": "point-mutations",
+      "deprecated": true
+    },
+    {
+      "uuid": "9fd94229-f974-45bb-97ea-8bfe484f6eb3",
+      "slug": "proverb",
+      "deprecated": true
+    },
+    {
+      "uuid": "82d82e32-cb30-4119-8862-d019563dd1e3",
+      "slug": "raindrops",
+      "deprecated": true
+    },
+    {
+      "uuid": "b50b29a1-782d-4277-a4d4-23f635fbdaa6",
+      "slug": "strain",
+      "deprecated": true
+    },
+    {
+      "uuid": "061a6543-d51d-4619-891b-16f92c6435ca",
+      "slug": "trinary",
+      "deprecated": true
+    },
+    {
+      "uuid": "49127efa-1124-4f27-bee4-99992e3433de",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "6b7f7b1f-c388-4f4c-b924-84535cc5e1a0",
+      "slug": "hexadecimal",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "accumulate",
-    "nucleotide-count",
-    "octal",
-    "pascals-triangle",
-    "point-mutations",
-    "proverb",
-    "raindrops",
-    "strain",
-    "trinary",
-    "binary",
-    "hexadecimal"
   ],
   "foregone": [
 

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -67,12 +67,11 @@ def load_config():
 
     try:
         problems = [entry['slug'] for entry in data['exercises']]
-        deprecated_problems = data['deprecated']
     except KeyError:
         print('FAIL: config.json has an incorrect format')
         raise SystemExit(1)
 
-    return problems, deprecated_problems
+    return problems
 
 
 def main():
@@ -81,7 +80,7 @@ def main():
         exercises = [exercise.strip('/') for exercise in sys.argv[1:]]
     else:
         # load exercises from config-file
-        exercises, _ = load_config()
+        exercises = load_config()
 
     failures = []
     for exercise in exercises:


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16