### PR TITLE
Update the enigmatic scale case

### DIFF
--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -110,7 +110,7 @@ class ScaleGeneratorTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_enigmatic(self):
-        enigmatic = Scale('G', 'enigmatic', 'mAMMMmM')
+        enigmatic = Scale('G', 'enigmatic', 'mAMMMmm')
         expected = ['G', 'G#', 'B', 'C#', 'D#', 'F', 'F#']
         actual = enigmatic.pitches
         self.assertEqual(expected, actual)


### PR DESCRIPTION
http://exercism.io/submissions/3c67c65da6e34871946a955fca7ff2ae
There seem to be a mistake in the enigmatic scale: enigmatic = Scale('G', 'enigmatic', 'mAMMMmM')

https://en.wikipedia.org/wiki/Enigmatic_scale Semitone, Tone and a half, Tone, Tone, Tone, Semitone, Semitone. Should be enigmatic = Scale('G', 'enigmatic', 'mAMMMmm')