### PR TITLE
Add annotation to skip all but first test

### DIFF
--- a/exercises/isogram/isogram_test.py
+++ b/exercises/isogram/isogram_test.py
@@ -10,30 +10,39 @@ class TestIsogram(unittest.TestCase):
     def test_empty_string(self):
         self.assertTrue(is_isogram(""))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_isogram_with_only_lower_case_characters(self):
         self.assertTrue(is_isogram("isogram"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_word_with_one_duplicated_character(self):
         self.assertFalse(is_isogram("eleven"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_longest_reported_english_isogram(self):
         self.assertTrue(is_isogram("subdermatoglyphic"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_word_with_duplicated_character_in_mixed_case(self):
         self.assertFalse(is_isogram("Alphabet"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_hypothetical_isogrammic_word_with_hyphen(self):
         self.assertTrue(is_isogram("thumbscrew-japingly"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_isogram_with_duplicated_non_letter_character(self):
         self.assertTrue(is_isogram("Hjelmqvist-Gryb-Zock-Pfund-Wax"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_made_up_name_that_is_an_isogram(self):
         self.assertTrue(is_isogram("Emily Jung Schwartzkopf"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_duplicated_character_in_the_middle(self):
         self.assertFalse(is_isogram("accentor"))
 
+    @unittest.skip("remove this annotation to run this test")
     def test_isogram_with_duplicated_letter_and_nonletter_character(self):
         self.assertFalse(is_isogram("Aleph Bot Chap"))
 

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -23,11 +23,20 @@ def check_assignment(name, test_file):
     try:
         test_file_out = os.path.join(workdir, os.path.basename(test_file))
         shutil.copyfile(test_file, test_file_out)
+        unskip_tests(test_file_out)
         shutil.copyfile(os.path.join(os.path.dirname(test_file), 'example.py'),
                         os.path.join(workdir, '{}.py'.format(example_name)))
         return subprocess.call([python_executable_name(), test_file_out])
     finally:
         shutil.rmtree(workdir)
+
+
+def unskip_tests(testfile):
+    with open(testfile) as f:
+        txt = f.read()
+    txt = txt.replace('@unittest.skip', '#@unittest.skip')
+    with open(testfile, 'w') as f:
+        f.write(txt)
 
 
 def modname_heuristic(test_file):


### PR DESCRIPTION
~~I'm not sure if this behavior is desired, but it's pretty common in the other exercism tracks I've seen:~~

~~1. Test suite arrives to the user with only the first test enabled.  All others are skipped.~~
~~2. After getting the first test passing, user 'unskips' the next test.~~
~~3. pass test, rinse, repeat...~~

I implemented the change in `check_exercises.py` to 'unskip' the skipped tests for CI.

~~If this isn't wanted, no big deal, I'll just close it.  LMK!~~

Closes #391 

NB I made a change to this to use Python file methods instead of calling `sed`.