### PR TITLE
acronym: changed template function param list from empty to "words"

### DIFF
--- a/exercises/acronym/acronym.py
+++ b/exercises/acronym/acronym.py
@@ -1,2 +1,2 @@
-def abbreviate():
+def abbreviate(words):
     pass


### PR DESCRIPTION
Proposing a fix for a first exercise(alphabetically) for issue #509 . A question: should naming be taken from example.py, when possible? Most of them seem sensible, like this one, but not all of them are. 