### PR TITLE
phone-number: Add validation of area code and exchange code

### DIFF
--- a/exercises/phone-number/example.py
+++ b/exercises/phone-number/example.py
@@ -27,8 +27,10 @@ class Phone(object):
         )
 
     def _normalize(self, number):
-        valid = len(number) == 10 or \
-            len(number) == 11 and number.startswith('1')
+        if len(number) == 10 or len(number) == 11 and number.startswith('1'):
+            valid = number[-10] in "23456789" and number[-7] in "23456789"
+        else:
+            valid = False
 
         if valid:
             return number[-10:]

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -3,6 +3,8 @@ import unittest
 from phone_number import Phone
 
 
+# test cases adapted from `x-common//canonical-data.json` @ version: 1.2.0
+
 class PhoneTest(unittest.TestCase):
     def test_cleans_number(self):
         number = Phone("(223) 456-7890").number
@@ -12,16 +14,36 @@ class PhoneTest(unittest.TestCase):
         number = Phone("223.456.7890").number
         self.assertEqual(number, "2234567890")
 
+    def test_cleans_number_with_multiple_spaces(self):
+        number = Phone("223 456   7890   ").number
+        self.assertEqual(number, "2234567890")
+
+    def test_invalid_when_9_digits(self):
+        number = Phone("123456789").number
+        self.assertEqual(number, "0000000000")
+
+    def test_invalid_when_11_digits_and_first_not_1(self):
+        number = Phone("22234567890").number
+        self.assertEqual(number, "0000000000")
+
     def test_valid_when_11_digits_and_first_is_1(self):
         number = Phone("12234567890").number
         self.assertEqual(number, "2234567890")
 
-    def test_invalid_when_11_digits(self):
-        number = Phone("22234567890").number
+    def test_valid_when_11_digits_and_first_is_1_with_punctuation(self):
+        number = Phone("+1 (223) 456-7890").number
+        self.assertEqual(number, "2234567890")
+
+    def test_invalid_when_more_than_11_digits(self):
+        number = Phone("321234567890").number
         self.assertEqual(number, "0000000000")
 
-    def test_invalid_when_9_digits(self):
-        number = Phone("123456789").number
+    def test_invalid_with_letters(self):
+        number = Phone("123-abc-7890").number
+        self.assertEqual(number, "0000000000")
+
+    def test_invalid_with_punctuation(self):
+        number = Phone("123-@:!-7890").number
         self.assertEqual(number, "0000000000")
 
     def test_invalid_area_code(self):
@@ -32,6 +54,7 @@ class PhoneTest(unittest.TestCase):
         number = Phone("(223) 056-7890").number
         self.assertEqual(number, "0000000000")
 
+    # Track specific tests
     def test_area_code(self):
         number = Phone("2234567890")
         self.assertEqual(number.area_code(), "223")

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -5,36 +5,44 @@ from phone_number import Phone
 
 class PhoneTest(unittest.TestCase):
     def test_cleans_number(self):
-        number = Phone("(123) 456-7890").number
-        self.assertEqual(number, "1234567890")
+        number = Phone("(223) 456-7890").number
+        self.assertEqual(number, "2234567890")
 
     def test_cleans_number_with_dots(self):
-        number = Phone("123.456.7890").number
-        self.assertEqual(number, "1234567890")
+        number = Phone("223.456.7890").number
+        self.assertEqual(number, "2234567890")
 
     def test_valid_when_11_digits_and_first_is_1(self):
-        number = Phone("11234567890").number
-        self.assertEqual(number, "1234567890")
+        number = Phone("12234567890").number
+        self.assertEqual(number, "2234567890")
 
     def test_invalid_when_11_digits(self):
-        number = Phone("21234567890").number
+        number = Phone("22234567890").number
         self.assertEqual(number, "0000000000")
 
     def test_invalid_when_9_digits(self):
         number = Phone("123456789").number
         self.assertEqual(number, "0000000000")
 
+    def test_invalid_area_code(self):
+        number = Phone("(123) 456-7890").number
+        self.assertEqual(number, "0000000000")
+
+    def test_invalid_exchange_code(self):
+        number = Phone("(223) 056-7890").number
+        self.assertEqual(number, "0000000000")
+
     def test_area_code(self):
-        number = Phone("1234567890")
-        self.assertEqual(number.area_code(), "123")
+        number = Phone("2234567890")
+        self.assertEqual(number.area_code(), "223")
 
     def test_pretty_print(self):
-        number = Phone("1234567890")
-        self.assertEqual(number.pretty(), "(123) 456-7890")
+        number = Phone("2234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
 
     def test_pretty_print_with_full_us_phone_number(self):
-        number = Phone("11234567890")
-        self.assertEqual(number.pretty(), "(123) 456-7890")
+        number = Phone("12234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Update tests to use current version of canonical data (v1.2.0). These tests
  require validation of the area and exchange codes, which is already mentioned
  in README.md - the first digit of each must be between 2 and 9

* Update example code to pass new tests