### PR TITLE
Acronym: update function to have params as in #509

### DIFF
--- a/exercises/acronym/acronym.py
+++ b/exercises/acronym/acronym.py
@@ -1,2 +1,2 @@
-def abbreviate():
+def abbreviate(words):
     pass


### PR DESCRIPTION
Added a `words` parameter to the abbreviate method to ensure clarity to future users. This change was discussed in issue #509.

Fixes #597