### PR TITLE
hexadecimal: Add Example Parameter for hexa()

### DIFF
--- a/exercises/hexadecimal/hexadecimal.py
+++ b/exercises/hexadecimal/hexadecimal.py
@@ -1,2 +1,2 @@
-def hexa():
+def hexa(hex_string):
     pass


### PR DESCRIPTION
Add an example parameter `hex_string` for the `hexa()` function. Issue: #564 
Fixes #564