### PR TITLE
Nucleotide Count - Added Parameters to Placeholders

### DIFF
--- a/exercises/nucleotide-count/nucleotide_count.py
+++ b/exercises/nucleotide-count/nucleotide_count.py
@@ -1,6 +1,6 @@
-def count():
+def count(length, abbrev):
     pass
 
 
-def nucleotide_counts():
+def nucleotide_counts(length):
     pass


### PR DESCRIPTION
Added Parameters to the Nucleotide Count file in the functions `count` and `nucleotide_count`

This resolves the issue #590.
TODO: Nucleotide Count - Ticked on #509 

Fixes #601 