### PR TITLE
protein-translation: add parameters to exercise placeholder as in #613

### DIFF
--- a/exercises/protein-translation/protein_translation.py
+++ b/exercises/protein-translation/protein_translation.py
@@ -1,6 +1,6 @@
-def of_codon():
+def of_codon(codon):
     pass
 
 
-def of_rna():
+def of_rna(strand):
     pass


### PR DESCRIPTION
Added parameters to the `protein-translation.py` as described in issue #613 .

Fixes #613