### PR TITLE
ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 bin/configlet
 bin/configlet.exe
 .idea/
+.vscode/


### PR DESCRIPTION
This is completely unrelated to any exercise but for those contributors who use Visual Studio Code this would prevent git from accidentally adding VS code settings to this repo.