### PR TITLE
sublist: add parameters to exercise placeholder

### DIFF
--- a/exercises/sublist/sublist.py
+++ b/exercises/sublist/sublist.py
@@ -1,2 +1,2 @@
-def check_lists():
+def check_lists(firstList, secondList):
     pass

--- a/exercises/sublist/sublist.py
+++ b/exercises/sublist/sublist.py
@@ -1,2 +1,2 @@
-def check_lists(firstList, secondList):
+def check_lists(first_list, second_list):
     pass


### PR DESCRIPTION
Added the `firstList` and `secondList` parameters to the abbreviate method to ensure clarity to future users. This change was discussed in issue #509.

Fixes #643 