### PR TITLE
queen-attack: Add parameters to exercise placeholder

### DIFF
--- a/exercises/queen-attack/queen_attack.py
+++ b/exercises/queen-attack/queen_attack.py
@@ -1,6 +1,6 @@
-def board():
+def board(white_position, black_position):
     pass
 
 
-def can_attack():
+def can_attack(white_position, black_position):
     pass


### PR DESCRIPTION
As described in [#616](https://github.com/exercism/python/issues/616)

Fixes #616