### PR TITLE
list-ops: Update test cases to v2.0.0

### DIFF
--- a/exercises/list-ops/example.py
+++ b/exercises/list-ops/example.py
@@ -1,15 +1,9 @@
-def append(xs, y):
-    xs[len(xs):] = [y]
-    return xs
+def append(xs, ys):
+    return concat([xs, ys])
 
 
-def concat(xs, ys):
-    if not ys:
-        return xs
-    else:
-        for item in ys:
-            xs.append(item)
-        return xs
+def concat(lists):
+    return [elem for lst in lists for elem in lst]
 
 
 def filter_clone(function, xs):
@@ -22,7 +16,6 @@ def length(xs):
 
 def map_clone(function, xs):
     return [function(elem) for elem in xs]
-
 
 
 def foldl(function, xs, acc):
@@ -39,7 +32,4 @@ def foldr(function, xs, acc):
         return function(xs[0], foldr(function, xs[1:], acc))
 
 def reverse(xs):
-    if not xs:
-        return []
-    else:
-        return xs[::-1]
+    return xs[::-1]

--- a/exercises/list-ops/example.py
+++ b/exercises/list-ops/example.py
@@ -1,25 +1,28 @@
-def map_clone(function, xs):
-    return [function(elem) for elem in xs]
+def append(xs, y):
+    xs[len(xs):] = [y]
+    return xs
 
 
-def length(xs):
-    return sum(1 for _ in xs)
+def concat(xs, ys):
+    if not ys:
+        return xs
+    else:
+        for item in ys:
+            xs.append(item)
+        return xs
 
 
 def filter_clone(function, xs):
     return [x for x in xs if function(x)]
 
 
-def reverse(xs):
-    if not xs:
-        return []
-    else:
-        return xs[::-1]
+def length(xs):
+    return sum(1 for _ in xs)
 
 
-def append(xs, y):
-    xs[len(xs):] = [y]
-    return xs
+def map_clone(function, xs):
+    return [function(elem) for elem in xs]
+
 
 
 def foldl(function, xs, acc):
@@ -35,21 +38,8 @@ def foldr(function, xs, acc):
     else:
         return function(xs[0], foldr(function, xs[1:], acc))
 
-
-def flat(xs):
-    out = []
-    for item in xs:
-        if isinstance(item, list):
-            out.extend(flat(item))
-        else:
-            out.append(item)
-    return out
-
-
-def concat(xs, ys):
-    if not ys:
-        return xs
+def reverse(xs):
+    if not xs:
+        return []
     else:
-        for item in ys:
-            xs.append(item)
-        return xs
+        return xs[::-1]

--- a/exercises/list-ops/example.py
+++ b/exercises/list-ops/example.py
@@ -31,5 +31,6 @@ def foldr(function, xs, acc):
     else:
         return function(xs[0], foldr(function, xs[1:], acc))
 
+
 def reverse(xs):
     return xs[::-1]

--- a/exercises/list-ops/list_ops.py
+++ b/exercises/list-ops/list_ops.py
@@ -1,30 +1,30 @@
-def append():
+def append(xs, ys):
     pass
 
 
-def concat():
+def concat(lists):
     pass
 
 
-def filter_clone():
+def filter_clone(function, xs):
     pass
 
 
-def length():
+def length(xs):
     pass
 
 
-def map_clone():
+def map_clone(function, xs):
     pass
 
 
-def foldl():
+def foldl(function, xs, acc):
     pass
 
 
-def foldr():
+def foldr(function, xs, acc):
     pass
 
 
-def reverse():
+def reverse(xs):
     pass

--- a/exercises/list-ops/list_ops.py
+++ b/exercises/list-ops/list_ops.py
@@ -1,8 +1,8 @@
-def map_clone():
+def append():
     pass
 
 
-def length():
+def concat():
     pass
 
 
@@ -10,11 +10,11 @@ def filter_clone():
     pass
 
 
-def reverse():
+def length():
     pass
 
 
-def append():
+def map_clone():
     pass
 
 
@@ -26,9 +26,5 @@ def foldr():
     pass
 
 
-def flat():
-    pass
-
-
-def concat():
+def reverse():
     pass

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -29,13 +29,12 @@ class ListOpsTest(unittest.TestCase):
 
     # tests for filter_clone
     def test_filter_empty_list(self):
-        condition = lambda x: x % 2 == 1
-        self.assertEqual(list_ops.filter_clone(condition, []), [])
+        self.assertEqual(list_ops.filter_clone(lambda x: x % 2 == 1, []), [])
 
     def test_filter_nonempty_list(self):
-        condition = lambda x: x % 2 == 1
-        self.assertEqual(list_ops.filter_clone(condition, [1, 2, 3, 4, 5]),
-                         [1, 3, 5])
+        self.assertEqual(
+            list_ops.filter_clone(lambda x: x % 2 == 1, [1, 2, 3, 4, 5]),
+            [1, 3, 5])
 
     # tests for length
     def test_length_empty_list(self):

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -4,7 +4,7 @@ import operator
 import list_ops
 
 
-# Tests adapted from problem-specification//canonical-data.json @ version 2.0.0
+# Tests adapted from problem-specifications//canonical-data.json @ v2.0.0
 
 class ListOpsTest(unittest.TestCase):
 

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -4,7 +4,7 @@ import operator
 import list_ops
 
 
-# Units tests adapted from canonical-data.json @ version 2.0.0
+# Tests adapted from problem-specification//canonical-data.json @ version 2.0.0
 
 class ListOpsTest(unittest.TestCase):
 

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -19,11 +19,6 @@ class ListOpsTest(unittest.TestCase):
         self.assertEqual(list_ops.append([1, 2], [2, 3, 4, 5]),
                          [1, 2, 2, 3, 4, 5])
 
-    # additional test for append
-    def test_append_range(self):
-        self.assertEqual(
-            list_ops.append([100], range(1000)), [100, range(1000)])
-
     # tests for concat
     def test_concat_empty_list(self):
         self.assertEqual(list_ops.concat([]), [])

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -4,122 +4,97 @@ import operator
 import list_ops
 
 
+# Units tests adapted from canonical-data.json @ version 2.0.0
+
 class ListOpsTest(unittest.TestCase):
 
-    # tests for map
-    def test_map_square(self):
-        self.assertEqual(
-            list_ops.map_clone(lambda x: x**2,
-                               [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-            [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])
+    # test for append
+    def test_append_empty_lists(self):
+        self.assertEqual(list_ops.append([], []), [])
 
-    def test_map_cube(self):
-        self.assertEqual(
-            list_ops.map_clone(lambda x: x**3,
-                               [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]),
-            [-1, 8, -27, 64, -125, 216, -343, 512, -729, 1000])
+    def test_append_empty_list_to_list(self):
+        self.assertEqual(list_ops.append([], [1, 2, 3, 4]), [1, 2, 3, 4])
 
-    def test_map_absolute(self):
-        self.assertEqual(
-            list_ops.map_clone(lambda x: abs(x),
-                               [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]),
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    def test_append_nonempty_lists(self):
+        self.assertEqual(list_ops.append([1, 2], [2, 3, 4, 5]),
+                         [1, 2, 2, 3, 4, 5])
 
-    def test_map_empty(self):
-        self.assertEqual(list_ops.map_clone(operator.index, []), [])
-
-    # tests for length
-    def test_pos_leng(self):
-        self.assertEqual(
-            list_ops.length([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]), 10)
-
-    def test_empty_len(self):
-        self.assertEqual(list_ops.length([]), 0)
-
-    # tests for filter
-    def test_filter_odd(self):
-        self.assertEqual(
-            list_ops.filter_clone(lambda x: x % 2 != 0, [1, 2, 3, 4, 5, 6]),
-            [1, 3, 5])
-
-    def test_filter_even(self):
-        self.assertEqual(
-            list_ops.filter_clone(lambda x: x % 2 == 0, [1, 2, 3, 4, 5, 6]),
-            [2, 4, 6])
-
-    # tests for reverse
-    def test_reverse_small(self):
-        self.assertEqual(list_ops.reverse([3, 2, 1]), [1, 2, 3])
-
-    def test_reverse_mixed_types(self):
-        self.assertEqual(
-            list_ops.reverse(["xyz", 4.0, "cat", 1]), [1, "cat", 4.0, "xyz"])
-
-    def test_reverse_empty(self):
-        self.assertEqual(list_ops.reverse([]), [])
-
-    # tests for append
-    def test_append_tuple(self):
-        self.assertEqual(
-            list_ops.append(["10", "python"], "hello"),
-            ["10", "python", "hello"])
-
+    # additional test for append
     def test_append_range(self):
         self.assertEqual(
             list_ops.append([100], range(1000)), [100, range(1000)])
 
-    def test_append_to_empty(self):
-        self.assertEqual(list_ops.append([], 42), [42])
+    # tests for concat
+    def test_concat_empty_list(self):
+        self.assertEqual(list_ops.concat([]), [])
+
+    def test_concat_list_of_lists(self):
+        self.assertEqual(list_ops.concat([[1, 2], [3], [], [4, 5, 6]]),
+                         [1, 2, 3, 4, 5, 6])
+
+    # tests for filter_clone
+    def test_filter_empty_list(self):
+        condition = lambda x: x % 2 == 1
+        self.assertEqual(list_ops.filter_clone(condition, []), [])
+
+    def test_filter_empty_list(self):
+        condition = lambda x: x % 2 == 1
+        self.assertEqual(list_ops.filter_clone(condition, [1, 2, 3, 4, 5]),
+                         [1, 3, 5])
+
+    # tests for length
+    def test_length_empty_list(self):
+        self.assertEqual(list_ops.length([]), 0)
+
+    def test_length_nonempty_list(self):
+        self.assertEqual(list_ops.length([1, 2, 3, 4]), 4)
+
+    # tests for map_clone
+    def test_map_empty_list(self):
+        self.assertEqual(list_ops.map_clone(lambda x: x + 1, []), [])
+
+    def test_map_nonempty_list(self):
+        self.assertEqual(list_ops.map_clone(lambda x: x + 1, [1, 3, 5, 7]),
+                         [2, 4, 6, 8])
 
     # tests for foldl
-    def test_foldl_sum(self):
-        self.assertEqual(
-            list_ops.foldl(operator.add, [1, 2, 3, 4, 5, 6], 0), 21)
+    def test_foldl_empty_list(self):
+        self.assertEqual(list_ops.foldl(operator.mul, [], 2), 2)
 
-    def test_foldl_product(self):
-        self.assertEqual(
-            list_ops.foldl(operator.mul, [1, 2, 3, 4, 5, 6], 1), 720)
+    def test_foldl_nonempty_list_addition(self):
+        self.assertEqual(list_ops.foldl(operator.add, [1, 2, 3, 4], 5), 15)
 
-    def test_foldl_div(self):
-        self.assertEqual(
-            list_ops.foldl(operator.floordiv, [1, 2, 3, 4, 5, 6], 1), 0)
-
-    def test_foldl_sub(self):
-        self.assertEqual(list_ops.foldl(operator.sub, [1, 2, 3, 4, 5], 0), -15)
+    def test_foldl_nonempty_list_floordiv(self):
+        self.assertEqual(list_ops.foldl(operator.floordiv, [2, 5], 5), 0)
 
     # tests for foldr
-    def test_foldr_sub(self):
-        self.assertEqual(list_ops.foldr(operator.sub, [1, 2, 3, 4, 5], 0), 3)
+    def test_foldr_empty_list(self):
+        self.assertEqual(list_ops.foldr(operator.mul, [], 2), 2)
 
+    def test_foldr_nonempty_list_addition(self):
+        self.assertEqual(list_ops.foldr(operator.add, [1, 2, 3, 4], 5), 15)
+
+    def test_foldr_nonempty_list_floordiv(self):
+        self.assertEqual(list_ops.foldr(operator.floordiv, [2, 5], 5), 2)
+
+    # additional test for foldr
     def test_foldr_add_str(self):
         self.assertEqual(
             list_ops.foldr(operator.add,
                            ["e", "x", "e", "r", "c", "i", "s", "m"], "!"),
             "exercism!")
 
-    # tests for flatten
-    def test_flatten_nested(self):
-        self.assertEqual(list_ops.flat([[[1, 2], [3]], [[4]]]), [1, 2, 3, 4])
+    # tests for reverse
+    def test_reverse_empty_list(self):
+        self.assertEqual(list_ops.reverse([]), [])
 
-    def test_flatten_once(self):
-        self.assertEqual(list_ops.flat([["x", "y", "z"]]), ["x", "y", "z"])
+    def test_reverse_nonempty_list(self):
+        self.assertEqual(list_ops.reverse([1, 3, 5, 7]), [7, 5, 3, 1])
 
-    def test_flatten_empty(self):
-        self.assertEqual(list_ops.flat([]), [])
-
-    # tests for concat
-    def test_concat_two(self):
+    # additional test for reverse
+    def test_reverse_mixed_types(self):
         self.assertEqual(
-            list_ops.concat([1, 3, 5, 8], [9, 4, 5, 6]),
-            [1, 3, 5, 8, 9, 4, 5, 6])
-
-    def test_concat_nothing(self):
-        self.assertEqual(
-            list_ops.concat(['orange', 'apple', 'banana'], None),
-            ["orange", "apple", "banana"])
-
-    def test_concat_empty(self):
-        self.assertEqual(list_ops.concat([], []), [])
+            list_ops.reverse(["xyz", 4.0, "cat", 1]), [1, "cat", 4.0, "xyz"])
 
 
 if __name__ == '__main__':

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -32,7 +32,7 @@ class ListOpsTest(unittest.TestCase):
         condition = lambda x: x % 2 == 1
         self.assertEqual(list_ops.filter_clone(condition, []), [])
 
-    def test_filter_empty_list(self):
+    def test_filter_nonempty_list(self):
         condition = lambda x: x % 2 == 1
         self.assertEqual(list_ops.filter_clone(condition, [1, 2, 3, 4, 5]),
                          [1, 3, 5])


### PR DESCRIPTION
I've implemented the tests from the most recent version of the [canonical data (v2.0.0)](https://github.com/exercism/problem-specifications/blob/master/exercises/list-ops/canonical-data.json), and I kept a couple of the old tests that I thought were good additions. This PR also fixes #570.

There are a couple of points that I'm not too sure about though and would invite comment.

**Key questions:**
- Is the new implementation of `append` and `concat` sensible? Or should we revert their behaviour?
- Do we want the suggested optional tests for long lists?

### Altered behaviour of `append` and `concat`

The canonical data seems to suggest implementing `append` and `concat` in a different way to the previous tests, and I'm not sure that I like it. The new `append` function is essentially just the old `concat` function, and the new `concat` takes a list of lists. I've included examples below to demonstrate this change.

**Old version:**
```
append([1, 2], 3) == [1, 2, 3]

concat([1, 2], [3, 4]) == [1, 2, 3, 4]
```

**New version:**
```
append([1, 2], [3]) == [1, 2, 3]
append([1, 2], [3, 4]) == [1, 2, 3, 4]

concat([[1, 2], [3, 4]]) = [1, 2, 3, 4]
concat([[1, 2], [3, 4], [5, 6]]) = [1, 2, 3, 4, 5, 6]
```

My personal preference would be to use the old form of `append` and `concat`, but change `concat` to accept an arbitrary number of arguments so that a list of lists can be unpacked into it, but `concat(list1, list2)` would still work.

### Tests with long lists

There is also the suggestion in the canonical data that we could include tests with long lists to give people a reason to think about the efficiency of their approach. Do you think that these would be a good idea? I'm struggling to think of any particularly inefficient solutions that it would discourage.




