### PR TITLE
variable-length-quantity: add parameters to exercise placeholder

### DIFF
--- a/exercises/variable-length-quantity/example.py
+++ b/exercises/variable-length-quantity/example.py
@@ -3,32 +3,32 @@ SEVENBITSMASK = 0x7f
 
 
 def encode_single(n):
-    bytes = [n & SEVENBITSMASK]
+    bytes_ = [n & SEVENBITSMASK]
     n >>= 7
 
     while n > 0:
-        bytes.append(n & SEVENBITSMASK | EIGHTBITMASK)
+        bytes_.append(n & SEVENBITSMASK | EIGHTBITMASK)
         n >>= 7
 
-    return bytes[::-1]
+    return bytes_[::-1]
 
 
 def encode(numbers):
     return sum((encode_single(n) for n in numbers), [])
 
 
-def decode(bytes):
+def decode(bytes_):
     values = []
     n = 0
 
-    for i, byte in enumerate(bytes):
+    for i, byte in enumerate(bytes_):
         n <<= 7
         n += (byte & SEVENBITSMASK)
 
         if byte & EIGHTBITMASK == 0:
             values.append(n)
             n = 0
-        elif i == len(bytes) - 1:
+        elif i == len(bytes_) - 1:
             raise ValueError('incomplete byte sequence')
 
     return values

--- a/exercises/variable-length-quantity/variable_length_quantity.py
+++ b/exercises/variable-length-quantity/variable_length_quantity.py
@@ -1,6 +1,6 @@
-def encode():
+def encode(numbers):
     pass
 
 
-def decode():
+def decode(bytes_):
     pass


### PR DESCRIPTION
Add parameters to exercise placeholder for variable-length-quantity.

Also change variable naming from bytes to bytes_ to avoid shadowing
python's bytes

Fixes: #651