### PR TITLE
Change execution order of verification scripts for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_script:
   - flake8
 
 script:
-  - ./test/check-exercises.py
   - ./bin/fetch-configlet
   - ./bin/configlet lint .
+  - ./test/check-exercises.py


### PR DESCRIPTION
By reading logs from https://travis-ci.org/exercism/python/jobs/286835621 I've noticed that our test script run tests before verifiying high level things with `configlet` which can be improved
This PR is meant to fix that