### PR TITLE
forth: fix import line

### DIFF
--- a/exercises/forth/forth.py
+++ b/exercises/forth/forth.py
@@ -1,2 +1,6 @@
+class StackUnderflowError(Exception):
+    pass
+
+
 def evaluate(input_data):
     pass

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from example import evaluate, StackUnderflowError
+from forth import evaluate, StackUnderflowError
 
 
 # test cases adapted from `x-common//canonical-data.json` @ version: 1.2.0


### PR DESCRIPTION
While solving exercises, I noticed that somehow myself, @m-a-ge, and @N-Parsons all managed to miss that the test file was importing from `example`, not `forth`. This is now fixed.