### PR TITLE
Swap '2016' for '1996' to stop faulty logic from passing unit test in Leap

### DIFF
--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -10,7 +10,7 @@ class YearTest(unittest.TestCase):
         self.assertIs(is_leap_year(2015), False)
 
     def test_year_divisible_by_4_not_divisible_by_100(self):
-        self.assertIs(is_leap_year(2016), True)
+        self.assertIs(is_leap_year(1996), True)
 
     def test_year_divisible_by_100_not_divisible_by_400(self):
         self.assertIs(is_leap_year(2100), False)

--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -3,7 +3,7 @@ import unittest
 from leap import is_leap_year
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class YearTest(unittest.TestCase):
     def test_year_not_divisible_by_4(self):


### PR DESCRIPTION
[This Leap solution](http://exercism.io/submissions/7ef5b0ab93b540f79cdee9f153e0a21c) should not pass the unit test, since it checks whether `year % 100` and `year % 400` are equal in order to tell whether the year it has been passed is a leap year. This works for 2016 because `2016 % 100` and `2016 % 400` both evaluate to 16.

1996, another leap year that is divisible by 4 but not 100, does not have this property and, under that solution, would be falsely *not* classed as a leap year.