### PR TITLE
forth: Update version string to reference problem-specifications

### DIFF
--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -3,7 +3,7 @@ import unittest
 from forth import evaluate, StackUnderflowError
 
 
-# test cases adapted from `x-common//canonical-data.json` @ version: 1.2.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 
 class ForthAdditionTest(unittest.TestCase):


### PR DESCRIPTION
Updates the version string format for `forth`, since it was missed when it was recently merged.