### PR TITLE
Fix topics naming to meet naming convention 

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,9 +9,9 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (if-else statements)",
-        "optional values",
-        "text formatting"
+        "conditionals",
+        "optional_values",
+        "text_formatting"
       ]
     },
     {
@@ -21,7 +21,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (if-else statements)",
+        "conditionals",
         "booleans",
         "logic"
       ]
@@ -46,8 +46,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (loops)",
-        "control-flow (if-else statements)",
+        "loops",
+        "conditionals",
         "strings",
         "algorithms",
         "filtering",
@@ -61,8 +61,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (if-else statements)",
-        "control-flow (loops)",
+        "conditionals",
+        "loops",
         "maps",
         "strings",
         "logic",
@@ -76,8 +76,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (if-else statements)",
-        "control-flow (loops)",
+        "conditionals",
+        "loops",
         "sequences",
         "sets",
         "strings",
@@ -96,8 +96,8 @@
         "strings",
         "algorithms",
         "logic",
-        "pattern recognition",
-        "text formatting"
+        "pattern_recognition",
+        "text_formatting"
       ]
     },
     {
@@ -158,7 +158,7 @@
       "topics": [
         "strings",
         "logic",
-        "control-flow (loops)"
+        "loops"
       ]
     },
     {
@@ -479,8 +479,7 @@
       "topics": [
         "lists",
         "searching",
-        "loops",
-        "iteration"
+        "loops"
       ]
     },
     {
@@ -672,7 +671,7 @@
       "topics": [
         "lists",
         "parsing",
-        "transformation",
+        "transforming",
         "loops",
         "games"
       ]
@@ -908,7 +907,7 @@
         "time",
         "mathematics",
         "logic",
-        "text formatting"
+        "text_formatting"
       ]
     },
     {
@@ -919,7 +918,7 @@
       "difficulty": 4,
       "topics": [
         "files",
-        "text formatting",
+        "text_formatting",
         "searching"
       ]
     },
@@ -967,7 +966,7 @@
       "difficulty": 3,
       "topics": [
         "strings",
-        "pattern matching"
+        "pattern_matching"
       ]
     },
     {
@@ -978,7 +977,7 @@
       "difficulty": 3,
       "topics": [
         "strings",
-        "pattern matching"
+        "pattern_matching"
       ]
     },
     {
@@ -988,9 +987,9 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Control-flow (loops)",
-        "Arrays",
-        "Algorithms"
+        "loops",
+        "arrays",
+        "algorithms"
       ]
     },
     {
@@ -1000,9 +999,9 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control-flow (if-else statements)",
-        "optional values",
-        "text formatting"
+        "conditionals",
+        "optional_values",
+        "text_formatting"
       ]
     },
     {
@@ -1012,7 +1011,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-            "control-flow (loops)"
+        "loops"
       ]
     },
     {


### PR DESCRIPTION
To finish with #808 we must ensure that there are no topics in our `config.json` which are not listed in https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt

This PR fixes this inconsistency