### PR TITLE
word-count: added test version and updated tests to match canonical 

### DIFF
--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -3,6 +3,8 @@ import unittest
 from word_count import word_count
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class WordCountTests(unittest.TestCase):
 
     def test_count_one_word(self):
@@ -23,6 +25,18 @@ class WordCountTests(unittest.TestCase):
             word_count('one fish two fish red fish blue fish')
         )
 
+    def test_cramped_lists(self):
+        self.assertEqual(
+            {'one': 1, 'two': 1, 'three': 1},
+            word_count("one,two,three")
+        )
+
+    def test_expanded_lists(self):
+        self.assertEqual(
+            {'one': 1, 'two': 1, 'three': 1},
+            word_count("one,\ntwo,\nthree")
+        )
+
     def test_ignores_punctuation(self):
         self.assertEqual(
             {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1},
@@ -40,6 +54,21 @@ class WordCountTests(unittest.TestCase):
             [2, 3],
             sorted(list(word_count('go Go GO Stop stop').values()))
         )
+
+    def test_apostrophes(self):
+        self.assertEqual(
+            {'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1},
+            word_count("First: don't laugh. Then: don't cry.")
+        )
+
+    def test_quotations(self):
+        self.assertEqual(
+            {'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2,
+             'and': 1},
+            word_count("Joe can't tell between 'large' and large.")
+        )
+
+    # Additional tests for this track
 
     def test_multiple_spaces(self):
         self.assertEqual(

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -3,8 +3,6 @@ import unittest
 from word_count import word_count
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
-
 class WordCountTests(unittest.TestCase):
 
     def test_count_one_word(self):
@@ -25,18 +23,6 @@ class WordCountTests(unittest.TestCase):
             word_count('one fish two fish red fish blue fish')
         )
 
-    def test_cramped_lists(self):
-        self.assertEqual(
-            {'one': 1, 'two': 1, 'three': 1},
-            word_count("one,two,three")
-        )
-
-    def test_expanded_lists(self):
-        self.assertEqual(
-            {'one': 1, 'two': 1, 'three': 1},
-            word_count("one,\ntwo,\nthree")
-        )
-
     def test_ignores_punctuation(self):
         self.assertEqual(
             {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1},
@@ -54,6 +40,19 @@ class WordCountTests(unittest.TestCase):
             [2, 3],
             sorted(list(word_count('go Go GO Stop stop').values()))
         )
+
+    # def test_apostrophes(self):
+    #     self.assertEqual(
+    #         {'first': 1, "don't": 2, 'laugh': 1, 'then': 1, 'cry': 1},
+    #         word_count("First: don't laugh. Then: don't cry.")
+    #     )
+    #
+    # def test_quotations(self):
+    #     self.assertEqual(
+    #         {'joe': 1, "can't": 1, 'tell': 1, 'between': 1, 'large': 2,
+    #          'and': 1},
+    #         word_count("Joe can't tell between 'large' and large.")
+    #     )
 
     # Additional tests for this track
 

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -55,19 +55,6 @@ class WordCountTests(unittest.TestCase):
             sorted(list(word_count('go Go GO Stop stop').values()))
         )
 
-    def test_apostrophes(self):
-        self.assertEqual(
-            {'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1},
-            word_count("First: don't laugh. Then: don't cry.")
-        )
-
-    def test_quotations(self):
-        self.assertEqual(
-            {'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2,
-             'and': 1},
-            word_count("Joe can't tell between 'large' and large.")
-        )
-
     # Additional tests for this track
 
     def test_multiple_spaces(self):

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -7,81 +7,93 @@ class WordCountTests(unittest.TestCase):
 
     def test_count_one_word(self):
         self.assertEqual(
-            {'word': 1},
-            word_count('word')
+            word_count('word'),
+            {'word': 1}
         )
 
     def test_count_one_of_each(self):
         self.assertEqual(
-            {'one': 1, 'of': 1, 'each': 1},
-            word_count('one of each')
+            word_count('one of each'),
+            {'one': 1, 'of': 1, 'each': 1}
         )
 
     def test_count_multiple_occurences(self):
         self.assertEqual(
-            {'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1},
-            word_count('one fish two fish red fish blue fish')
+            word_count('one fish two fish red fish blue fish'),
+            {'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1}
+        )
+
+    def test_cramped_list(self):
+        self.assertEqual(
+            word_count('one,two,three'),
+            {'one': 1, 'two': 1, 'three': 1}
+        )
+
+    def test_expanded_list(self):
+        self.assertEqual(
+            word_count('one,\ntwo,\nthree'),
+            {'one': 1, 'two': 1, 'three': 1}
         )
 
     def test_ignores_punctuation(self):
         self.assertEqual(
-            {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1},
-            word_count('car : carpet as java : javascript!!&@$%^&')
+            word_count('car : carpet as java : javascript!!&@$%^&'),
+            {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1}
         )
 
     def test_include_numbers(self):
         self.assertEqual(
-            {'testing': 2, '1': 1, '2': 1},
-            word_count('testing 1 2 testing')
+            word_count('testing 1 2 testing'),
+            {'testing': 2, '1': 1, '2': 1}
         )
 
     def test_mixed_case(self):
         self.assertEqual(
-            [2, 3],
-            sorted(list(word_count('go Go GO Stop stop').values()))
+            sorted(list(word_count('go Go GO Stop stop').values())),
+            [2, 3]
         )
 
-    # def test_apostrophes(self):
-    #     self.assertEqual(
-    #         {'first': 1, "don't": 2, 'laugh': 1, 'then': 1, 'cry': 1},
-    #         word_count("First: don't laugh. Then: don't cry.")
-    #     )
-    #
-    # def test_quotations(self):
-    #     self.assertEqual(
-    #         {'joe': 1, "can't": 1, 'tell': 1, 'between': 1, 'large': 2,
-    #          'and': 1},
-    #         word_count("Joe can't tell between 'large' and large.")
-    #     )
+    def test_apostrophes(self):
+        self.assertEqual(
+            word_count("First: don't laugh. Then: don't cry."),
+            {'first': 1, "don't": 2, 'laugh': 1, 'then': 1, 'cry': 1}
+        )
+
+    def test_quotations(self):
+        self.assertEqual(
+            word_count("Joe can't tell between 'large' and large."),
+            {'joe': 1, "can't": 1, 'tell': 1, 'between': 1, 'large': 2,
+             'and': 1}
+        )
 
     # Additional tests for this track
 
     def test_multiple_spaces(self):
         self.assertEqual(
-            {'wait': 1, 'for': 1, 'it': 1},
-            word_count('wait for       it')
+            word_count('wait for       it'),
+            {'wait': 1, 'for': 1, 'it': 1}
         )
 
     def test_newlines(self):
         self.assertEqual(
-            {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
-             'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
             word_count('rah rah ah ah ah\nroma roma ma\n'
-                       'ga ga oh la la\nwant your bad romance')
+                       'ga ga oh la la\nwant your bad romance'),
+            {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
+             'want': 1, 'your': 1, 'bad': 1, 'romance': 1}
         )
 
     def test_tabs(self):
         self.assertEqual(
-            {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
-             'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
             word_count('rah rah ah ah ah\troma roma ma\tga ga oh la la\t'
-                       'want your bad romance')
+                       'want your bad romance'),
+            {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
+             'want': 1, 'your': 1, 'bad': 1, 'romance': 1}
         )
 
     def test_non_alphanumeric(self):
         self.assertEqual(
-            {'hey': 1, 'my': 1, 'spacebar': 1, 'is': 1, 'broken': 1},
-            word_count('hey,my_spacebar_is_broken.')
+            word_count('hey,my_spacebar_is_broken.'),
+            {'hey': 1, 'my': 1, 'spacebar': 1, 'is': 1, 'broken': 1}
         )
 
 

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -49,8 +49,8 @@ class WordCountTests(unittest.TestCase):
 
     def test_mixed_case(self):
         self.assertEqual(
-            sorted(list(word_count('go Go GO Stop stop').values())),
-            [2, 3]
+            word_count('go Go GO Stop stop'),
+            {'go': 3, 'stop': 2}
         )
 
     def test_apostrophes(self):


### PR DESCRIPTION
Fix #1011 

As I mentioned in issue #1045, there were two tests from the canonical data that failed with the example implementation, so I left them out.