### PR TITLE
saddle-points: Update the tests folling the canonical data

### DIFF
--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -11,6 +11,7 @@ from saddle_points import saddle_points
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class SaddlePointTest(unittest.TestCase):
     def test_one_saddle(self):
         inp = [[9, 8, 7], [5, 3, 2], [6, 6, 7]]

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -9,28 +9,29 @@ import unittest
 
 from saddle_points import saddle_points
 
+
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 class SaddlePointTest(unittest.TestCase):
     def test_one_saddle(self):
         inp = [[9, 8, 7], [5, 3, 2], [6, 6, 7]]
-        self.assertEqual(set([(1, 0)]), saddle_points(inp))
+        self.assertEqual(saddle_points(inp), set([(1, 0)]))
 
     def test_empty_matrix(self):
-        self.assertEqual(set(), saddle_points([]))
+        self.assertEqual(saddle_points([]), set())
 
     def test_no_saddle(self):
         inp = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]
-        self.assertEqual(set(), saddle_points(inp))
+        self.assertEqual(saddle_points(inp), set())
 
     def test_mult_saddle(self):
         inp = [[4, 5, 4], [3, 5, 5], [1, 5, 4]]
         ans = set([(0, 1), (1, 1), (2, 1)])
-        self.assertEqual(ans, saddle_points(inp))
+        self.assertEqual(saddle_points(inp), ans)
 
     def test_indentify_saddle_bottom_right_corner(self):
         inp = [[8, 7, 9], [6, 7, 6], [3, 2, 5]]
         ans = set([(2, 2)])
-        self.assertEqual(ans, saddle_points(inp))
+        self.assertEqual(saddle_points(inp), ans)
 
     # Additional tests for this track
 

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -9,22 +9,30 @@ import unittest
 
 from saddle_points import saddle_points
 
-
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 class SaddlePointTest(unittest.TestCase):
     def test_one_saddle(self):
         inp = [[9, 8, 7], [5, 3, 2], [6, 6, 7]]
-        self.assertEqual(saddle_points(inp), set([(1, 0)]))
-
-    def test_no_saddle(self):
-        self.assertEqual(saddle_points([[2, 1], [1, 2]]), set())
-
-    def test_mult_saddle(self):
-        inp = [[5, 3, 5, 4], [6, 4, 7, 3], [5, 1, 5, 3]]
-        ans = set([(0, 0), (0, 2), (2, 0), (2, 2)])
-        self.assertEqual(saddle_points(inp), ans)
+        self.assertEqual(set([(1, 0)]), saddle_points(inp))
 
     def test_empty_matrix(self):
-        self.assertEqual(saddle_points([]), set())
+        self.assertEqual(set(), saddle_points([]))
+
+    def test_no_saddle(self):
+        inp = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]
+        self.assertEqual(set(), saddle_points(inp))
+
+    def test_mult_saddle(self):
+        inp = [[4, 5, 4], [3, 5, 5], [1, 5, 4]]
+        ans = set([(0, 1), (1, 1), (2, 1)])
+        self.assertEqual(ans, saddle_points(inp))
+
+    def test_indentify_saddle_bottom_right_corner(self):
+        inp = [[8, 7, 9], [6, 7, 6], [3, 2, 5]]
+        ans = set([(2, 2)])
+        self.assertEqual(ans, saddle_points(inp))
+
+    # Additional tests for this track
 
     def test_irregular_matrix(self):
         inp = [[3, 2, 1], [0, 1], [2, 1, 0]]


### PR DESCRIPTION
Update the `saddle points` testes following the recomandations of closes #1005 