### PR TITLE
binary-search: Update the tests following the canonical data

### DIFF
--- a/exercises/binary-search/binary_search_test.py
+++ b/exercises/binary-search/binary_search_test.py
@@ -2,29 +2,32 @@ import unittest
 
 from binary_search import binary_search
 
-
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 class BinarySearchTests(unittest.TestCase):
     def test_finds_value_in_array_with_one_element(self):
-        self.assertEqual(binary_search([6], 6), 0)
+        self.assertEqual(0, binary_search([6], 6))
 
     def test_finds_value_in_middle_of_array(self):
-        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 6), 3)
+        self.assertEqual(3, binary_search([1, 3, 4, 6, 8, 9, 11], 6))
 
     def test_finds_value_at_beginning_of_array(self):
-        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 1), 0)
+        self.assertEqual(0, binary_search([1, 3, 4, 6, 8, 9, 11], 1))
 
     def test_finds_value_at_end_of_array(self):
-        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 11), 6)
+        self.assertEqual(6, binary_search([1, 3, 4, 6, 8, 9, 11], 11))
 
     def test_finds_value_in_array_of_odd_length(self):
         self.assertEqual(
+            9,
             binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634],
-                          144), 9)
+                          144)
+        )
 
     def test_finds_value_in_array_of_even_length(self):
         self.assertEqual(
-            binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21),
-            5)
+            5,
+            binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21)
+        )
 
     def test_identifies_value_missing(self):
         with self.assertRaises(ValueError):

--- a/exercises/binary-search/binary_search_test.py
+++ b/exercises/binary-search/binary_search_test.py
@@ -2,31 +2,32 @@ import unittest
 
 from binary_search import binary_search
 
+
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 class BinarySearchTests(unittest.TestCase):
     def test_finds_value_in_array_with_one_element(self):
-        self.assertEqual(0, binary_search([6], 6))
+        self.assertEqual(binary_search([6], 6), 0)
 
     def test_finds_value_in_middle_of_array(self):
-        self.assertEqual(3, binary_search([1, 3, 4, 6, 8, 9, 11], 6))
+        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 6), 3)
 
     def test_finds_value_at_beginning_of_array(self):
-        self.assertEqual(0, binary_search([1, 3, 4, 6, 8, 9, 11], 1))
+        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 1), 0)
 
     def test_finds_value_at_end_of_array(self):
-        self.assertEqual(6, binary_search([1, 3, 4, 6, 8, 9, 11], 11))
+        self.assertEqual(binary_search([1, 3, 4, 6, 8, 9, 11], 11), 6)
 
     def test_finds_value_in_array_of_odd_length(self):
         self.assertEqual(
-            9,
             binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634],
-                          144)
+                          144),
+            9
         )
 
     def test_finds_value_in_array_of_even_length(self):
         self.assertEqual(
-            5,
-            binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21)
+            binary_search([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21),
+            5
         )
 
     def test_identifies_value_missing(self):


### PR DESCRIPTION
Update the `binary-search` track following the recommendations from issue #989