### PR TITLE
perfect-numbers: Update perfect-numbers to reflect changes to canonical data

### DIFF
--- a/exercises/perfect-numbers/example.py
+++ b/exercises/perfect-numbers/example.py
@@ -7,6 +7,17 @@ def divisor_generator(n):
                 yield n // i
 
 
-def is_perfect(n):
+def classify(n):
     ''' A perfect number equals the sum of its positive divisors. '''
-    return sum(divisor_generator(n)) + 1 == n
+    if n <= 0:
+        raise ValueError("Classification is only possible" +
+                         " for positive whole numbers.")
+
+    aliquot_sum = sum(divisor_generator(n)) + (1 if n > 1 else 0)
+
+    if aliquot_sum < n:
+        return "deficient"
+    elif aliquot_sum == n:
+        return "perfect"
+    else:
+        return "abundant"

--- a/exercises/perfect-numbers/perfect_numbers.py
+++ b/exercises/perfect-numbers/perfect_numbers.py
@@ -2,5 +2,5 @@ def divisor_generator(number):
     pass
 
 
-def is_perfect(number):
+def classify(number):
     pass

--- a/exercises/perfect-numbers/perfect_numbers.py
+++ b/exercises/perfect-numbers/perfect_numbers.py
@@ -1,6 +1,2 @@
-def divisor_generator(number):
-    pass
-
-
 def classify(number):
     pass

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -1,42 +1,78 @@
 import unittest
 
-from perfect_numbers import is_perfect
+from perfect_numbers import classify
+
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
 
 
 class PerfectNumbersTest(unittest.TestCase):
+    def test_smallest_perfect_number(self):
+        self.assertIs(classify(6), "perfect")
 
-    def test_first_perfect_number(self):
-        self.assertIs(is_perfect(6), True)
+    def test_medium_perfect_number(self):
+        self.assertIs(classify(28), "perfect")
 
-    def test_no_perfect_number(self):
-        self.assertIs(is_perfect(8), False)
+    def test_large_perfect_number(self):
+        self.assertIs(classify(33550336), "perfect")
 
-    def test_second_perfect_number(self):
-        self.assertIs(is_perfect(28), True)
-
-    def test_abundant(self):
-        self.assertIs(is_perfect(20), False)
-
-    def test_answer_to_the_ultimate_question_of_life(self):
-        self.assertIs(is_perfect(42), False)
-
+    # Additional tests for this track
     def test_third_perfect_number(self):
-        self.assertIs(is_perfect(496), True)
-
-    def test_odd_abundant(self):
-        self.assertIs(is_perfect(945), False)
+        self.assertIs(classify(496), "perfect")
 
     def test_fourth_perfect_number(self):
-        self.assertIs(is_perfect(8128), True)
-
-    def test_fifth_perfect_number(self):
-        self.assertIs(is_perfect(33550336), True)
+        self.assertIs(classify(8128), "perfect")
 
     def test_sixth_perfect_number(self):
-        self.assertIs(is_perfect(8589869056), True)
+        self.assertIs(classify(8589869056), "perfect")
 
     def test_seventh_perfect_number(self):
-        self.assertIs(is_perfect(137438691328), True)
+        self.assertIs(classify(137438691328), "perfect")
+
+
+class AbundantNumbersTest(unittest.TestCase):
+    def test_smallest_abundant_number(self):
+        self.assertIs(classify(12), "abundant")
+
+    def test_medium_abundant_number(self):
+        self.assertIs(classify(30), "abundant")
+
+    def test_large_abundant_number(self):
+        self.assertIs(classify(33550335), "abundant")
+
+    # Additional tests for this track
+    def test_answer_to_the_ultimate_question_of_life(self):
+        self.assertIs(classify(42), "abundant")
+
+    def test_odd_abundant(self):
+        self.assertIs(classify(945), "abundant")
+
+    def test_even_abundant(self):
+        self.assertIs(classify(20), "abundant")
+
+
+class DeficientNumbersTest(unittest.TestCase):
+    def test_smallest_prime_deficient_number(self):
+        self.assertIs(classify(2), "deficient")
+
+    def test_smallest_nonprime_deficient_number(self):
+        self.assertIs(classify(4), "deficient")
+
+    def test_medium_deficient_number(self):
+        self.assertIs(classify(32), "deficient")
+
+    def test_large_deficient_number(self):
+        self.assertIs(classify(33550337), "deficient")
+
+    def test_edge_case(self):
+        self.assertIs(classify(1), "deficient")
+
+
+class InvalidInputsTest(unittest.TestCase):
+    def test_zero(self):
+        self.assertRaises(ValueError, classify, 0)
+
+    def test_negative(self):
+        self.assertRaises(ValueError, classify, -1)
 
 
 if __name__ == '__main__':

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -69,17 +69,11 @@ class DeficientNumbersTest(unittest.TestCase):
 
 class InvalidInputsTest(unittest.TestCase):
     def test_zero(self):
-        with self.assertRaisesRegexp(
-                ValueError,
-                ("Classification is only possible"
-                 " for positive whole numbers.")):
+        with self.assertRaises(ValueError):
             classify(0)
 
     def test_negative(self):
-        with self.assertRaisesRegexp(
-                ValueError,
-                ("Classification is only possible"
-                 " for positive whole numbers.")):
+        with self.assertRaises(ValueError):
             classify(-1)
 
 

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -69,14 +69,14 @@ class DeficientNumbersTest(unittest.TestCase):
 
 class InvalidInputsTest(unittest.TestCase):
     def test_zero(self):
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexp(
                 ValueError,
                 ("Classification is only possible"
                  " for positive whole numbers.")):
             classify(0)
 
     def test_negative(self):
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexp(
                 ValueError,
                 ("Classification is only possible"
                  " for positive whole numbers.")):

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -69,10 +69,18 @@ class DeficientNumbersTest(unittest.TestCase):
 
 class InvalidInputsTest(unittest.TestCase):
     def test_zero(self):
-        self.assertRaises(ValueError, classify, 0)
+        with self.assertRaisesRegex(
+                ValueError,
+                ("Classification is only possible"
+                 " for positive whole numbers.")):
+            classify(0)
 
     def test_negative(self):
-        self.assertRaises(ValueError, classify, -1)
+        with self.assertRaisesRegex(
+                ValueError,
+                ("Classification is only possible"
+                 " for positive whole numbers.")):
+            classify(-1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #1001

A few things to note:

- I added errors + error catching to both the example solution and the test cases (as these were specified in the canonical data)
- I refer to the range of valid inputs as "positive whole numbers" as the definition of natural numbers can either include or exclude 0. If this is accepted, I'll open an appropriate PR to update the canonical data accordingly
- I've put two blank lines below the version string as my PEP8 linter was complaining about it (it's possible my linter is not configured properly)
