### PR TITLE
grains: Update tests to match canonical-data 

### DIFF
--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -5,8 +5,8 @@ from grains import (
     total_after,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
 class GrainsTest(unittest.TestCase):
     def test_square_1(self):

--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -33,14 +33,20 @@ class GrainsTest(unittest.TestCase):
     def test_square_0_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(0)
+        with self.assertRaises(ValueError):
+            total_after(0)
 
     def test_square_negative_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(-1)
+        with self.assertRaises(ValueError):
+            total_after(-1)
 
     def test_square_gt_64_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(65)
+        with self.assertRaises(ValueError):
+            total_after(65)
 
     def test_total(self):
         self.assertEqual(total_after(64), 18446744073709551615)

--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -5,53 +5,45 @@ from grains import (
     total_after,
 )
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 
 class GrainsTest(unittest.TestCase):
     def test_square_1(self):
         self.assertEqual(on_square(1), 1)
-        self.assertEqual(total_after(1), 1)
 
     def test_square_2(self):
         self.assertEqual(on_square(2), 2)
-        self.assertEqual(total_after(2), 3)
 
     def test_square_3(self):
         self.assertEqual(on_square(3), 4)
-        self.assertEqual(total_after(3), 7)
 
     def test_square_4(self):
         self.assertEqual(on_square(4), 8)
-        self.assertEqual(total_after(4), 15)
 
     def test_square_16(self):
         self.assertEqual(on_square(16), 32768)
-        self.assertEqual(total_after(16), 65535)
 
     def test_square_32(self):
         self.assertEqual(on_square(32), 2147483648)
-        self.assertEqual(total_after(32), 4294967295)
 
     def test_square_64(self):
         self.assertEqual(on_square(64), 9223372036854775808)
-        self.assertEqual(total_after(64), 18446744073709551615)
 
     def test_square_0_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(0)
-        with self.assertRaises(ValueError):
-            total_after(0)
 
     def test_square_negative_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(-1)
-        with self.assertRaises(ValueError):
-            total_after(-1)
 
     def test_square_gt_64_raises_exception(self):
         with self.assertRaises(ValueError):
             on_square(65)
-        with self.assertRaises(ValueError):
-            total_after(65)
+
+    def test_total(self):
+        self.assertEqual(total_after(64), 18446744073709551615)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #996 

Removes multiple total_after tests in favor of one at the end as specified in canonical-data.