### PR TITLE
minesweeper: update tests to version 1.1.0

### DIFF
--- a/exercises/minesweeper/example.py
+++ b/exercises/minesweeper/example.py
@@ -1,4 +1,6 @@
 def board(inp):
+    if(inp == []):
+        return []
     verify_board(inp)
     rowlen = len(inp[0])
     collen = len(inp)
@@ -7,9 +9,13 @@ def board(inp):
         for i2 in range(rowlen):
             if b[i1][i2] != ' ':
                 continue
-            cnt = inp[i1 - 1][i2 - 1:i2 + 2].count('*') + \
-                inp[i1][i2 - 1:i2 + 2].count('*') + \
-                inp[i1 + 1][i2 - 1:i2 + 2].count('*')
+            low = max(i2 - 1, 0)
+            high = min(i2 + 2, rowlen + 2)
+            cnt = inp[i1][low:high].count('*')
+            if(i1 > 0):
+                cnt += inp[i1 - 1][low:high].count('*')
+            if(i1 < collen - 1):
+                cnt += inp[i1 + 1][low:high].count('*')
             if cnt == 0:
                 continue
             b[i1][i2] = str(cnt)
@@ -17,23 +23,13 @@ def board(inp):
 
 
 def verify_board(inp):
-    # Null board or a null row
-    if not inp or not all(r for r in inp):
-        raise ValueError("Invalid board")
     # Rows with different lengths
     rowlen = len(inp[0])
-    collen = len(inp)
     if not all(len(r) == rowlen for r in inp):
         raise ValueError("Invalid board")
     # Unknown character in board
     cset = set()
     for r in inp:
         cset.update(r)
-    if cset - set('+- *|'):
-        raise ValueError("Invalid board")
-    # Borders not as expected
-    if any(inp[i1] != '+' + '-' * (rowlen - 2) + '+'
-           for i1 in [0, -1]) or any(inp[i1][i2] != '|'
-                                     for i1 in range(1, collen - 1)
-                                     for i2 in [0, -1]):
+    if cset - set(' *'):
         raise ValueError("Invalid board")

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -14,193 +14,136 @@ from minesweeper import board
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
 class MinesweeperTest(unittest.TestCase):
-    # Tests in canonical data incompatible with board class
+
     def test_no_rows(self):
-        with self.assertRaises(ValueError):
-            board([])
+        self.assertEqual(board([]), [])
 
     def test_no_columns(self):
-        with self.assertRaises(ValueError):
-            board([""])
+        self.assertEqual(board([""]), [""])
 
     def test_no_mines(self):
-        inp = ["+---+",
-               "|   |",
-               "|   |",
-               "|   |",
-               "+---+"]
-        out = ["+---+",
-               "|   |",
-               "|   |",
-               "|   |",
-               "+---+"]
+        inp = ["   ",
+               "   ",
+               "   "]
+        out = ["   ",
+               "   ",
+               "   "]
         self.assertEqual(board(inp), out)
 
     def test_board_with_only_mines(self):
-        inp = ["+---+",
-               "|***|",
-               "|***|",
-               "|***|",
-               "+---+"]
-        out = ["+---+",
-               "|***|",
-               "|***|",
-               "|***|",
-               "+---+"]
+        inp = ["***",
+               "***",
+               "***"]
+        out = ["***",
+               "***",
+               "***"]
         self.assertEqual(board(inp), out)
 
     def test_mine_surrounded_by_spaces(self):
-        inp = ["+---+",
-               "|   |",
-               "| * |",
-               "|   |",
-               "+---+"]
-        out = ["+---+",
-               "|111|",
-               "|1*1|",
-               "|111|",
-               "+---+"]
+        inp = ["   ",
+               " * ",
+               "   "]
+        out = ["111",
+               "1*1",
+               "111"]
         self.assertEqual(board(inp), out)
 
     def test_space_surrounded_by_mines(self):
-        inp = ["+---+",
-               "|***|",
-               "|* *|",
-               "|***|",
-               "+---+"]
-        out = ["+---+",
-               "|***|",
-               "|*8*|",
-               "|***|",
-               "+---+"]
+        inp = ["***",
+               "* *",
+               "***"]
+        out = ["***",
+               "*8*",
+               "***"]
         self.assertEqual(board(inp), out)
 
     def test_horizontal_line(self):
-        inp = ["+-----+",
-               "| * * |",
-               "+-----+"]
-        out = ["+-----+",
-               "|1*2*1|",
-               "+-----+"]
+        inp = [" * * "]
+        out = ["1*2*1"]
         self.assertEqual(board(inp), out)
 
     def test_horizontal_line_mines_at_edges(self):
-        inp = ["+-----+",
-               "|*   *|",
-               "+-----+"]
-        out = ["+-----+",
-               "|*1 1*|",
-               "+-----+"]
+        inp = ["*   *"]
+        out = ["*1 1*"]
         self.assertEqual(board(inp), out)
 
     def test_vertical_line(self):
-        inp = ["+-+",
-               "| |",
-               "|*|",
-               "| |",
-               "|*|",
-               "| |",
-               "+-+"]
-        out = ["+-+",
-               "|1|",
-               "|*|",
-               "|2|",
-               "|*|",
-               "|1|",
-               "+-+"]
+        inp = [" ",
+               "*",
+               " ",
+               "*",
+               " "]
+        out = ["1",
+               "*",
+               "2",
+               "*",
+               "1"]
         self.assertEqual(board(inp), out)
 
     def test_vertical_line_mines_at_edges(self):
-        inp = ["+-+",
-               "|*|",
-               "| |",
-               "| |",
-               "| |",
-               "|*|",
-               "+-+"]
-        out = ["+-+",
-               "|*|",
-               "|1|",
-               "| |",
-               "|1|",
-               "|*|",
-               "+-+"]
+        inp = ["*",
+               " ",
+               " ",
+               " ",
+               "*"]
+        out = ["*",
+               "1",
+               " ",
+               "1",
+               "*"]
         self.assertEqual(board(inp), out)
 
     def test_cross(self):
-        inp = ["+-----+",
-               "|  *  |",
-               "|  *  |",
-               "|*****|",
-               "|  *  |",
-               "|  *  |",
-               "+-----+"]
-        out = ["+-----+",
-               "| 2*2 |",
-               "|25*52|",
-               "|*****|",
-               "|25*52|",
-               "| 2*2 |",
-               "+-----+"]
+        inp = ["  *  ",
+               "  *  ",
+               "*****",
+               "  *  ",
+               "  *  "]
+        out = [" 2*2 ",
+               "25*52",
+               "*****",
+               "25*52",
+               " 2*2 "]
         self.assertEqual(board(inp), out)
 
     def test_large_board(self):
-        inp = ["+------+",
-               "| *  * |",
-               "|  *   |",
-               "|    * |",
-               "|   * *|",
-               "| *  * |",
-               "|      |",
-               "+------+"]
-        out = ["+------+",
-               "|1*22*1|",
-               "|12*322|",
-               "| 123*2|",
-               "|112*4*|",
-               "|1*22*2|",
-               "|111111|",
-               "+------+"]
+        inp = [" *  * ",
+               "  *   ",
+               "    * ",
+               "   * *",
+               " *  * ",
+               "      "]
+        out = ["1*22*1",
+               "12*322",
+               " 123*2",
+               "112*4*",
+               "1*22*2",
+               "111111"]
         self.assertEqual(board(inp), out)
 
     # Additional test for this track
     def test_board9(self):
-        inp = ["+-----+",
-               "|     |",
-               "|   * |",
-               "|     |",
-               "|     |",
-               "| *   |",
-               "+-----+"]
-        out = ["+-----+",
-               "|  111|",
-               "|  1*1|",
-               "|  111|",
-               "|111  |",
-               "|1*1  |",
-               "+-----+"]
+        inp = ["     ",
+               "   * ",
+               "     ",
+               "     ",
+               " *   "]
+        out = ["  111",
+               "  1*1",
+               "  111",
+               "111  ",
+               "1*1  "]
         self.assertEqual(board(inp), out)
 
     def test_different_len(self):
-        inp = ["+-+",
-               "| |",
-               "|*  |",
-               "|  |",
-               "+-+"]
-        with self.assertRaises(ValueError):
-            board(inp)
-
-    def test_faulty_border(self):
-        inp = ["+-----+",
-               "*   * |",
-               "+-- --+"]
+        inp = [" ",
+               "*  ",
+               "  "]
         with self.assertRaises(ValueError):
             board(inp)
 
     def test_invalid_char(self):
-        inp = ["+-----+",
-               "|X  * |",
-               "+-----+"]
+        inp = ["X  * "]
         with self.assertRaises(ValueError):
             board(inp)
 

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -11,8 +11,140 @@ import unittest
 from minesweeper import board
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class MinesweeperTest(unittest.TestCase):
-    def test_board1(self):
+    # Tests in canonical data incompatible with board class
+    def test_no_rows(self):
+        with self.assertRaises(ValueError):
+            board([])
+
+    def test_no_columns(self):
+        with self.assertRaises(ValueError):
+            board([""])
+
+    def test_no_mines(self):
+        inp = ["+---+",
+               "|   |",
+               "|   |",
+               "|   |",
+               "+---+"]
+        out = ["+---+",
+               "|   |",
+               "|   |",
+               "|   |",
+               "+---+"]
+        self.assertEqual(board(inp), out)
+
+    def test_board_with_only_mines(self):
+        inp = ["+---+",
+               "|***|",
+               "|***|",
+               "|***|",
+               "+---+"]
+        out = ["+---+",
+               "|***|",
+               "|***|",
+               "|***|",
+               "+---+"]
+        self.assertEqual(board(inp), out)
+
+    def test_mine_surrounded_by_spaces(self):
+        inp = ["+---+",
+               "|   |",
+               "| * |",
+               "|   |",
+               "+---+"]
+        out = ["+---+",
+               "|111|",
+               "|1*1|",
+               "|111|",
+               "+---+"]
+        self.assertEqual(board(inp), out)
+
+    def test_space_surrounded_by_mines(self):
+        inp = ["+---+",
+               "|***|",
+               "|* *|",
+               "|***|",
+               "+---+"]
+        out = ["+---+",
+               "|***|",
+               "|*8*|",
+               "|***|",
+               "+---+"]
+        self.assertEqual(board(inp), out)
+
+    def test_horizontal_line(self):
+        inp = ["+-----+",
+               "| * * |",
+               "+-----+"]
+        out = ["+-----+",
+               "|1*2*1|",
+               "+-----+"]
+        self.assertEqual(board(inp), out)
+
+    def test_horizontal_line_mines_at_edges(self):
+        inp = ["+-----+",
+               "|*   *|",
+               "+-----+"]
+        out = ["+-----+",
+               "|*1 1*|",
+               "+-----+"]
+        self.assertEqual(board(inp), out)
+
+    def test_vertical_line(self):
+        inp = ["+-+",
+               "| |",
+               "|*|",
+               "| |",
+               "|*|",
+               "| |",
+               "+-+"]
+        out = ["+-+",
+               "|1|",
+               "|*|",
+               "|2|",
+               "|*|",
+               "|1|",
+               "+-+"]
+        self.assertEqual(board(inp), out)
+
+    def test_vertical_line_mines_at_edges(self):
+        inp = ["+-+",
+               "|*|",
+               "| |",
+               "| |",
+               "| |",
+               "|*|",
+               "+-+"]
+        out = ["+-+",
+               "|*|",
+               "|1|",
+               "| |",
+               "|1|",
+               "|*|",
+               "+-+"]
+        self.assertEqual(board(inp), out)
+
+    def test_cross(self):
+        inp = ["+-----+",
+               "|  *  |",
+               "|  *  |",
+               "|*****|",
+               "|  *  |",
+               "|  *  |",
+               "+-----+"]
+        out = ["+-----+",
+               "| 2*2 |",
+               "|25*52|",
+               "|*****|",
+               "|25*52|",
+               "| 2*2 |",
+               "+-----+"]
+        self.assertEqual(board(inp), out)
+
+    def test_large_board(self):
         inp = ["+------+",
                "| *  * |",
                "|  *   |",
@@ -31,93 +163,7 @@ class MinesweeperTest(unittest.TestCase):
                "+------+"]
         self.assertEqual(board(inp), out)
 
-    def test_board2(self):
-        inp = ["+-----+",
-               "| * * |",
-               "|     |",
-               "|   * |",
-               "|  * *|",
-               "| * * |",
-               "+-----+"]
-        out = ["+-----+",
-               "|1*2*1|",
-               "|11322|",
-               "| 12*2|",
-               "|12*4*|",
-               "|1*3*2|",
-               "+-----+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board3(self):
-        inp = ["+-----+",
-               "| * * |",
-               "+-----+"]
-        out = ["+-----+",
-               "|1*2*1|",
-               "+-----+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board4(self):
-        inp = ["+-+",
-               "|*|",
-               "| |",
-               "|*|",
-               "| |",
-               "| |",
-               "+-+"]
-        out = ["+-+",
-               "|*|",
-               "|2|",
-               "|*|",
-               "|1|",
-               "| |",
-               "+-+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board5(self):
-        inp = ["+-+",
-               "|*|",
-               "+-+"]
-        out = ["+-+",
-               "|*|",
-               "+-+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board6(self):
-        inp = ["+--+",
-               "|**|",
-               "|**|",
-               "+--+"]
-        out = ["+--+",
-               "|**|",
-               "|**|",
-               "+--+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board7(self):
-        inp = ["+--+",
-               "|**|",
-               "|**|",
-               "+--+"]
-        out = ["+--+",
-               "|**|",
-               "|**|",
-               "+--+"]
-        self.assertEqual(board(inp), out)
-
-    def test_board8(self):
-        inp = ["+---+",
-               "|***|",
-               "|* *|",
-               "|***|",
-               "+---+"]
-        out = ["+---+",
-               "|***|",
-               "|*8*|",
-               "|***|",
-               "+---+"]
-        self.assertEqual(board(inp), out)
-
+    # Additional test for this track
     def test_board9(self):
         inp = ["+-----+",
                "|     |",


### PR DESCRIPTION
Add missing test version comment.
Add ordered tests with names matching canonical data descriptions.
Disable empty board tests which are incompatible with board class.
Move selected old tests to additional tests section. Closes #998