### PR TITLE
forth: Fix errors in tests

### DIFF
--- a/exercises/forth/example.py
+++ b/exercises/forth/example.py
@@ -11,6 +11,8 @@ def is_integer(string):
 
 
 def evaluate(input_data):
+    if not input_data:
+        return []
     defines = {}
     while input_data[0][:1] == ':':
         values = input_data.pop(0).split()

--- a/exercises/forth/example.py
+++ b/exercises/forth/example.py
@@ -12,7 +12,7 @@ def is_integer(string):
 
 def evaluate(input_data):
     defines = {}
-    while input_data[0][0] == ':':
+    while input_data[0][:1] == ':':
         values = input_data.pop(0).split()
         values.pop()
         values.pop(0)

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -8,6 +8,11 @@ from forth import evaluate, StackUnderflowError
 
 class ForthParsingTest(unittest.TestCase):
     def test_empty_input_empty_stack(self):
+        input_data = []
+        expected = []
+        self.assertEqual(evaluate(input_data), expected)
+
+    def test_empty_line_empty_stack(self):
         input_data = [""]
         expected = []
         self.assertEqual(evaluate(input_data), expected)

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -4,13 +4,25 @@ from forth import evaluate, StackUnderflowError
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
+# Tests for case-insensitivity are track-specific
+
+class ForthParsingTest(unittest.TestCase):
+    def test_empty_input_empty_stack(self):
+        input_data = [""]
+        expected = []
+        self.assertEqual(evaluate(input_data), expected)
+
+    def test_numbers_just_get_pushed_to_stack(self):
+        input_data = ["1 2 3 4 5"]
+        expected = [1, 2, 3, 4, 5]
+        self.assertEqual(evaluate(input_data), expected)
 
 
 class ForthAdditionTest(unittest.TestCase):
     def test_can_add_two_numbers(self):
         input_data = ["1 2 +"]
         expected = [3]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["+"]
@@ -27,7 +39,7 @@ class ForthSubtractionTest(unittest.TestCase):
     def test_can_subtract_two_numbers(self):
         input_data = ["3 4 -"]
         expected = [-1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["-"]
@@ -44,7 +56,7 @@ class ForthMultiplicationTest(unittest.TestCase):
     def test_can_multiply_two_numbers(self):
         input_data = ["2 4 *"]
         expected = [8]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["*"]
@@ -59,14 +71,14 @@ class ForthMultiplicationTest(unittest.TestCase):
 
 class ForthDivisionTest(unittest.TestCase):
     def test_can_divide_two_numbers(self):
-        input_data = ["3 4 -"]
-        expected = [-1]
-        self.assertEqual(expected, evaluate(input_data))
+        input_data = ["12 3 /"]
+        expected = [4]
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_performs_integer_division(self):
         input_data = ["8 3 /"]
         expected = [2]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_dividing_by_zero(self):
         input_data = ["4 0 /"]
@@ -88,24 +100,24 @@ class ForthCombinedArithmeticTest(unittest.TestCase):
     def test_addition_and_subtraction(self):
         input_data = ["1 2 + 4 -"]
         expected = [-1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_multiplication_and_division(self):
         input_data = ["2 4 * 3 /"]
         expected = [2]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
 
 class ForthDupTest(unittest.TestCase):
     def test_copies_the_top_value_on_the_stack(self):
         input_data = ["1 DUP"]
         expected = [1, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_is_case_insensitive(self):
         input_data = ["1 2 Dup"]
         expected = [1, 2, 2]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["dup"]
@@ -117,17 +129,17 @@ class ForthDropTest(unittest.TestCase):
     def test_removes_the_top_value_on_the_stack_if_it_is_the_only_one(self):
         input_data = ["1 DROP"]
         expected = []
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_removes_the_top_value_on_the_stack_if_it_not_the_only_one(self):
         input_data = ["3 4 DROP"]
         expected = [3]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_is_case_insensitive(self):
         input_data = ["1 2 Drop"]
         expected = [1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["drop"]
@@ -139,17 +151,17 @@ class ForthSwapTest(unittest.TestCase):
     def test_swaps_only_two_values_on_stack(self):
         input_data = ["1 2 SWAP"]
         expected = [2, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_swaps_two_two_values_on_stack(self):
         input_data = ["1 2 3 SWAP"]
         expected = [1, 3, 2]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_is_case_insensitive(self):
         input_data = ["3 4 Swap"]
         expected = [4, 3]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["swap"]
@@ -166,17 +178,17 @@ class ForthOverTest(unittest.TestCase):
     def test_copies_the_second_element_if_there_are_only_two(self):
         input_data = ["1 2 OVER"]
         expected = [1, 2, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_copies_the_second_element_if_there_are_more_than_two(self):
         input_data = ["1 2 3 OVER"]
         expected = [1, 2, 3, 2]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_is_case_insensitive(self):
         input_data = ["3 4 Over"]
         expected = [3, 4, 3]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
         input_data = ["over"]
@@ -196,7 +208,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "1 dup-twice"
         ]
         expected = [1, 1, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_execute_in_the_right_order(self):
         input_data = [
@@ -204,7 +216,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "countup"
         ]
         expected = [1, 2, 3]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_can_override_other_user_defined_words(self):
         input_data = [
@@ -213,7 +225,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "1 foo"
         ]
         expected = [1, 1, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_can_override_built_in_words(self):
         input_data = [
@@ -221,7 +233,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "1 swap"
         ]
         expected = [1, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_can_override_built_in_operators(self):
         input_data = [
@@ -229,7 +241,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "3 4 +"
         ]
         expected = [12]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_is_case_insensitive(self):
         input_data = [
@@ -237,7 +249,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
             "1 FOO"
         ]
         expected = [1, 1]
-        self.assertEqual(expected, evaluate(input_data))
+        self.assertEqual(evaluate(input_data), expected)
 
     def test_cannot_redefine_numbers(self):
         input_data = [": 1 2 ;"]


### PR DESCRIPTION
I noticed that there was an error in one of the tests, and that the simple parsing/stack tests from the `canonical-data` were not implemented. This PR fixes these issues, as well as applying the convention of `assertEqual(actual, expected)`.