### PR TITLE
rna-transcription: Use an exception to handle input errors

### DIFF
--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -18,7 +18,8 @@ each nucleotide with its complement:
 * `T` -> `A`
 * `A` -> `U`
 
-Your function will need to be able to handle invalid inputs, both partial (a few invalid bases) and completely invalid strings. In these cases it should return an empty string.
+Your function will need to be able to handle invalid inputs by raising a
+`ValueError` with a meaningful message.
 
 ## Submitting Exercises
 

--- a/exercises/rna-transcription/example.py
+++ b/exercises/rna-transcription/example.py
@@ -13,6 +13,6 @@ DNA_TO_RNA = maketrans(DNA_CHARS, 'UCGA')
 def to_rna(dna_strand):
     valid_chars = set(DNA_CHARS)
     if any(char not in valid_chars for char in dna_strand):
-        return ''
+        raise ValueError("Input DNA strand contains invalid bases")
 
     return dna_strand.translate(DNA_TO_RNA)

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -20,16 +20,19 @@ class DNATests(unittest.TestCase):
         self.assertEqual(to_rna('A'), 'U')
 
     def test_transcribes_all_occurences(self):
-        self.assertMultiLineEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
+        self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
 
     def test_correctly_handles_single_invalid_input(self):
-        self.assertEqual(to_rna('U'), '')
+        with self.assertRaises(ValueError):
+            to_rna('U')
 
     def test_correctly_handles_completely_invalid_input(self):
-        self.assertMultiLineEqual(to_rna('XXX'), '')
+        with self.assertRaises(ValueError):
+            to_rna('XXX')
 
     def test_correctly_handles_partially_invalid_input(self):
-        self.assertMultiLineEqual(to_rna('ACGTXXXCTTAA'), '')
+        with self.assertRaises(ValueError):
+            to_rna('ACGTXXXCTTAA')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based on discussion at exercism/problem-specifications#956, this PR changes the `rna-transcription` exercise to raise a `ValueError` instead of returning an empty string.