### PR TITLE
queen-attack: Update tests to match canonical data v2.0.0

### DIFF
--- a/exercises/queen-attack/queen_attack_test.py
+++ b/exercises/queen-attack/queen_attack_test.py
@@ -3,7 +3,69 @@ import unittest
 from queen_attack import board, can_attack
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
+
 class QueenAttackTest(unittest.TestCase):
+
+    def test_queen_valid_position(self):
+        try:
+            board((1, 1), (2, 2))
+        except ValueError:
+            self.fail("Unexpected Exception")
+
+    def test_queen_negative_row(self):
+        with self.assertRaises(ValueError):
+            board((1, 1), (-2, 2))
+
+    def test_queen_invalid_row(self):
+        with self.assertRaises(ValueError):
+            board((1, 1), (8, 4))
+
+    def test_queen_negative_column(self):
+        with self.assertRaises(ValueError):
+            board((1, 1), (2, -2))
+
+    def test_queen_invalid_column(self):
+        with self.assertRaises(ValueError):
+            board((1, 1), (4, 8))
+
+    def test_attack_false(self):
+        self.assertIs(can_attack((2, 4), (6, 6)), False)
+
+    def test_attack_same_row(self):
+        self.assertIs(can_attack((2, 4), (2, 6)), True)
+
+    def test_attack_same_column(self):
+        self.assertIs(can_attack((4, 5), (2, 5)), True)
+
+    def test_attack_diagonal1(self):
+        self.assertIs(can_attack((2, 2), (0, 4)), True)
+
+    def test_attack_diagonal2(self):
+        self.assertIs(can_attack((2, 2), (3, 1)), True)
+
+    def test_attack_diagonal3(self):
+        self.assertIs(can_attack((2, 2), (1, 1)), True)
+
+    def test_attack_diagonal4(self):
+        self.assertIs(can_attack((2, 2), (5, 5)), True)
+
+    # Tests beyond this point are not part of the canonical data.
+
+    # If either board or can_attack are called with an invalid board position
+    # they should raise a ValueError with a meaningful error message.
+    def test_invalid_position_can_attack(self):
+        with self.assertRaises(ValueError):
+            can_attack((0, 0), (7, 8))
+
+    def test_queens_same_position_board(self):
+        with self.assertRaises(ValueError):
+            board((2, 2), (2, 2))
+
+    def test_queens_same_position_can_attack(self):
+        with self.assertRaises(ValueError):
+            can_attack((2, 2), (2, 2))
+
     def test_board1(self):
         ans = ['________',
                '________',
@@ -25,48 +87,6 @@ class QueenAttackTest(unittest.TestCase):
                '________',
                '________']
         self.assertEqual(board((0, 6), (1, 7)), ans)
-
-    def test_attack_true1(self):
-        self.assertIs(can_attack((2, 3), (5, 6)), True)
-
-    def test_attack_true2(self):
-        self.assertIs(can_attack((2, 6), (5, 3)), True)
-
-    def test_attack_true3(self):
-        self.assertIs(can_attack((2, 4), (2, 7)), True)
-
-    def test_attack_true4(self):
-        self.assertIs(can_attack((5, 4), (2, 4)), True)
-
-    def test_attack_true5(self):
-        self.assertIs(can_attack((1, 1), (6, 6)), True)
-
-    def test_attack_true6(self):
-        self.assertIs(can_attack((0, 6), (1, 7)), True)
-
-    def test_attack_false1(self):
-        self.assertIs(can_attack((4, 2), (0, 5)), False)
-
-    def test_attack_false2(self):
-        self.assertIs(can_attack((2, 3), (4, 7)), False)
-
-    # If either board or can_attack are called with an invalid board position
-    # they should raise a ValueError with a meaningful error message.
-    def test_invalid_position_board(self):
-        with self.assertRaises(ValueError):
-            board((0, 0), (7, 8))
-
-    def test_invalid_position_can_attack(self):
-        with self.assertRaises(ValueError):
-            can_attack((0, 0), (7, 8))
-
-    def test_queens_same_position_board(self):
-        with self.assertRaises(ValueError):
-            board((2, 2), (2, 2))
-
-    def test_queens_same_position_can_attack(self):
-        with self.assertRaises(ValueError):
-            can_attack((2, 2), (2, 2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #1003 

Updated tests to match canonical data.

I moved some extra existing tests cases not covered by the tests in canonical data to the bottom.
The extra exception tests seem useful.