### PR TITLE
alphametics: improve test ordering

### DIFF
--- a/exercises/alphametics/alphametics_test.py
+++ b/exercises/alphametics/alphametics_test.py
@@ -6,7 +6,7 @@ from alphametics import solve
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
 class TestAlphametics(unittest.TestCase):
-    def test_puzzle_with_three_letters(self):
+    def test_puzzle_with_03_letters(self):
         self.assertEqual(solve("I + BB == ILL"), {"I": 1, "B": 9, "L": 0})
 
     def test_invalid_solution_must_have_unique_value_for_each_letter(self):
@@ -15,11 +15,11 @@ class TestAlphametics(unittest.TestCase):
     def test_invalid_leading_zero_solution(self):
         self.assertEqual(solve("ACA + DD == BD"), {})
 
-    def test_puzzle_with_four_letters(self):
+    def test_puzzle_with_04_letters(self):
         self.assertEqual(
             solve("AS + A == MOM"), {"A": 9, "S": 2, "M": 1, "O": 0})
 
-    def test_puzzle_with_six_letters(self):
+    def test_puzzle_with_06_letters(self):
         self.assertEqual(
             solve("NO + NO + TOO == LATE"),
             {"N": 7,
@@ -29,7 +29,7 @@ class TestAlphametics(unittest.TestCase):
              "A": 0,
              "E": 2})
 
-    def test_puzzle_with_seven_letters(self):
+    def test_puzzle_with_07_letters(self):
         self.assertEqual(
             solve("HE + SEES + THE == LIGHT"),
             {"E": 4,
@@ -40,7 +40,7 @@ class TestAlphametics(unittest.TestCase):
              "S": 9,
              "T": 7})
 
-    def test_puzzle_with_eight_letters(self):
+    def test_puzzle_with_08_letters(self):
         self.assertEqual(
             solve("SEND + MORE == MONEY"),
             {"S": 9,
@@ -52,7 +52,7 @@ class TestAlphametics(unittest.TestCase):
              "R": 8,
              "Y": 2})
 
-    def test_puzzle_with_ten_letters(self):
+    def test_puzzle_with_10_letters(self):
         self.assertEqual(
             solve("AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"),
             {"A": 5,


### PR DESCRIPTION
Resolves #531 

Before:
```Bash
$ pytest -v
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- c:\python36\python.exe
cachedir: .cache
rootdir: C:\Git\python\exercises\alphametics, inifile:
collected 8 items

alphametics_test.py::TestAlphametics::test_invalid_leading_zero_solution PASSED
alphametics_test.py::TestAlphametics::test_invalid_solution_must_have_unique_value_for_each_letter PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_eight_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_four_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_seven_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_six_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_ten_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_three_letters PASSED

========================== 8 passed in 2.36 seconds ===========================
```

After:
```Bash
$ pytest -v
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- c:\python36\python.exe
cachedir: .cache
rootdir: C:\Git\python\exercises\alphametics, inifile:
collected 8 items

alphametics_test.py::TestAlphametics::test_invalid_leading_zero_solution PASSED
alphametics_test.py::TestAlphametics::test_invalid_solution_must_have_unique_value_for_each_letter PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_03_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_04_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_06_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_07_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_08_letters PASSED
alphametics_test.py::TestAlphametics::test_puzzle_with_10_letters PASSED

========================== 8 passed in 2.53 seconds ===========================
```