### PR TITLE
Make probot/stale more useful

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,8 @@ exemptLabels:
   - discussion
   - pinned
   - epic
+  - enhancement
+  - beginner friendly
 # Label to use when marking an issue as stale
 staleLabel: abandoned
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,16 +1,17 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 21
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - discussion
   - pinned
+  - epic
 # Label to use when marking an issue as stale
-staleLabel: on hiatus
+staleLabel: abandoned
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as `on hiatus` because it has not had
+  This issue has been automatically marked as `abandoned` because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable


### PR DESCRIPTION
Propose the following changes:
- `daysUntilStale: 60 -> 21`: With 5 track maintainers (3+ active), issues are being manually closed after ~20 days frequently. 60 days is too long.
- Add `epic` to `exemptLabels`: `epic` denotes issues that are usually super-issues, and closing every sub-issue takes a lot of effort and time.
- `staleLabel: on hiatus -> abandoned`: `abandoned` is typically used by the maintainers here, so change for consistency