### PR TITLE
Ignore pytest cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/configlet
 bin/configlet.exe
 .idea/
 .cache
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 bin/configlet
 bin/configlet.exe
 .idea/
+.cache


### PR DESCRIPTION
If people use `pytest-cache` when working on exercises, it creates a `.cache` directory that is currently not ignored - I've experienced this myself, and I just saw a PR with this issue.

This PR updates `.gitignore` to ignore the cache directories of `py-test` and Python modules (`.cache` and `__pycache__`, respectively).