### PR TITLE
check-exercises.py: Enforce strict module naming

### DIFF
--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -2,8 +2,6 @@
 from __future__ import print_function
 
 import os
-import ast
-import imp
 import glob
 import shutil
 import subprocess
@@ -22,7 +20,7 @@ def python_executable_name():
 def check_assignment(name, test_file):
     # Returns the exit code of the tests
     workdir = tempfile.mkdtemp(name)
-    example_name = modname_heuristic(test_file)
+    example_name = name.replace("-", "_")
     try:
         test_file_out = os.path.join(workdir, os.path.basename(test_file))
         if name in ALLOW_SKIP:
@@ -38,33 +36,6 @@ def check_assignment(name, test_file):
         return subprocess.call([python_executable_name(), test_file_out])
     finally:
         shutil.rmtree(workdir)
-
-
-def modname_heuristic(test_file):
-    with open(test_file) as f:
-        tree = ast.parse(f.read(), filename=test_file)
-    # return the first nonexistent module that the tests import
-    for node in ast.walk(tree):
-        for modname in possible_module_names(node):
-            if is_module_missing(modname):
-                return modname
-
-
-def possible_module_names(node):
-    if isinstance(node, ast.Import):
-        for alias in node.names:
-            yield alias.name
-    elif isinstance(node, ast.ImportFrom):
-        yield node.module
-
-
-def is_module_missing(modname):
-    try:
-        imp.find_module(modname)
-    except ImportError:
-        return True
-    else:
-        return False
 
 
 def load_config():


### PR DESCRIPTION
This PR simplifies the `check-exercises.py` script by enforcing strict module naming.

The previous version used a heuristic to determine the correct name for the example to be renamed to for the tests to run. This meant that:
* The test-suite could import an arbitrary module name as long as it didn't exist.
* If the script was run locally, it would fail to determine the module name if the name clashed with an installed module (eg. `markdown`).
* Incorrect module names were accepted by Travis-CI checks, and thus could be displayed to learners and prevent their tests from passing.

~~DO NOT MERGE THIS!!!~~
~~This PR is designed to test Travis-CI for a possible issue I noticed due to #1104.~~