### PR TITLE
binary-search-tree: replace invalid uuid

### DIFF
--- a/config.json
+++ b/config.json
@@ -1187,7 +1187,7 @@
       ]
     },
     {
-      "uuid": "6f196341-0ffc-9780-a7ca-1f817508247161cbcd9",
+      "uuid": "df7cd9b9-283a-4466-accf-98c4a7609450",
       "slug": "binary-search-tree",
       "core": false,
       "unlocked_by": null,


### PR DESCRIPTION
Re #1096, valid uuid is X(8)-X(4)-X(4)-X(4)-X(12) where X is [\da-f]. This exercise must've been merged after #1096 or was simply missed.