### PR TITLE
proverb: Update exercise to canonical-data 1.0.0

### DIFF
--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -2,7 +2,7 @@
 
 For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
 
-Output the full text of this proverbial rhyme:
+Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
 
 ```text
 For want of a nail the shoe was lost.
@@ -11,8 +11,11 @@ For want of a horse the rider was lost.
 For want of a rider the message was lost.
 For want of a message the battle was lost.
 For want of a battle the kingdom was lost.
-And all for the want of a horseshoe nail.
+And all for the want of a nail.
 ```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.
+
 ## Submitting Exercises
 
 Note that, when trying to submit an exercise, make sure the solution is in the `exercism/python/<exerciseName>` directory.

--- a/exercises/proverb/example.py
+++ b/exercises/proverb/example.py
@@ -1,7 +1,7 @@
-def proverb(itens, qualifier=''):
+def proverb(rhyme_items):
+    if not rhyme_items:
+        return ""
     phrases = ['For want of a {0} the {1} was lost.'.format(el1, el2)
-               for el1, el2 in zip(itens, itens[1:])]
-    qualifier += ' ' if qualifier else ''
-    phrases.append('And all for the want of a {0}{1}.'.format(qualifier,
-                   itens[0]))
+               for el1, el2 in zip(rhyme_items, rhyme_items[1:])]
+    phrases.append('And all for the want of a {0}.'.format(rhyme_items[0]))
     return '\n'.join(phrases)

--- a/exercises/proverb/proverb.py
+++ b/exercises/proverb/proverb.py
@@ -1,2 +1,2 @@
-def proverb(rhyme_text):
+def proverb(rhyme_items):
     pass

--- a/exercises/proverb/proverb_test.py
+++ b/exercises/proverb/proverb_test.py
@@ -3,59 +3,49 @@ import unittest
 from proverb import proverb
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class ProverbTest(unittest.TestCase):
-    def test_a_single_consequence(self):
-        expected = 'For want of a nail the shoe was lost.\n'\
-                   'And all for the want of a nail.'
-        self.assertEqual(proverb(['nail', 'shoe']), expected)
+    def test_zero_pieces(self):
+        self.assertEqual(proverb([]), "")
 
-    def test_short_list(self):
-        expected = 'For want of a nail the shoe was lost.\n'\
-                   'For want of a shoe the horse was lost.\n'\
-                   'And all for the want of a nail.'
-        self.assertEqual(proverb(['nail', 'shoe', 'horse']), expected)
+    def test_one_piece(self):
+        inputs = ["nail"]
+        expected = "And all for the want of a nail."
+        self.assertEqual(proverb(inputs), expected)
 
-    def test_long_list(self):
-        expected = 'For want of a nail the shoe was lost.\n'\
-                   'For want of a shoe the horse was lost.\n'\
-                   'For want of a horse the rider was lost.\n'\
-                   'And all for the want of a nail.'
-        self.assertEqual(proverb(['nail', 'shoe', 'horse', 'rider']), expected)
+    def test_two_pieces(self):
+        inputs = ["nail", "shoe"]
+        expected = "\n".join(["For want of a nail the shoe was lost.",
+                              "And all for the want of a nail."])
+        self.assertEqual(proverb(inputs), expected)
 
-    def test_new_itens(self):
-        expected = 'For want of a key the value was lost.\n'\
-                   'And all for the want of a key.'
-        self.assertEqual(proverb(['key', 'value']), expected)
+    def test_three_pieces(self):
+        inputs = ["nail", "shoe", "horse"]
+        expected = "\n".join(["For want of a nail the shoe was lost.",
+                              "For want of a shoe the horse was lost.",
+                              "And all for the want of a nail."])
+        self.assertEqual(proverb(inputs), expected)
 
-    def test_whole_proverb(self):
-        expected = 'For want of a nail the shoe was lost.\n'\
-                   'For want of a shoe the horse was lost.\n'\
-                   'For want of a horse the rider was lost.\n'\
-                   'For want of a rider the message was lost.\n'\
-                   'For want of a message the battle was lost.\n'\
-                   'For want of a battle the kingdom was lost.\n'\
-                   'And all for the want of a nail.'
-        self.assertEqual(
-            proverb([
-                'nail', 'shoe', 'horse', 'rider', 'message', 'battle',
-                'kingdom'
-            ]), expected)
+    def test_full_proverb(self):
+        inputs = ["nail", "shoe", "horse", "rider",
+                  "message", "battle", "kingdom"]
+        expected = "\n".join(["For want of a nail the shoe was lost.",
+                              "For want of a shoe the horse was lost.",
+                              "For want of a horse the rider was lost.",
+                              "For want of a rider the message was lost.",
+                              "For want of a message the battle was lost.",
+                              "For want of a battle the kingdom was lost.",
+                              "And all for the want of a nail."])
+        self.assertEqual(proverb(inputs), expected)
 
-    def test_qualifier(self):
-        expected = 'For want of a nail the shoe was lost.\n'\
-                   'For want of a shoe the horse was lost.\n'\
-                   'For want of a horse the rider was lost.\n'\
-                   'For want of a rider the message was lost.\n'\
-                   'For want of a message the battle was lost.\n'\
-                   'For want of a battle the kingdom was lost.\n'\
-                   'And all for the want of a horseshoe nail.'
-        self.assertEqual(
-            proverb(
-                [
-                    'nail', 'shoe', 'horse', 'rider', 'message', 'battle',
-                    'kingdom'
-                ],
-                qualifier='horseshoe'), expected)
+    def test_four_pieces_modernised(self):
+        inputs = ["pin", "gun", "soldier", "battle"]
+        expected = "\n".join(["For want of a pin the gun was lost.",
+                              "For want of a gun the soldier was lost.",
+                              "For want of a soldier the battle was lost.",
+                              "And all for the want of a pin."])
+        self.assertEqual(proverb(inputs), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates the `proverb` exercise to use the recently implemented canonical data.

**Note:** there will be a merge conflict with #1113 due to changes in the README, but I will fix this when one of these PRs is merged.