### PR TITLE
say: change to more appropriate exception type

### DIFF
--- a/exercises/say/example.py
+++ b/exercises/say/example.py
@@ -10,9 +10,9 @@ def say(number, recursive=False):
     k, m, b, t = 1e3, 1e6, 1e9, 1e12
 
     if number < 0:
-        raise AttributeError('number is negative')
+        raise ValueError('number is negative')
     if number >= t:
-        raise AttributeError('number is too large: %s' % str(number))
+        raise ValueError('number is too large: %s' % str(number))
 
     if number < 20:
         return small[number] if not recursive else 'and ' + small[number]

--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -64,11 +64,11 @@ class SayTest(unittest.TestCase):
                                 "one hundred and twenty-three"))
 
     def test_number_to_large(self):
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             say(1e12)
 
     def test_number_negative(self):
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             say(-1)
 
 


### PR DESCRIPTION
From the [Python documentation](https://docs.python.org/2/library/exceptions.html#exceptions.AttributeError), `AttributeError` is "raised when an attribute reference or assignment fails." This situation is more appropriate for [`ValueError`](https://docs.python.org/2/library/exceptions.html#exceptions.ValueError): "Raised when a built-in operation or function receives an argument that has the right type but an inappropriate value..."