### PR TITLE
series: Update exercise to canonical-data v1.0.0

### DIFF
--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,18 +1,18 @@
 # Series
 
 Given a string of digits, output all the contiguous substrings of length `n` in
-that string.
+that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
-- 491
-- 914
-- 142
+- "491"
+- "914"
+- "142"
 
 And the following 4-digit series:
 
-- 4914
-- 9142
+- "4914"
+- "9142"
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve
 whatever you get.

--- a/exercises/series/example.py
+++ b/exercises/series/example.py
@@ -1,6 +1,4 @@
 def slices(series, length):
-    numbers = [int(digit) for digit in series]
-    if not 1 <= length <= len(numbers):
-        raise ValueError("Invalid slice length for this series: " + str(
-            length))
-    return [numbers[i:i + length] for i in range(len(numbers) - length + 1)]
+    if not 1 <= length <= len(series):
+        raise ValueError("Invalid slice length: {}" + str(length))
+    return [series[i:i + length] for i in range(len(series) - length + 1)]

--- a/exercises/series/series_test.py
+++ b/exercises/series/series_test.py
@@ -9,36 +9,54 @@ import unittest
 from series import slices
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class SeriesTest(unittest.TestCase):
     def test_slices_of_one(self):
         self.assertEqual(
             slices("01234", 1),
-            [[0], [1], [2], [3], [4]], )
+            ["0", "1", "2", "3", "4"]
+        )
 
     def test_slices_of_two(self):
         self.assertEqual(
-            slices("97867564", 2),
-            [[9, 7], [7, 8], [8, 6], [6, 7], [7, 5], [5, 6], [6, 4]], )
+            slices("01234", 2),
+            ["01", "12", "23", "34"]
+        )
 
     def test_slices_of_three(self):
         self.assertEqual(
-            slices("97867564", 3),
-            [[9, 7, 8], [7, 8, 6], [8, 6, 7], [6, 7, 5], [7, 5, 6], [5, 6, 4]],
+            slices("01234", 3),
+            ["012", "123", "234"]
         )
-
-    def test_slices_of_four(self):
-        self.assertEqual(
-            slices("01234", 4),
-            [[0, 1, 2, 3], [1, 2, 3, 4]], )
 
     def test_slices_of_five(self):
         self.assertEqual(
             slices("01234", 5),
-            [[0, 1, 2, 3, 4]], )
+            ["01234"]
+        )
+
+    def test_order_preserved_with_descending_numbers(self):
+        self.assertEqual(
+            slices("43210", 3),
+            ["432", "321", "210"]
+        )
+
+    def test_order_preserved_with_random_numbers(self):
+        self.assertEqual(
+            slices("83627", 3),
+            ["836", "362", "627"]
+        )
+
+    def test_slices_can_include_duplicates(self):
+        self.assertEqual(
+            slices("123123", 3),
+            ["123", "231", "312", "123"]
+        )
 
     def test_overly_long_slice(self):
         with self.assertRaises(ValueError):
-            slices("012", 4)
+            slices("01234", 6)
 
     def test_overly_short_slice(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
**Note:** This PR is dependent on exercism/problem-specifications#1020 and should only be merged after that PR is finalised and merged.

Resolves #1109 by clarifying the description and reworking the example and tests to expect a list of strings.