### PR TITLE
Migrate string formatting operations to `str.format`

### DIFF
--- a/exercises/beer-song/example.py
+++ b/exercises/beer-song/example.py
@@ -8,8 +8,8 @@ def song(first, last=0):
 
 def verse(number):
     return ''.join([
-        "%s of beer on the wall, " % _bottles(number).capitalize(),
-        "%s of beer.\n" % _bottles(number),
+        "{} of beer on the wall, ".format(_bottles(number).capitalize()),
+        "{} of beer.\n".format(_bottles(number)),
         _action(number),
         _next_bottle(number),
     ])
@@ -19,13 +19,15 @@ def _action(current_verse):
     if current_verse == 0:
         return "Go to the store and buy some more, "
     else:
-        return "Take %s down and pass it around, " % (
-            "one" if current_verse > 1 else "it"
+        return "Take {} down and pass it around, ".format(
+            "one" if current_verse > 1 else "it",
         )
 
 
 def _next_bottle(current_verse):
-    return "%s of beer on the wall.\n" % _bottles(_next_verse(current_verse))
+    return "{} of beer on the wall.\n".format(
+        _bottles(_next_verse(current_verse)),
+    )
 
 
 def _bottles(number):
@@ -34,7 +36,7 @@ def _bottles(number):
     if number == 1:
         return '1 bottle'
     else:
-        return '%d bottles' % number
+        return '{} bottles'.format(number)
 
 
 def _next_verse(current_verse):

--- a/exercises/clock/example.py
+++ b/exercises/clock/example.py
@@ -8,7 +8,7 @@ class Clock(object):
         self.cleanup()
 
     def __repr__(self):
-        return "%02d:%02d" % (self.hour, self.minute)
+        return "{:02d}:{:02d}".format(self.hour, self.minute)
 
     def __eq__(self, other):
         return repr(self) == repr(other)

--- a/exercises/nucleotide-count/example.py
+++ b/exercises/nucleotide-count/example.py
@@ -15,4 +15,4 @@ def nucleotide_counts(strand):
 
 def _validate(abbreviation):
     if abbreviation not in NUCLEOTIDES:
-        raise ValueError('%s is not a nucleotide.' % abbreviation)
+        raise ValueError('{} is not a nucleotide.'.format(abbreviation))

--- a/exercises/phone-number/example.py
+++ b/exercises/phone-number/example.py
@@ -9,15 +9,15 @@ class Phone(object):
         self.subscriber_number = self.number[-4:]
 
     def pretty(self):
-        return "(%s) %s-%s" % (
+        return "({}) {}-{}".format(
             self.area_code,
             self.exchange_code,
-            self.subscriber_number
+            self.subscriber_number,
         )
 
     def _clean(self, number):
         return self._normalize(
-            re.sub(r'[^\d]', '', number)
+            re.sub(r'[^\d]', '', number),
         )
 
     def _normalize(self, number):

--- a/exercises/protein-translation/example.py
+++ b/exercises/protein-translation/example.py
@@ -8,7 +8,7 @@ CODONS = {'AUG': "Methionine", 'UUU': "Phenylalanine",
 
 def of_codon(codon):
     if codon not in CODONS:
-        raise ValueError('Invalid codon: %s' % codon)
+        raise ValueError('Invalid codon: {}'.format(codon))
     return CODONS[codon]
 
 

--- a/exercises/say/example.py
+++ b/exercises/say/example.py
@@ -12,7 +12,7 @@ def say(number, recursive=False):
     if number < 0:
         raise ValueError('number is negative')
     if number >= t:
-        raise ValueError('number is too large: %s' % str(number))
+        raise ValueError('number is too large: {}'.format(number))
 
     if number < 20:
         return small[number] if not recursive else 'and ' + small[number]

--- a/exercises/two-fer/example.py
+++ b/exercises/two-fer/example.py
@@ -2,4 +2,4 @@ def two_fer(name=""):
     if not name.strip():
         return "One for you, one for me."
     else:
-        return "One for %s, one for me." % name
+        return "One for {}, one for me.".format(name)


### PR DESCRIPTION
I noticed that some of the exercises were still using the old style string formatting (eg.`"%s" % value`) rather than using the newer `str.format` method - this PR moves everything to the newer style.