### PR TITLE
word-search: adapt testdata-format from canonical-testdata-format

### DIFF
--- a/exercises/word-search/example.py
+++ b/exercises/word-search/example.py
@@ -28,7 +28,7 @@ DIRECTIONS = (Point(1, 0), Point(1, -1), Point(1, 1), Point(-1, -1),
 
 class WordSearch(object):
     def __init__(self, puzzle):
-        self.rows = puzzle.split()
+        self.rows = puzzle
         self.width = len(self.rows[0])
         self.height = len(self.rows)
 

--- a/exercises/word-search/word_search_test.py
+++ b/exercises/word-search/word_search_test.py
@@ -8,119 +8,119 @@ from word_search import WordSearch, Point
 class WordSearchTests(unittest.TestCase):
 
     def test_initial_game_grid(self):
-        puzzle = 'jefblpepre'
+        puzzle = ['jefblpepre']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertIsNone(searchAnswer)
 
     def test_left_to_right_word(self):
-        puzzle = 'clojurermt'
+        puzzle = ['clojurermt']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(0, 0), Point(6, 0)))
 
     def test_left_to_right_word_different_position(self):
-        puzzle = 'mtclojurer'
+        puzzle = ['mtclojurer']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(2, 0), Point(8, 0)))
 
     def test_different_left_to_right_word(self):
-        puzzle = 'coffeelplx'
+        puzzle = ['coffeelplx']
         searchAnswer = WordSearch(puzzle).search('coffee')
         self.assertEqual(searchAnswer, (Point(0, 0), Point(5, 0)))
 
     def test_different_left_to_right_word_different_position(self):
-        puzzle = 'xcoffeezlp'
+        puzzle = ['xcoffeezlp']
         searchAnswer = WordSearch(puzzle).search('coffee')
         self.assertEqual(searchAnswer, (Point(1, 0), Point(6, 0)))
 
     def test_left_to_right_word_two_lines(self):
-        puzzle = ('jefblpepre\n'
-                  'tclojurerm\n')
+        puzzle = ['jefblpepre',
+                  'tclojurerm']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(1, 1), Point(7, 1)))
 
     def test_left_to_right_word_three_lines(self):
-        puzzle = ('camdcimgtc\n'
-                  'jefblpepre\n'
-                  'clojurermt\n')
+        puzzle = ['camdcimgtc',
+                  'jefblpepre',
+                  'clojurermt']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(0, 2), Point(6, 2)))
 
     def test_left_to_right_word_ten_lines(self):
-        puzzle = ('jefblpepre\n'
-                  'camdcimgtc\n'
-                  'oivokprjsm\n'
-                  'pbwasqroua\n'
-                  'rixilelhrs\n'
-                  'wolcqlirpc\n'
-                  'screeaumgr\n'
-                  'alxhpburyi\n'
-                  'jalaycalmp\n'
-                  'clojurermt\n')
+        puzzle = ['jefblpepre',
+                  'camdcimgtc',
+                  'oivokprjsm',
+                  'pbwasqroua',
+                  'rixilelhrs',
+                  'wolcqlirpc',
+                  'screeaumgr',
+                  'alxhpburyi',
+                  'jalaycalmp',
+                  'clojurermt']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(0, 9), Point(6, 9)))
 
     def test_left_to_right_word_ten_lines_different_position(self):
-        puzzle = ('jefblpepre\n'
-                  'camdcimgtc\n'
-                  'oivokprjsm\n'
-                  'pbwasqroua\n'
-                  'rixilelhrs\n'
-                  'wolcqlirpc\n'
-                  'screeaumgr\n'
-                  'alxhpburyi\n'
-                  'clojurermt\n'
-                  'jalaycalmp\n')
+        puzzle = ['jefblpepre',
+                  'camdcimgtc',
+                  'oivokprjsm',
+                  'pbwasqroua',
+                  'rixilelhrs',
+                  'wolcqlirpc',
+                  'screeaumgr',
+                  'alxhpburyi',
+                  'clojurermt',
+                  'jalaycalmp']
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(0, 8), Point(6, 8)))
 
     def test_different_left_to_right_word_ten_lines(self):
-        puzzle = ('jefblpepre\n'
-                  'camdcimgtc\n'
-                  'oivokprjsm\n'
-                  'pbwasqroua\n'
-                  'rixilelhrs\n'
-                  'wolcqlirpc\n'
-                  'fortranftw\n'
-                  'alxhpburyi\n'
-                  'clojurermt\n'
-                  'jalaycalmp\n')
+        puzzle = ['jefblpepre',
+                  'camdcimgtc',
+                  'oivokprjsm',
+                  'pbwasqroua',
+                  'rixilelhrs',
+                  'wolcqlirpc',
+                  'fortranftw',
+                  'alxhpburyi',
+                  'clojurermt',
+                  'jalaycalmp']
         searchAnswer = WordSearch(puzzle).search('fortran')
         self.assertEqual(searchAnswer, (Point(0, 6), Point(6, 6)))
 
     def test_multiple_words(self):
-        puzzle = ('jefblpepre\n'
-                  'camdcimgtc\n'
-                  'oivokprjsm\n'
-                  'pbwasqroua\n'
-                  'rixilelhrs\n'
-                  'wolcqlirpc\n'
-                  'fortranftw\n'
-                  'alxhpburyi\n'
-                  'jalaycalmp\n'
-                  'clojurermt\n')
+        puzzle = ['jefblpepre',
+                  'camdcimgtc',
+                  'oivokprjsm',
+                  'pbwasqroua',
+                  'rixilelhrs',
+                  'wolcqlirpc',
+                  'fortranftw',
+                  'alxhpburyi',
+                  'jalaycalmp',
+                  'clojurermt']
         searchAnswer = WordSearch(puzzle).search('fortran')
         self.assertEqual(searchAnswer, (Point(0, 6), Point(6, 6)))
         searchAnswer = WordSearch(puzzle).search('clojure')
         self.assertEqual(searchAnswer, (Point(0, 9), Point(6, 9)))
 
     def test_single_word_right_to_left(self):
-        puzzle = 'rixilelhrs'
+        puzzle = ['rixilelhrs']
         searchAnswer = WordSearch(puzzle).search('elixir')
         self.assertEqual(searchAnswer, (Point(5, 0), Point(0, 0)))
 
     @classmethod
-    def setUpClass(self):
-        puzzle = ('jefblpepre\n'
-                  'camdcimgtc\n'
-                  'oivokprjsm\n'
-                  'pbwasqroua\n'
-                  'rixilelhrs\n'
-                  'wolcqlirpc\n'
-                  'screeaumgr\n'
-                  'alxhpburyi\n'
-                  'jalaycalmp\n'
-                  'clojurermt')
-        self.example = WordSearch(puzzle)
+    def setUpClass(cls):
+        puzzle = ['jefblpepre',
+                  'camdcimgtc',
+                  'oivokprjsm',
+                  'pbwasqroua',
+                  'rixilelhrs',
+                  'wolcqlirpc',
+                  'screeaumgr',
+                  'alxhpburyi',
+                  'jalaycalmp',
+                  'clojurermt']
+        cls.example = WordSearch(puzzle)
 
     def test_horizontal_words_different_directions(self):
         self.assertEqual(


### PR DESCRIPTION
I felt the "\n" are superfluous and therefore removed them (I've made this suggestion before in another Issue/PR).
Also this proposed format (with a list of strings) matches the format from [canonical-data of problem-specifications  ](https://github.com/exercism/problem-specifications/blob/master/exercises/word-search/canonical-data.json)
@N-Parsons and @behrtam could you review this please?
