### PR TITLE
Rename test cases in reverse_string_test.py so that they will run

### DIFF
--- a/exercises/reverse-string/reverse_string_test.py
+++ b/exercises/reverse-string/reverse_string_test.py
@@ -6,19 +6,19 @@ from reverse_string import reverse
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
 
 class ReverseStringTests(unittest.TestCase):
-    def empty_string(self):
+    def test_empty_string(self):
             self.assertEqual(reverse(''), '')
 
-    def a_word(self):
+    def test_a_word(self):
             self.assertEqual(reverse('robot'), 'tobor')
 
-    def a_capitalized_word(self):
+    def test_a_capitalized_word(self):
             self.assertEqual(reverse('Ramen'), 'nemaR')
 
-    def a_sentence_with_punctuation(self):
+    def test_a_sentence_with_punctuation(self):
             self.assertEqual(reverse('I\'m hungry!'), '!yrgnuh m\'I')
 
-    def a_palindrome(self):
+    def test_a_palindrome(self):
             self.assertEqual(reverse('racecar'), 'racecar')
 
 


### PR DESCRIPTION
Hi,
I fixed the naming of the test cases in reverse_string_test.py by adding the prefix `test_` in front of their names.  I noticed that they were not running and I made the small adjustments.

Thanks and regards,

J F