### PR TITLE
Fixed class name

### DIFF
--- a/exercises/reverse-string/reverse_string_test.py
+++ b/exercises/reverse-string/reverse_string_test.py
@@ -5,7 +5,7 @@ from reverse_string import reverse
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
 
-class ReverseStringTests(unittest.TestCase):
+class ReverseStringTest(unittest.TestCase):
     def test_empty_string(self):
             self.assertEqual(reverse(''), '')
 


### PR DESCRIPTION
No tests would run because the class name was `ReverseStringTests` instead of `ReverseStringTest`, which matches the filename.