### PR TITLE
phone-number: rename 2 tests

### DIFF
--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -46,11 +46,11 @@ class PhoneTest(unittest.TestCase):
         with self.assertRaisesWithMessage(ValueError):
             Phone("123-@:!-7890")
 
-    def test_invalid_area_code(self):
+    def test_invalid_when_area_code_does_start_with_1(self):
         with self.assertRaisesWithMessage(ValueError):
             Phone("(123) 456-7890")
 
-    def test_invalid_exchange_code(self):
+    def test_invalid_when_exchange_code_does_start_with_1(self):
         with self.assertRaisesWithMessage(ValueError):
             Phone("(223) 056-7890")
 


### PR DESCRIPTION
I added the reason for why the tests should fail to give users a better understanding and also to reflect the the naming from canonical