### PR TITLE
fix deprecation warnings

### DIFF
--- a/exercises/all-your-base/all_your_base_test.py
+++ b/exercises/all-your-base/all_your_base_test.py
@@ -82,9 +82,10 @@ class AllYourBaseTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/all-your-base/all_your_base_test.py
+++ b/exercises/all-your-base/all_your_base_test.py
@@ -82,8 +82,7 @@ class AllYourBaseTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/binary-search/binary_search_test.py
+++ b/exercises/binary-search/binary_search_test.py
@@ -47,8 +47,7 @@ class BinarySearchTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/binary-search/binary_search_test.py
+++ b/exercises/binary-search/binary_search_test.py
@@ -47,9 +47,10 @@ class BinarySearchTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/binary/binary_test.py
+++ b/exercises/binary/binary_test.py
@@ -50,9 +50,10 @@ class BinaryTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/binary/binary_test.py
+++ b/exercises/binary/binary_test.py
@@ -50,8 +50,7 @@ class BinaryTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/circular-buffer/circular_buffer_test.py
+++ b/exercises/circular-buffer/circular_buffer_test.py
@@ -113,8 +113,7 @@ class CircularBufferTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/circular-buffer/circular_buffer_test.py
+++ b/exercises/circular-buffer/circular_buffer_test.py
@@ -113,9 +113,10 @@ class CircularBufferTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/error-handling/error_handling_test.py
+++ b/exercises/error-handling/error_handling_test.py
@@ -76,8 +76,7 @@ class ErrorHandlingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/error-handling/error_handling_test.py
+++ b/exercises/error-handling/error_handling_test.py
@@ -76,9 +76,10 @@ class ErrorHandlingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -42,9 +42,10 @@ class ForthAdditionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -69,9 +70,10 @@ class ForthSubtractionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -96,9 +98,10 @@ class ForthMultiplicationTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -133,9 +136,10 @@ class ForthDivisionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -172,9 +176,10 @@ class ForthDupTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -204,9 +209,10 @@ class ForthDropTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -241,9 +247,10 @@ class ForthSwapTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -278,9 +285,10 @@ class ForthOverTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
@@ -349,9 +357,10 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -42,8 +42,7 @@ class ForthAdditionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -70,8 +69,7 @@ class ForthSubtractionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -98,8 +96,7 @@ class ForthMultiplicationTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -136,8 +133,7 @@ class ForthDivisionTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -176,8 +172,7 @@ class ForthDupTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -209,8 +204,7 @@ class ForthDropTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -247,8 +241,7 @@ class ForthSwapTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -285,8 +278,7 @@ class ForthOverTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -357,8 +349,7 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -54,8 +54,7 @@ class GrainsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -54,9 +54,10 @@ class GrainsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -57,8 +57,7 @@ class HammingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -57,9 +57,10 @@ class HammingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/hexadecimal/hexadecimal_test.py
+++ b/exercises/hexadecimal/hexadecimal_test.py
@@ -41,9 +41,10 @@ class HexadecimalTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/hexadecimal/hexadecimal_test.py
+++ b/exercises/hexadecimal/hexadecimal_test.py
@@ -41,8 +41,7 @@ class HexadecimalTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/largest-series-product/largest_series_product_test.py
+++ b/exercises/largest-series-product/largest_series_product_test.py
@@ -90,8 +90,7 @@ class SeriesTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/largest-series-product/largest_series_product_test.py
+++ b/exercises/largest-series-product/largest_series_product_test.py
@@ -90,9 +90,10 @@ class SeriesTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/meetup/meetup_test.py
+++ b/exercises/meetup/meetup_test.py
@@ -405,9 +405,10 @@ class MeetupTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/meetup/meetup_test.py
+++ b/exercises/meetup/meetup_test.py
@@ -405,8 +405,7 @@ class MeetupTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -150,8 +150,7 @@ class MinesweeperTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -150,9 +150,10 @@ class MinesweeperTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/nth-prime/nth_prime_test.py
+++ b/exercises/nth-prime/nth_prime_test.py
@@ -31,8 +31,7 @@ class NthPrimeTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/nth-prime/nth_prime_test.py
+++ b/exercises/nth-prime/nth_prime_test.py
@@ -31,9 +31,10 @@ class NthPrimeTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/nucleotide-count/nucleotide_count_test.py
+++ b/exercises/nucleotide-count/nucleotide_count_test.py
@@ -40,9 +40,10 @@ class DNATest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/nucleotide-count/nucleotide_count_test.py
+++ b/exercises/nucleotide-count/nucleotide_count_test.py
@@ -40,8 +40,7 @@ class DNATest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/ocr-numbers/ocr_numbers_test.py
@@ -140,9 +140,10 @@ class OcrTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/ocr-numbers/ocr_numbers_test.py
@@ -140,8 +140,7 @@ class OcrTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/octal/octal_test.py
+++ b/exercises/octal/octal_test.py
@@ -46,9 +46,10 @@ class OctalTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/octal/octal_test.py
+++ b/exercises/octal/octal_test.py
@@ -46,8 +46,7 @@ class OctalTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -79,8 +79,7 @@ class InvalidInputsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/perfect-numbers/perfect_numbers_test.py
@@ -79,9 +79,10 @@ class InvalidInputsTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -70,8 +70,7 @@ class PhoneTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -70,9 +70,10 @@ class PhoneTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/pov/pov_test.py
+++ b/exercises/pov/pov_test.py
@@ -198,9 +198,10 @@ class PovTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/pov/pov_test.py
+++ b/exercises/pov/pov_test.py
@@ -198,8 +198,7 @@ class PovTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -68,8 +68,7 @@ class ProteinTranslationTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -68,9 +68,10 @@ class ProteinTranslationTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.py
@@ -86,8 +86,7 @@ class PythagoreanTripletTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.py
@@ -86,9 +86,10 @@ class PythagoreanTripletTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/queen-attack/queen_attack_test.py
+++ b/exercises/queen-attack/queen_attack_test.py
@@ -91,9 +91,10 @@ class QueenAttackTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/queen-attack/queen_attack_test.py
+++ b/exercises/queen-attack/queen_attack_test.py
@@ -91,8 +91,7 @@ class QueenAttackTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -37,8 +37,7 @@ class DNATests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -37,9 +37,10 @@ class DNATests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -44,8 +44,7 @@ class SaddlePointTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -44,9 +44,10 @@ class SaddlePointTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -74,9 +74,10 @@ class SayTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -74,8 +74,7 @@ class SayTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -122,9 +122,10 @@ class ScaleGeneratorTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -122,8 +122,7 @@ class ScaleGeneratorTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/series/series_test.py
+++ b/exercises/series/series_test.py
@@ -47,9 +47,10 @@ class SeriesTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/series/series_test.py
+++ b/exercises/series/series_test.py
@@ -47,8 +47,7 @@ class SeriesTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/simple-cipher/simple_cipher_test.py
+++ b/exercises/simple-cipher/simple_cipher_test.py
@@ -76,8 +76,7 @@ class CipherTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/simple-cipher/simple_cipher_test.py
+++ b/exercises/simple-cipher/simple_cipher_test.py
@@ -76,9 +76,10 @@ class CipherTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/simple-linked-list/simple_linked_list_test.py
+++ b/exercises/simple-linked-list/simple_linked_list_test.py
@@ -110,9 +110,10 @@ class LinkedListTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/simple-linked-list/simple_linked_list_test.py
+++ b/exercises/simple-linked-list/simple_linked_list_test.py
@@ -110,8 +110,7 @@ class LinkedListTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/tree-building/tree_building_test.py
+++ b/exercises/tree-building/tree_building_test.py
@@ -181,9 +181,10 @@ class TestBuildingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/tree-building/tree_building_test.py
+++ b/exercises/tree-building/tree_building_test.py
@@ -181,8 +181,7 @@ class TestBuildingTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/triangle/triangle_test.py
+++ b/exercises/triangle/triangle_test.py
@@ -56,9 +56,10 @@ class TriangleTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/triangle/triangle_test.py
+++ b/exercises/triangle/triangle_test.py
@@ -56,8 +56,7 @@ class TriangleTests(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.py
@@ -98,8 +98,7 @@ class TestVLQ(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.py
@@ -98,9 +98,10 @@ class TestVLQ(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")

--- a/exercises/wordy/wordy_test.py
+++ b/exercises/wordy/wordy_test.py
@@ -71,8 +71,7 @@ class WordyTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            with self.assertRaisesRegex(AttributeError, r".+"):
-                raise AttributeError('x')
+            self.assertRaisesRegex
         except AttributeError:
             self.assertRaisesRegex = self.assertRaisesRegexp
 

--- a/exercises/wordy/wordy_test.py
+++ b/exercises/wordy/wordy_test.py
@@ -71,9 +71,10 @@ class WordyTest(unittest.TestCase):
     # Utility functions
     def setUp(self):
         try:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+            with self.assertRaisesRegex(AttributeError, r".+"):
+                raise AttributeError('x')
         except AttributeError:
-            pass
+            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")


### PR DESCRIPTION
In changes made in #1113, a convention was added to ensure that all exceptions raises by exercise solutions contained messages. The existing Python2/3 compatible solution was actually calling `assertRaisesRegexp` in Python3, raising `DeprecationWarning`s in the Travis-CI output for all Python3 builds. This PR fixes this, accomplishing the original intent to call `assertRaisesRegex` in Python3 and `assertRaisesRegexp` in Python2.