### PR TITLE
check-exercises: Skip deprecated exercises

### DIFF
--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -47,7 +47,8 @@ def load_config():
         raise SystemExit(1)
 
     try:
-        problems = [entry['slug'] for entry in data['exercises']]
+        problems = [entry['slug'] for entry in data['exercises']
+                    if "deprecated" not in entry and "foregone" not in entry]
     except KeyError:
         print('FAIL: config.json has an incorrect format')
         raise SystemExit(1)

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -48,7 +48,7 @@ def load_config():
 
     try:
         problems = [entry['slug'] for entry in data['exercises']
-                    if "deprecated" not in entry and "foregone" not in entry]
+                    if "deprecated" not in entry]
     except KeyError:
         print('FAIL: config.json has an incorrect format')
         raise SystemExit(1)


### PR DESCRIPTION
This PR edits the `check-exercises.py` script to skip testing of deprecated ~~and foregone~~ exercises.

The logic used assumes that `"deprecated"` ~~and `"foregone"`~~ are not keys in active exercises, as is currently the case.