### PR TITLE
rail-fence-cipher: update tests to v1.1.0

### DIFF
--- a/exercises/rail-fence-cipher/rail_fence_cipher.py
+++ b/exercises/rail-fence-cipher/rail_fence_cipher.py
@@ -1,10 +1,6 @@
-def fence_pattern(rails, message_size):
+def encode(message, rails):
     pass
 
 
-def encode(rails, message):
-    pass
-
-
-def decode(rails, encoded_message):
+def decode(encoded_message, rails):
     pass

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.py
@@ -3,7 +3,7 @@ import unittest
 from rail_fence_cipher import encode, decode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class RailFenceTests(unittest.TestCase):
     def test_encode_with_two_rails(self):


### PR DESCRIPTION
Fix #1216. Besides updating test, I've modified stub file in two places:

- Adjust the order of function parameters to be consistent with test file.
- Remove `fence_pattern` function to give learners more freedom.