### PR TITLE
rail-fence-cipher: improve stub file

### DIFF
--- a/exercises/rail-fence-cipher/rail_fence_cipher.py
+++ b/exercises/rail-fence-cipher/rail_fence_cipher.py
@@ -1,10 +1,6 @@
-def fence_pattern(rails, message_size):
+def encode(message, rails):
     pass
 
 
-def encode(rails, message):
-    pass
-
-
-def decode(rails, encoded_message):
+def decode(encoded_message, rails):
     pass


### PR DESCRIPTION
Modifications in two places:

- Adjust the order of function parameters to be consistent with [test file](https://github.com/exercism/python/blob/master/exercises/rail-fence-cipher/rail_fence_cipher_test.py).
- Remove `fence_pattern` function to give learners more freedom.