### PR TITLE
leap: update tests to v1.3.0

### DIFF
--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -3,7 +3,7 @@ import unittest
 from leap import is_leap_year
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
 
 class YearTest(unittest.TestCase):
     def test_year_not_divisible_by_4(self):


### PR DESCRIPTION
Closes #1184. 

Since canonical data was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.