### PR TITLE
reverse-string: update tests to v1.1.0

### DIFF
--- a/exercises/reverse-string/reverse_string_test.py
+++ b/exercises/reverse-string/reverse_string_test.py
@@ -3,7 +3,7 @@ import unittest
 from reverse_string import reverse
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class ReverseStringTests(unittest.TestCase):
     def test_empty_string(self):


### PR DESCRIPTION
Closes #1185

Since canonical data was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.