### PR TITLE
pangram: update tests to v1.4.0

### DIFF
--- a/exercises/pangram/pangram_test.py
+++ b/exercises/pangram/pangram_test.py
@@ -3,7 +3,7 @@ import unittest
 from pangram import is_pangram
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
 
 class PangramTests(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1186 

Since canonical data was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.