### PR TITLE
rna-transcription: update tests to v1.2.0

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -3,9 +3,9 @@ import unittest
 from rna_transcription import to_rna
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
-class DNATests(unittest.TestCase):
+class RNATranscriptionTests(unittest.TestCase):
 
     def test_transcribes_cytosine_to_guanine(self):
         self.assertEqual(to_rna('C'), 'G')
@@ -19,30 +19,8 @@ class DNATests(unittest.TestCase):
     def test_transcribes_adenine_to_uracil(self):
         self.assertEqual(to_rna('A'), 'U')
 
-    def test_transcribes_all_occurences(self):
+    def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
-
-    def test_correctly_handles_single_invalid_input(self):
-        with self.assertRaisesWithMessage(ValueError):
-            to_rna('U')
-
-    def test_correctly_handles_completely_invalid_input(self):
-        with self.assertRaisesWithMessage(ValueError):
-            to_rna('XXX')
-
-    def test_correctly_handles_partially_invalid_input(self):
-        with self.assertRaisesWithMessage(ValueError):
-            to_rna('ACGTXXXCTTAA')
-
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1187 

* Update version number
* Correct test class name from 'DNA' to 'RNA'
* Fix typo in test case method name
* Remove bad input tests