### PR TITLE
hamming: update tests to v2.1.0

### DIFF
--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -3,7 +3,7 @@ import unittest
 import hamming
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
 
 class HammingTest(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1188 

Since canonical data was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.