### PR TITLE
bowling: update tests to v1.2.0

### DIFF
--- a/exercises/bowling/bowling.py
+++ b/exercises/bowling/bowling.py
@@ -1,5 +1,3 @@
-
-
 class BowlingGame(object):
     def __init__(self):
         pass

--- a/exercises/bowling/bowling_test.py
+++ b/exercises/bowling/bowling_test.py
@@ -3,7 +3,7 @@ import unittest
 from bowling import BowlingGame
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class BowlingTests(unittest.TestCase):
     def setUp(self):
@@ -187,6 +187,21 @@ class BowlingTests(unittest.TestCase):
         self.roll(rolls)
 
         self.assertRaises(IndexError, self.game.score)
+
+    def test_cannot_roll_after_bonus_roll_for_spare(self):
+        rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2]
+
+        self.roll(rolls)
+
+        self.assertRaises(IndexError, self.game.roll, 2)
+
+    def test_cannot_roll_after_bonus_rolls_for_strike(self):
+        rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10,
+                 3, 2]
+
+        self.roll(rolls)
+
+        self.assertRaises(IndexError, self.game.roll, 2)
 
 
 if __name__ == '__main__':

--- a/exercises/bowling/bowling_test.py
+++ b/exercises/bowling/bowling_test.py
@@ -6,8 +6,6 @@ from bowling import BowlingGame
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class BowlingTests(unittest.TestCase):
-    def setUp(self):
-        self.game = BowlingGame()
 
     def roll(self, rolls):
         [self.game.roll(roll) for roll in rolls]
@@ -120,23 +118,27 @@ class BowlingTests(unittest.TestCase):
 
     def test_rolls_cannot_score_negative_points(self):
 
-        self.assertRaises(ValueError, self.game.roll, -11)
+        with self.assertRaisesWithMessage(ValueError):
+            self.game.roll(11)
 
     def test_a_roll_cannot_score_more_than_10_points(self):
 
-        self.assertRaises(ValueError, self.game.roll, 11)
+        with self.assertRaisesWithMessage(ValueError):
+            self.game.roll(11)
 
     def test_two_rolls_in_a_frame_cannot_score_more_than_10_points(self):
         self.game.roll(5)
 
-        self.assertRaises(ValueError, self.game.roll, 6)
+        with self.assertRaisesWithMessage(ValueError):
+            self.game.roll(6)
 
     def test_bonus_after_strike_in_last_frame_cannot_score_more_than_10(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 
         self.roll(rolls)
 
-        self.assertRaises(ValueError, self.game.roll, 11)
+        with self.assertRaisesWithMessage(ValueError):
+            self.game.roll(11)
 
     def test_bonus_aft_last_frame_strk_can_be_more_than_10_if_1_is_strk(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10,
@@ -151,49 +153,56 @@ class BowlingTests(unittest.TestCase):
 
         self.roll(rolls)
 
-        self.assertRaises(ValueError, self.game.roll, 10)
+        with self.assertRaisesWithMessage(ValueError):
+            self.game.roll(10)
 
     def test_an_incomplete_game_cannot_be_scored(self):
         rolls = [0, 0]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.score)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.score()
 
     def test_cannot_roll_if_there_are_already_ten_frames(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.roll, 0)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.roll(0)
 
     def test_bonus_rolls_for_strike_must_be_rolled_before_score_is_calc(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.score)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.score()
 
     def test_both_bonuses_for_strike_must_be_rolled_before_score(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.score)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.score()
 
     def test_bonus_rolls_for_spare_must_be_rolled_before_score_is_calc(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.score)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.score()
 
     def test_cannot_roll_after_bonus_roll_for_spare(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2]
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.roll, 2)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.roll(2)
 
     def test_cannot_roll_after_bonus_rolls_for_strike(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10,
@@ -201,7 +210,19 @@ class BowlingTests(unittest.TestCase):
 
         self.roll(rolls)
 
-        self.assertRaises(IndexError, self.game.roll, 2)
+        with self.assertRaisesWithMessage(IndexError):
+            self.game.roll(2)
+
+    # Utility functions
+    def setUp(self):
+        self.game = BowlingGame()
+        try:
+            self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
 
 
 if __name__ == '__main__':

--- a/exercises/bowling/example.py
+++ b/exercises/bowling/example.py
@@ -1,149 +1,99 @@
-MAX_PINS = 10
-NUM_FRAMES = 10
-
-
-class BowlingGame(object):
-    """This class manages the Bowling Game including the roll and score
-    methods"""
-    def __init__(self):
-        self.rolls = []
-        self.totalScore = 0
-        self.currentFrame = Frame()
-        self.bonusRollsAccrued = 0
-        self.bonusRollsSeen = 0
-
-    def roll(self, pins):
-        if self.isBonusRoll():
-            self.bonusRollsSeen += 1
-
-        # is the second roll valid based off the first?
-        if (self.currentFrame.isOpen() and
-           self.currentFrame.getFrame()[0] is not None):
-            if self.currentFrame.getFrame()[0] + pins > MAX_PINS:
-                raise ValueError("This roll will cause the current frame  "
-                                 "to be getter than the max number of pins")
-
-        # open a new frame if the last one has been closed
-        if not self.currentFrame.isOpen():
-            self.currentFrame = Frame()
-
-        # valid roll between 0-10
-        if pins in range(MAX_PINS + 1):
-            # raise an error if the game is over and they try to roll again
-            if ((len(self.rolls) == NUM_FRAMES) and
-               self.bonusRollsAccrued == 0):
-                raise IndexError("Max Frames have been reached.  Too many "
-                                 "rolls")
-            else:
-                self.currentFrame.roll(pins,
-                                       self.isBonusRoll(),
-                                       self.bonusRollsAccrued,
-                                       self.bonusRollsSeen)
-                # if we closed it add it to our rolls
-                if not self.currentFrame.isOpen():
-                    self.rolls.append(self.currentFrame)
-                    # If this is the last frame did we earn any bonus rolls?
-                    if len(self.rolls) == NUM_FRAMES:
-                        self.bonusRollsEarned()
-        else:
-            raise ValueError("Amount of pins rolled is greater than the max "
-                             "number of pins")
-
-    def score(self):
-        frame_index = 0
-
-        while (frame_index <= NUM_FRAMES-1):
-            frame = self.rolls[frame_index].getFrame()
-
-            roll1 = frame[0]
-            roll2 = frame[1]
-
-            if self.isStrike(roll1):
-                self.totalScore += roll1 + self.stikeBonus(frame_index)
-            else:
-                if self.isSpare(roll1, roll2):
-                    self.totalScore += roll1 + roll2 + \
-                                       self.spareBonus(frame_index)
-                else:
-                    self.totalScore += roll1 + roll2
-
-            frame_index += 1
-
-        return self.totalScore
-
-    def isStrike(self, pins):
-        return True if pins == MAX_PINS else False
-
-    def isSpare(self, roll1, roll2):
-        return True if roll1 + roll2 == MAX_PINS else False
-
-    def stikeBonus(self, frame_index):
-        bonusroll1 = self.rolls[frame_index+1].getFrame()[0]
-        bonusroll2 = 0
-        # need to go further out if the next on is a strike
-        if bonusroll1 == 10:
-            bonusroll2 = self.rolls[frame_index+2].getFrame()[0]
-        else:
-            bonusroll2 = self.rolls[frame_index+1].getFrame()[1]
-        # edge case - if the last roll is a stike the bonus rolls needs to be
-        # validated
-        if (not self.isStrike(bonusroll1) and
-           (bonusroll1 + bonusroll2 > MAX_PINS)):
-            raise ValueError("The bonus rolls total to greater than the max "
-                             "number of pins")
-        else:
-            return bonusroll1 + bonusroll2
-
-    def spareBonus(self, frame_index):
-        return self.rolls[frame_index+1].getFrame()[0]
-
-    def isLastFrame(self, frame_index):
-        return True if frame_index >= len(self.rolls)-1 else False
-
-    def bonusRollsEarned(self):
-        if len(self.rolls) == NUM_FRAMES:
-            lastFrame = self.rolls[NUM_FRAMES-1].getFrame()
-            if self.isStrike(lastFrame[0]):
-                self.bonusRollsAccrued = 2
-            elif self.isSpare(lastFrame[0], lastFrame[1]):
-                self.bonusRollsAccrued = 1
-        else:
-            self.bonusRollsAccrued = 0
-        return
-
-    def isBonusRoll(self):
-        # if we've already seen all
-        return True if len(self.rolls) >= NUM_FRAMES else False
+MAX_FRAME = 10
 
 
 class Frame(object):
-    """This class is for internal use only.  It divides up the array of
-    rolls into Frame objects"""
+    def __init__(self, idx):
+        self.idx = idx
+        self.throws = []
+
+    @property
+    def total_pins(self):
+        """Total pins knocked down in a frame."""
+        return sum(self.throws)
+
+    def is_strike(self):
+        return self.total_pins == 10 and len(self.throws) == 1
+
+    def is_spare(self):
+        return self.total_pins == 10 and len(self.throws) == 2
+
+    def is_open(self):
+        return self.total_pins < 10 and len(self.throws) == 2
+
+    def is_closed(self):
+        """Return whether a frame is over."""
+        return self.total_pins == 10 or len(self.throws) == 2
+
+    def throw(self, pins):
+        if self.total_pins + pins > 10:
+            raise ValueError("a frame's rolls cannot exceed 10")
+        self.throws.append(pins)
+
+    def score(self, next_throws):
+        result = self.total_pins
+        if self.is_strike():
+            result += sum(next_throws[:2])
+        elif self.is_spare():
+            result += sum(next_throws[:1])
+        return result
+
+
+class BowlingGame(object):
     def __init__(self):
-        self.rolls = [None, None]
-        self.open = True
+        self.current_frame_idx = 0
+        self.bonus_throws = []
+        self.frames = [Frame(idx) for idx in range(MAX_FRAME)]
 
-    def roll(self, roll, bonusRoll, accruedBonuses, seenBonuses):
-        # if it's a strike we close the frame
-        if roll == 10:
-            self.rolls[0] = 10
-            self.rolls[1] = 0
-            self.open = False
+    @property
+    def current_frame(self):
+        return self.frames[self.current_frame_idx]
+
+    def next_throws(self, frame_idx):
+        """Return a frame's next throws in the form of a list."""
+        throws = []
+        for idx in range(frame_idx + 1, MAX_FRAME):
+            throws.extend(self.frames[idx].throws)
+        throws.extend(self.bonus_throws)
+        return throws
+
+    def roll_bonus(self, pins):
+        tenth_frame = self.frames[-1]
+        if tenth_frame.is_open():
+            raise IndexError("cannot throw bonus with an open tenth frame")
+
+        self.bonus_throws.append(pins)
+
+        # Check against invalid fill balls, e.g. [3, 10]
+        if (len(self.bonus_throws) == 2 and self.bonus_throws[0] != 10 and
+                sum(self.bonus_throws) > 10):
+            raise ValueError("invalid fill balls")
+
+        # Check if there are more bonuses than it should be
+        if tenth_frame.is_strike() and len(self.bonus_throws) > 2:
+            raise IndexError(
+                "wrong number of fill balls when the tenth frame is a strike")
+        elif tenth_frame.is_spare() and len(self.bonus_throws) > 1:
+            raise IndexError(
+                "wrong number of fill balls when the tenth frame is a spare")
+
+    def roll(self, pins):
+        if not 0 <= pins <= 10:
+            raise ValueError("invalid pins")
+        elif self.current_frame_idx == MAX_FRAME:
+            self.roll_bonus(pins)
         else:
-            # first roll, but frame is still open
-            if self.rolls[0] is None:
-                self.rolls[0] = roll
-                # may need to close bonus roll frames before 2 have been seen
-                if bonusRoll and seenBonuses == accruedBonuses:
-                    self.rolls[1] = 0
-                    self.open = False
-            else:
-                # second roll, closes frame
-                self.rolls[1] = roll
-                self.open = False
+            self.current_frame.throw(pins)
+            if self.current_frame.is_closed():
+                self.current_frame_idx += 1
 
-    def isOpen(self):
-        return self.open
-
-    def getFrame(self):
-        return self.rolls
+    def score(self):
+        if self.current_frame_idx < MAX_FRAME:
+            raise IndexError("frame less than 10")
+        if self.frames[-1].is_spare() and len(self.bonus_throws) != 1:
+            raise IndexError(
+                "one bonus must be rolled when the tenth frame is spare")
+        if self.frames[-1].is_strike() and len(self.bonus_throws) != 2:
+            raise IndexError(
+                "two bonuses must be rolled when the tenth frame is strike")
+        return sum(frame.score(self.next_throws(frame.idx))
+                   for frame in self.frames)


### PR DESCRIPTION
Closes #1240 

* Update version number
* Add two new test cases, `test_cannot_roll_after_bonus_roll_for_spare` and `test_cannot_roll_after_bonus_rolls_for_strike`, according to [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/bowling/canonical-data.json)