### PR TITLE
gigasecond: update tests to v1.1.0

### DIFF
--- a/exercises/gigasecond/gigasecond_test.py
+++ b/exercises/gigasecond/gigasecond_test.py
@@ -1,11 +1,10 @@
 import unittest
-
 from datetime import datetime
 
 from gigasecond import add_gigasecond
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class GigasecondTest(unittest.TestCase):
     def test_date_only_specification_of_time(self):


### PR DESCRIPTION
Closes #1190.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/gigasecond/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.

