### PR TITLE
run-length-encoding: update tests to v1.1.0

### DIFF
--- a/exercises/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/run-length-encoding/run_length_encoding_test.py
@@ -5,7 +5,7 @@ from run_length_encoding import encode, decode
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
-class WordCountTests(unittest.TestCase):
+class RunLengthEncodingTests(unittest.TestCase):
     def test_encode_empty_string(self):
         self.assertMultiLineEqual(encode(''), '')
 

--- a/exercises/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/run-length-encoding/run_length_encoding_test.py
@@ -3,7 +3,7 @@ import unittest
 from run_length_encoding import encode, decode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class WordCountTests(unittest.TestCase):
     def test_encode_empty_string(self):


### PR DESCRIPTION
Closes #1191.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/run-length-encoding/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.