### PR TITLE
meetup: update tests to v1.1.0

### DIFF
--- a/exercises/meetup/meetup_test.py
+++ b/exercises/meetup/meetup_test.py
@@ -1,5 +1,4 @@
 import unittest
-
 from datetime import date
 
 from meetup import meetup_day
@@ -10,7 +9,7 @@ except ImportError:
     MeetupDayException = Exception
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class MeetupTest(unittest.TestCase):
     def test_monteenth_of_may_2013(self):


### PR DESCRIPTION
Closes #1192.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/meetup/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.