### PR TITLE
rotational-cipher: update tests to v1.2.0

### DIFF
--- a/exercises/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/rotational-cipher/rotational_cipher_test.py
@@ -3,7 +3,7 @@ import unittest
 import rotational_cipher
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class RotationalCipher(unittest.TestCase):
     def test_rotate_a_by_0(self):


### PR DESCRIPTION
Closes #1193.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/rotational-cipher/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.