### PR TITLE
difference-of-squares: update tests to v1.2.0

### DIFF
--- a/exercises/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/difference-of-squares/difference_of_squares_test.py
@@ -3,7 +3,7 @@ import unittest
 from difference_of_squares import difference, square_of_sum, sum_of_squares
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class DifferenceOfSquaresTest(unittest.TestCase):
     def test_square_of_sum_1(self):


### PR DESCRIPTION
Closes #1194.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/difference-of-squares/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.