### PR TITLE
allergies: update tests to v1.1.0

### DIFF
--- a/exercises/allergies/allergies_test.py
+++ b/exercises/allergies/allergies_test.py
@@ -7,7 +7,7 @@ if not hasattr(unittest.TestCase, 'assertCountEqual'):
     unittest.TestCase.assertCountEqual = unittest.TestCase.assertItemsEqual
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class AllergiesTests(unittest.TestCase):
     def test_no_allergies_means_not_allergic(self):


### PR DESCRIPTION
Closes #1196.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/allergies/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.