### PR TITLE
robot-simulator: update tests to v2.2.0

### DIFF
--- a/exercises/robot-simulator/robot_simulator_test.py
+++ b/exercises/robot-simulator/robot_simulator_test.py
@@ -3,7 +3,7 @@ import unittest
 from robot_simulator import Robot, NORTH, EAST, SOUTH, WEST
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.2.0
 
 class RobotTests(unittest.TestCase):
     def test_init(self):


### PR DESCRIPTION
Closes #1197.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/robot-simulator/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.