### PR TITLE
sieve: update tests to v1.1.0

### DIFF
--- a/exercises/sieve/sieve_test.py
+++ b/exercises/sieve/sieve_test.py
@@ -3,7 +3,7 @@ import unittest
 from sieve import sieve
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SieveTest(unittest.TestCase):
     def test_no_primes_under_two(self):


### PR DESCRIPTION
Closes #1198.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/sieve/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.