### PR TITLE
atbash-cipher: update tests to v1.1.0

### DIFF
--- a/exercises/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/atbash-cipher/atbash_cipher_test.py
@@ -3,7 +3,7 @@ import unittest
 from atbash_cipher import decode, encode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class AtbashCipherTest(unittest.TestCase):
     def test_encode_no(self):


### PR DESCRIPTION
Closes #1199.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/atbash-cipher/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.