### PR TITLE
sum-of-multiples: update tests to v1.2.0

### DIFF
--- a/exercises/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.py
@@ -12,7 +12,7 @@ import unittest
 from sum_of_multiples import sum_of_multiples
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class SumOfMultiplesTest(unittest.TestCase):
     def test_multiples_of_3_or_5_up_to_1(self):


### PR DESCRIPTION
Closes #1200.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/sum-of-multiples/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.