### PR TITLE
say: update tests to v1.1.0

### DIFF
--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -3,7 +3,7 @@ import unittest
 from say import say
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SayTest(unittest.TestCase):
     def test_zero(self):


### PR DESCRIPTION
Closes #1202.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/say/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.