### PR TITLE
largest-series-product: update tests to v1.1.0

### DIFF
--- a/exercises/largest-series-product/largest_series_product_test.py
+++ b/exercises/largest-series-product/largest_series_product_test.py
@@ -11,7 +11,7 @@ import unittest
 from largest_series_product import largest_product
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SeriesTest(unittest.TestCase):
     def test_finds_the_largest_product_if_span_equals_length(self):


### PR DESCRIPTION
Closes #1203.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/largest-series-product/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.