### PR TITLE
kindergarten-garden: update tests to v1.1.0

### DIFF
--- a/exercises/kindergarten-garden/kindergarten_garden_test.py
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.py
@@ -2,8 +2,8 @@ import unittest
 
 from kindergarten_garden import Garden
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class KindergartenGardenTests(unittest.TestCase):
     def test_garden_with_single_student(self):


### PR DESCRIPTION
Closes #1204.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/kindergarten-garden/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.