### PR TITLE
flatten-array: update tests to v1.2.0

### DIFF
--- a/exercises/flatten-array/flatten_array_test.py
+++ b/exercises/flatten-array/flatten_array_test.py
@@ -3,7 +3,7 @@ import unittest
 from flatten_array import flatten
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class FlattenArrayTests(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1205.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/flatten-array/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.