### PR TITLE
space-age: update tests to v1.1.0

### DIFF
--- a/exercises/space-age/space_age_test.py
+++ b/exercises/space-age/space_age_test.py
@@ -3,7 +3,7 @@ import unittest
 from space_age import SpaceAge
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SpaceAgeTest(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1207.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/space-age/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.