### PR TITLE
prime-factors: update tests to v1.1.0

### DIFF
--- a/exercises/prime-factors/prime_factors_test.py
+++ b/exercises/prime-factors/prime_factors_test.py
@@ -3,7 +3,7 @@ import unittest
 from prime_factors import prime_factors
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class PrimeFactorsTest(unittest.TestCase):
     def test_no_factors(self):


### PR DESCRIPTION
Closes #1209.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/prime-factors/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.