### PR TITLE
pig-latin: update tests to v1.2.0

### DIFF
--- a/exercises/pig-latin/pig_latin_test.py
+++ b/exercises/pig-latin/pig_latin_test.py
@@ -3,7 +3,7 @@ import unittest
 from pig_latin import translate
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class PigLatinTests(unittest.TestCase):
     def test_word_beginning_with_a(self):


### PR DESCRIPTION
Closes #1210.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/pig-latin/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.