### PR TITLE
scrabble-score: update tests to v1.1.0

### DIFF
--- a/exercises/scrabble-score/scrabble_score_test.py
+++ b/exercises/scrabble-score/scrabble_score_test.py
@@ -3,7 +3,7 @@ import unittest
 from scrabble_score import score
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class WordTest(unittest.TestCase):
     def test_lowercase_letter(self):


### PR DESCRIPTION
Closes #1211.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/scrabble-score/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.