### PR TITLE
crypto-square: update tests to v3.2.0

### DIFF
--- a/exercises/crypto-square/crypto_square_test.py
+++ b/exercises/crypto-square/crypto_square_test.py
@@ -3,7 +3,7 @@ import unittest
 from crypto_square import encode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v3.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v3.2.0
 
 class CryptoSquareTest(unittest.TestCase):
     def test_empty_string(self):


### PR DESCRIPTION
Closes #1212.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/crypto-square/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.