### PR TITLE
sublist: update tests to v1.1.0

### DIFF
--- a/exercises/sublist/sublist_test.py
+++ b/exercises/sublist/sublist_test.py
@@ -3,7 +3,7 @@ import unittest
 from sublist import check_lists, SUBLIST, SUPERLIST, EQUAL, UNEQUAL
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SublistTest(unittest.TestCase):
     def test_unique_return_values(self):


### PR DESCRIPTION
Closes #1212.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/sublist/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.