### PR TITLE
circular-buffer: update tests and improve stub file

### DIFF
--- a/exercises/circular-buffer/circular_buffer.py
+++ b/exercises/circular-buffer/circular_buffer.py
@@ -9,3 +9,15 @@ class BufferEmptyException(Exception):
 class CircularBuffer(object):
     def __init__(self, capacity):
         pass
+
+    def read(self):
+        pass
+
+    def write(self, data):
+        pass
+
+    def overwrite(self, data):
+        pass
+
+    def clear(self):
+        pass

--- a/exercises/circular-buffer/circular_buffer_test.py
+++ b/exercises/circular-buffer/circular_buffer_test.py
@@ -34,7 +34,7 @@ class CircularBufferTest(unittest.TestCase):
         self.assertEqual(buf.read(), '1')
         self.assertEqual(buf.read(), '2')
 
-    def test_full_buffer_cant_written(self):
+    def test_cant_write_to_full_buffer(self):
         buf = CircularBuffer(1)
         buf.write('1')
         with self.assertRaisesWithMessage(BufferFullException):
@@ -70,7 +70,7 @@ class CircularBufferTest(unittest.TestCase):
         buf.write('2')
         self.assertEqual(buf.read(), '2')
 
-    def test_clear_does_nothin_empty_buffer(self):
+    def test_clear_does_nothing_on_empty_buffer(self):
         buf = CircularBuffer(1)
         buf.clear()
         buf.write('1')
@@ -91,14 +91,7 @@ class CircularBufferTest(unittest.TestCase):
         self.assertEqual(buf.read(), '2')
         self.assertEqual(buf.read(), '3')
 
-    def test_write_full_buffer(self):
-        buf = CircularBuffer(2)
-        buf.write('1')
-        buf.write('2')
-        with self.assertRaisesWithMessage(BufferFullException):
-            buf.write('A')
-
-    def test_over_write_replaces_oldest_remaning_item(self):
+    def test_overwrite_replaces_oldest_remaining_item(self):
         buf = CircularBuffer(3)
         buf.write('1')
         buf.write('2')

--- a/exercises/circular-buffer/circular_buffer_test.py
+++ b/exercises/circular-buffer/circular_buffer_test.py
@@ -7,7 +7,7 @@ from circular_buffer import (
 )
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class CircularBufferTest(unittest.TestCase):
     def test_read_empty_buffer(self):


### PR DESCRIPTION
Closes #1214.

Currently method names in [test file](https://github.com/exercism/python/blob/master/exercises/circular-buffer/circular_buffer_test.py) don't strictly correspond with `description`s in [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/circular-buffer/canonical-data.json), some of which are ambiguous and even syntactically invalid, such as `test_full_buffer_cant_written` on [Line 37](https://github.com/exercism/python/blob/master/exercises/circular-buffer/circular_buffer_test.py#L37). As far as I can see, less descriptive test method names can slow down the process of working through the exercise and confuse beginners.

@cmccandless Advice?