### PR TITLE
matrix: re-implement to conform with canonical data

### DIFF
--- a/exercises/matrix/example.py
+++ b/exercises/matrix/example.py
@@ -2,7 +2,10 @@ class Matrix(object):
     def __init__(self, s):
         self.rows = [[int(n) for n in row.split()]
                      for row in s.split('\n')]
+        self.columns = [list(tup) for tup in zip(*self.rows)]
 
-    @property
-    def columns(self):
-        return [list(tup) for tup in zip(*self.rows)]
+    def row(self, index):
+        return self.rows[index]
+
+    def column(self, index):
+        return self.columns[index]

--- a/exercises/matrix/matrix.py
+++ b/exercises/matrix/matrix.py
@@ -1,3 +1,9 @@
 class Matrix(object):
     def __init__(self, matrix_string):
         pass
+
+    def row(self, index):
+        pass
+
+    def column(self, index):
+        pass

--- a/exercises/matrix/matrix_test.py
+++ b/exercises/matrix/matrix_test.py
@@ -3,30 +3,40 @@ import unittest
 from matrix import Matrix
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class MatrixTest(unittest.TestCase):
-    def test_extract_a_row(self):
+    def test_extract_row_from_one_number_matrix(self):
+        matrix = Matrix("1")
+        self.assertEqual(matrix.row(0), [1])
+
+    def test_can_extract_row(self):
+        matrix = Matrix("1 2\n3 4")
+        self.assertEqual(matrix.row(1), [3, 4])
+
+    def test_extract_row_where_numbers_have_different_widths(self):
         matrix = Matrix("1 2\n10 20")
-        self.assertEqual(matrix.rows[0], [1, 2])
+        self.assertEqual(matrix.row(1), [10, 20])
 
-    def test_extract_same_row_again(self):
-        matrix = Matrix("9 7\n8 6")
-        self.assertEqual(matrix.rows[0], [9, 7])
-
-    def test_extract_other_row(self):
-        matrix = Matrix("9 8 7\n19 18 17")
-        self.assertEqual(matrix.rows[1], [19, 18, 17])
-
-    def test_extract_other_row_again(self):
-        matrix = Matrix("1 4 9\n16 25 36")
-        self.assertEqual(matrix.rows[1], [16, 25, 36])
-
-    def test_extract_a_column(self):
+    def test_can_extract_row_from_non_square_matrix(self):
         matrix = Matrix("1 2 3\n4 5 6\n7 8 9\n8 7 6")
-        self.assertEqual(matrix.columns[0], [1, 4, 7, 8])
+        self.assertEqual(matrix.row(2), [7, 8, 9])
 
-    def test_extract_another_column(self):
+    def test_extract_column_from_one_number_matrix(self):
+        matrix = Matrix("1")
+        self.assertEqual(matrix.column(0), [1])
+
+    def test_can_extract_column(self):
+        matrix = Matrix("1 2 3\n4 5 6\n7 8 9")
+        self.assertEqual(matrix.column(2), [3, 6, 9])
+
+    def test_can_extract_column_from_non_square_matrix(self):
+        matrix = Matrix("1 2 3\n4 5 6\n7 8 9\n8 7 6")
+        self.assertEqual(matrix.column(2), [3, 6, 9, 6])
+
+    def test_extract_column_where_numbers_have_different_widths(self):
         matrix = Matrix("89 1903 3\n18 3 1\n9 4 800")
-        self.assertEqual(matrix.columns[1], [1903, 3, 4])
+        self.assertEqual(matrix.column(1), [1903, 3, 4])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1215.

Since this exercise had been implemented before [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/matrix/canonical-data.json) was proposed, I've made dramatic change to the whole exercise. Notice that I've turned to testing `Matrix.row` method instead of retrieving instance attributes directly, because canonical data has input parameter `index`.