### PR TITLE
lens-person: forego exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1355,5 +1355,5 @@
   ],
   "foregone": [
     "lens-person"
-  ],
+  ]
 }

--- a/config.json
+++ b/config.json
@@ -1352,5 +1352,8 @@
       "slug": "parallel-letter-frequency",
       "deprecated": true
     }
-  ]
+  ],
+  "foregone": [
+    "lens-person"
+  ],
 }


### PR DESCRIPTION
`lens-person` is specific to languages with immutable data (i.e. Haskell). This concept does not exist in Python, so the exercise should be foregone.