### PR TITLE
rail-fence-cipher: update tests to v1.1.0

### DIFF
--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.py
@@ -3,7 +3,7 @@ import unittest
 from rail_fence_cipher import encode, decode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class RailFenceTests(unittest.TestCase):
     def test_encode_with_two_rails(self):


### PR DESCRIPTION
Closes #1216.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/rail-fence-cipher/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.