### PR TITLE
nth-prime: update tests to v2.1.0

### DIFF
--- a/exercises/nth-prime/nth_prime_test.py
+++ b/exercises/nth-prime/nth_prime_test.py
@@ -3,7 +3,7 @@ import unittest
 from nth_prime import nth_prime
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
 
 class NthPrimeTests(unittest.TestCase):
     def test_first_prime(self):


### PR DESCRIPTION
Closes #1217.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/nth-prime/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.