### PR TITLE
secret-handshake: update tests to v1.2.0

### DIFF
--- a/exercises/secret-handshake/secret_handshake_test.py
+++ b/exercises/secret-handshake/secret_handshake_test.py
@@ -3,7 +3,7 @@ import unittest
 from secret_handshake import handshake, secret_code
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class HandshakeTest(unittest.TestCase):
     def test_wink_for_1(self):


### PR DESCRIPTION
Closes #1220.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/secret-handshake/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.