### PR TITLE
bracket-push: update tests to v1.2.0

### DIFF
--- a/exercises/bracket-push/bracket_push.py
+++ b/exercises/bracket-push/bracket_push.py
@@ -1,2 +1,2 @@
-def is_paired(value):
+def is_paired(input_string):
     pass

--- a/exercises/bracket-push/bracket_push.py
+++ b/exercises/bracket-push/bracket_push.py
@@ -1,2 +1,2 @@
-def check_brackets(input_string):
+def is_paired(value):
     pass

--- a/exercises/bracket-push/bracket_push_test.py
+++ b/exercises/bracket-push/bracket_push_test.py
@@ -3,7 +3,7 @@ import unittest
 from bracket_push import check_brackets
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class BracketPushTests(unittest.TestCase):
     def test_paired_square_brackets(self):

--- a/exercises/bracket-push/bracket_push_test.py
+++ b/exercises/bracket-push/bracket_push_test.py
@@ -1,54 +1,54 @@
 import unittest
 
-from bracket_push import check_brackets
+from bracket_push import is_paired
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class BracketPushTests(unittest.TestCase):
     def test_paired_square_brackets(self):
-        self.assertEqual(check_brackets("[]"), True)
+        self.assertEqual(is_paired("[]"), True)
 
     def test_empty_string(self):
-        self.assertEqual(check_brackets(""), True)
+        self.assertEqual(is_paired(""), True)
 
     def test_unpaired_brackets(self):
-        self.assertEqual(check_brackets("[["), False)
+        self.assertEqual(is_paired("[["), False)
 
     def test_wrong_ordered_brackets(self):
-        self.assertEqual(check_brackets("}{"), False)
+        self.assertEqual(is_paired("}{"), False)
 
     def test_wrong_closing_bracket(self):
-        self.assertEqual(check_brackets("{]"), False)
+        self.assertEqual(is_paired("{]"), False)
 
     def test_paired_with_whitespace(self):
-        self.assertEqual(check_brackets("{ }"), True)
+        self.assertEqual(is_paired("{ }"), True)
 
     def test_simple_nested_brackets(self):
-        self.assertEqual(check_brackets("{[]}"), True)
+        self.assertEqual(is_paired("{[]}"), True)
 
     def test_several_paired_brackets(self):
-        self.assertEqual(check_brackets("{}[]"), True)
+        self.assertEqual(is_paired("{}[]"), True)
 
     def test_paired_and_nested_brackets(self):
-        self.assertEqual(check_brackets("([{}({}[])])"), True)
+        self.assertEqual(is_paired("([{}({}[])])"), True)
 
     def test_unopened_closing_brackets(self):
-        self.assertEqual(check_brackets("{[)][]}"), False)
+        self.assertEqual(is_paired("{[)][]}"), False)
 
     def test_unpaired_and_nested_brackets(self):
-        self.assertEqual(check_brackets("([{])"), False)
+        self.assertEqual(is_paired("([{])"), False)
 
     def test_paired_and_wrong_nested_brackets(self):
-        self.assertEqual(check_brackets("[({]})"), False)
+        self.assertEqual(is_paired("[({]})"), False)
 
     def test_math_expression(self):
         self.assertEqual(
-            check_brackets("(((185 + 223.85) * 15) - 543)/2"), True)
+            is_paired("(((185 + 223.85) * 15) - 543)/2"), True)
 
     def test_complex_latex_expression(self):
         self.assertEqual(
-            check_brackets(
+            is_paired(
                 ("\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{"
                  "x} &... x^2 \\end{array}\\right)")), True)
 

--- a/exercises/bracket-push/example.py
+++ b/exercises/bracket-push/example.py
@@ -1,8 +1,8 @@
-def is_paired(string):
+def is_paired(input_string):
     counterparts = {')': '(', '}': '{', ']': '['}
 
     stack = []
-    for char in string:
+    for char in input_string:
         if char in counterparts.values():
             stack.append(char)
         elif char in counterparts:

--- a/exercises/bracket-push/example.py
+++ b/exercises/bracket-push/example.py
@@ -1,4 +1,4 @@
-def check_brackets(string):
+def is_paired(string):
     counterparts = {')': '(', '}': '{', ']': '['}
 
     stack = []


### PR DESCRIPTION
Closes #1223. [Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/bracket-push/canonical-data.json).

Besides updating version number, I have renamed the function `check_bracket` and its parameter `input_string` to `is_paired` with parameter `value` to be consistent with canonical data.