### PR TITLE
minesweeper: update tests to v1.1.0

### DIFF
--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -11,7 +11,7 @@ import unittest
 from minesweeper import board
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class MinesweeperTest(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1224.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/minesweeper/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.