### PR TITLE
wordy: update tests to v1.1.0

### DIFF
--- a/exercises/wordy/wordy_test.py
+++ b/exercises/wordy/wordy_test.py
@@ -3,7 +3,7 @@ import unittest
 from wordy import calculate
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class WordyTest(unittest.TestCase):
     def test_addition(self):


### PR DESCRIPTION
Closes #1226.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/wordy/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.