### PR TITLE
ocr-numbers: update tests to v1.1.0

### DIFF
--- a/exercises/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/ocr-numbers/ocr_numbers_test.py
@@ -11,7 +11,7 @@ import unittest
 from ocr_numbers import convert
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class OcrTest(unittest.TestCase):
     def test_recognizes_0(self):


### PR DESCRIPTION
Closes #1228.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/ocr-numbers/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.