### PR TITLE
house: update to v2.1.0

### DIFF
--- a/exercises/house/example.py
+++ b/exercises/house/example.py
@@ -17,8 +17,16 @@ def verse(verse_num):
     v.extend(['that {0} {1}'.format(parts[i][0], parts[i][1])
               for i in range(verse_num - 1, -1, -1)])
     v[-1] += '.'
-    return '\n'.join(v)
+    return v
 
 
-def rhyme():
-    return "\n\n".join(verse(n) for n in range(len(parts)))
+def recite(start_verse, end_verse):
+    if start_verse == end_verse:
+        return verse(start_verse - 1)
+    else:
+        result = []
+        for verse_num in range(start_verse-1, end_verse):
+            result.extend(verse(verse_num))
+            result.append("")
+        result.pop()
+        return result

--- a/exercises/house/house.py
+++ b/exercises/house/house.py
@@ -1,6 +1,2 @@
-def verse(verse_num):
-    pass
-
-
-def rhyme():
+def recite(start_verse, end_verse):
     pass

--- a/exercises/house/house_test.py
+++ b/exercises/house/house_test.py
@@ -2,127 +2,280 @@
 
 import unittest
 
-from house import rhyme, verse
+from house import recite
 
+
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
 
 class VerseTest(unittest.TestCase):
-    def test_verse_0(self):
-        expected = 'This is the house that Jack built.'
-        self.assertEqual(verse(0), expected)
+    def test_verse_one(self):
+        expected = ["This is the house that Jack built."]
+        self.assertEqual(recite(1, 1), expected)
 
-    def test_verse_1(self):
-        expected = 'This is the malt\n'\
-                   'that lay in the house that Jack built.'
-        self.assertEqual(verse(1), expected)
+    def test_verse_two(self):
+        expected = [
+            "This is the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(2, 2), expected)
 
-    def test_verse_2(self):
-        expected = 'This is the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.'
-        self.assertEqual(verse(2), expected)
+    def test_verse_three(self):
+        expected = [
+            "This is the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(3, 3), expected)
 
-    def test_verse_3(self):
-        expected = 'This is the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.'
-        self.assertEqual(verse(3), expected)
+    def test_verse_four(self):
+        expected = [
+            "This is the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(4, 4), expected)
+
+    def test_verse_five(self):
+        expected = [
+            "This is the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(5, 5), expected)
+
+    def test_verse_six(self):
+        expected = [
+            "This is the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(6, 6), expected)
+
+    def test_verse_seven(self):
+        expected = [
+            "This is the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(7, 7), expected)
+
+    def test_verse_eight(self):
+        expected = [
+            "This is the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(8, 8), expected)
+
+    def test_verse_nine(self):
+        expected = [
+            "This is the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(9, 9), expected)
+
+    def test_verse_10(self):
+        expected = [
+            "This is the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(10, 10), expected)
 
     def test_verse_11(self):
-        expected = 'This is the horse and the hound and the horn\n'\
-                   'that belonged to the farmer sowing his corn\n'\
-                   'that kept the rooster that crowed in the morn\n'\
-                   'that woke the priest all shaven and shorn\n'\
-                   'that married the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.'
-        self.assertEqual(verse(11), expected)
+        expected = [
+            "This is the farmer sowing his corn",
+            "that kept the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(11, 11), expected)
 
-    def test_rhyme(self):
-        expected = 'This is the house that Jack built.\n\n'\
-                   'This is the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the priest all shaven and shorn\n'\
-                   'that married the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the rooster that crowed in the morn\n'\
-                   'that woke the priest all shaven and shorn\n'\
-                   'that married the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the farmer sowing his corn\n'\
-                   'that kept the rooster that crowed in the morn\n'\
-                   'that woke the priest all shaven and shorn\n'\
-                   'that married the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.\n\n'\
-                   'This is the horse and the hound and the horn\n'\
-                   'that belonged to the farmer sowing his corn\n'\
-                   'that kept the rooster that crowed in the morn\n'\
-                   'that woke the priest all shaven and shorn\n'\
-                   'that married the man all tattered and torn\n'\
-                   'that kissed the maiden all forlorn\n'\
-                   'that milked the cow with the crumpled horn\n'\
-                   'that tossed the dog\n'\
-                   'that worried the cat\n'\
-                   'that killed the rat\n'\
-                   'that ate the malt\n'\
-                   'that lay in the house that Jack built.'
-        self.assertEqual(rhyme(), expected)
+    def test_verse_12(self):
+        expected = [
+            "This is the horse and the hound and the horn",
+            "that belonged to the farmer sowing his corn",
+            "that kept the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(12, 12), expected)
+
+    def test_multiple_verses(self):
+        expected = [
+            "This is the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(4, 8), expected)
+
+    def test_full_rhyme(self):
+        expected = [
+            "This is the house that Jack built.",
+            "",
+            "This is the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the farmer sowing his corn",
+            "that kept the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+            "",
+            "This is the horse and the hound and the horn",
+            "that belonged to the farmer sowing his corn",
+            "that kept the rooster that crowed in the morn",
+            "that woke the priest all shaven and shorn",
+            "that married the man all tattered and torn",
+            "that kissed the maiden all forlorn",
+            "that milked the cow with the crumpled horn",
+            "that tossed the dog",
+            "that worried the cat",
+            "that killed the rat",
+            "that ate the malt",
+            "that lay in the house that Jack built.",
+        ]
+        self.assertEqual(recite(1, 12), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1229. [Canonical Data](https://github.com/exercism/problem-specifications/blob/master/exercises/house/canonical-data.json).

I'm uncertain about whether I should transform outputs to lists of strings. As is [commented](https://github.com/exercism/problem-specifications/blob/master/exercises/house/canonical-data.json#L4) in the canonical data:

> JSON doesn't allow for multi-line strings, so all verses are presented here as arrays of strings. It's up to the test generator to join the lines together with line breaks.