### PR TITLE
poker: update tests to v1.1.0

### DIFF
--- a/exercises/poker/example.py
+++ b/exercises/poker/example.py
@@ -1,4 +1,4 @@
-def poker(hands):
+def best_hands(hands):
     return allmax(hands, key=hand_rank)
 
 
@@ -15,12 +15,13 @@ def allmax(iterable, key=None):
 
 
 def hand_rank(hand):
+    hand = hand.replace("10", "T").split()
     card_ranks = ["..23456789TJQKA".index(r) for r, s in hand]
     groups = [(card_ranks.count(i), i) for i in set(card_ranks)]
     groups.sort(reverse=True)
     counts, ranks = zip(*groups)
-    if ranks == [14, 5, 4, 3, 2]:
-        ranks = [5, 4, 3, 2, 1]
+    if ranks == (14, 5, 4, 3, 2):
+        ranks = (5, 4, 3, 2, 1)
     straight = (len(counts) == 5) and (max(ranks) - min(ranks) == 4)
     flush = len(set([s for r, s in hand])) == 1
     return (9 if counts == (5,) else

--- a/exercises/poker/poker.py
+++ b/exercises/poker/poker.py
@@ -1,2 +1,2 @@
-def poker(hand):
+def best_hands(hands):
     pass

--- a/exercises/poker/poker_test.py
+++ b/exercises/poker/poker_test.py
@@ -1,160 +1,237 @@
 import unittest
 
-from poker import poker
+from poker import best_hands
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class PokerTest(unittest.TestCase):
-    def test_single_hand_wins(self):
-        hand = '4S 5S 7H 8D JC'.split()
-        self.assertEqual(poker([hand]), [hand])
+    def test_single_hand_always_wins(self):
+        hands = ["4S 5S 7H 8D JC"]
+        expected = ["4S 5S 7H 8D JC"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def highest_card_wins(self):
-        first = '4D 5S 6S 8D 3C'.split()
-        second = '2S 4C 7S 9H 10H'.split()
-        third = '3S 4S 5D 6H JH'.split()
-        self.assertEqual(poker([first, second, third]), [third])
+    def test_highest_card_out_of_all_hands_wins(self):
+        hands = [
+            "4D 5S 6S 8D 3C",
+            "2S 4C 7S 9H 10H",
+            "3S 4S 5D 6H JH",
+        ]
+        expected = ["3S 4S 5D 6H JH"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def tie_has_multiple_winners(self):
-        first = '4D 5S 6S 8D 3C'.split()
-        second = '2S 4C 7S 9H 10H'.split()
-        third = '3S 4S 5D 6H JH'.split()
-        fourth = '3H 4H 5C 6C JD'.split()
-        self.assertEqual(
-            poker([first, second, third, fourth]),
-            [third, fourth])
+    def test_tie_has_multiple_winners(self):
+        hands = [
+            "4D 5S 6S 8D 3C",
+            "2S 4C 7S 9H 10H",
+            "3S 4S 5D 6H JH",
+            "3H 4H 5C 6C JD",
+        ]
+        expected = [
+            "3S 4S 5D 6H JH",
+            "3H 4H 5C 6C JD",
+        ]
+        self.assertEqual(best_hands(hands), expected)
 
-    def tie_compares_multiple(self):
-        higher = '3S 5H 6S 8D 7H'.split()
-        lower = '2S 5D 6D 8C 7S'.split()
-        self.assertEqual(poker([higher, lower]), [higher])
+    def test_tie_compares_multiple(self):
+        hands = [
+            "3S 5H 6S 8D 7H",
+            "2S 5D 6D 8C 7S",
+        ]
+        expected = ["3S 5H 6S 8D 7H"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def pair_beats_high_card(self):
-        nothing = '4S 5H 6C 8D KH'.split()
-        pairOf4 = '2S 4H 6S 4D JH'.split()
-        self.assertEqual(poker([nothing, pairOf4]), [pairOf4])
+    def test_one_pair_beats_high_card(self):
+        hands = [
+            "4S 5H 6C 8D KH",
+            "2S 4H 6S 4D JH",
+        ]
+        expected = ["2S 4H 6S 4D JH"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def highest_pair_wins(self):
-        pairOf2 = '4S 2H 6S 2D JH'.split()
-        pairOf4 = '2S 4H 6C 4D JD'.split()
-        self.assertEqual(poker([pairOf2, pairOf4]), [pairOf4])
+    def test_highest_pair_wins(self):
+        hands = [
+            "4S 2H 6S 2D JH",
+            "2S 4H 6C 4D JD",
+        ]
+        expected = ["2S 4H 6C 4D JD"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def two_pairs_beats_one_pair(self):
-        pairOf8 = '2S 8H 6S 8D JH'.split()
-        doublePair = '4S 5H 4C 8C 5C'.split()
-        self.assertEqual(poker([pairOf8, doublePair]), [doublePair])
+    def test_two_pairs_beats_one_pair(self):
+        hands = [
+            "2S 8H 6S 8D JH",
+            "4S 5H 4C 8C 5C",
+        ]
+        expected = ["4S 5H 4C 8C 5C"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_double_pair(self):
-        doublePair2and8 = '2S 8H 2D 8D 3H'.split()
-        doublePair4and5 = '4S 5H 4C 8S 5D'.split()
-        self.assertEqual(
-            poker([doublePair2and8, doublePair4and5]), [doublePair2and8])
+        hands = [
+            "2S 8H 2D 8D 3H",
+            "4S 5H 4C 8S 5D",
+        ]
+        expected = ["2S 8H 2D 8D 3H"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_double_pair_higher_tie(self):
-        doublePair2andQ = '2S QS 2C QD JH'.split()
-        doublePairJandQ = 'JD QH JS 8D QC'.split()
-        self.assertEqual(
-            poker([doublePair2andQ, doublePairJandQ]), [doublePairJandQ])
+        hands = [
+            "2S QS 2C QD JH",
+            "JD QH JS 8D QC",
+        ]
+        expected = ["JD QH JS 8D QC"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_double_pair_tie_kicker(self):
-        doublePair2and8high = 'JD QH JS 8D QC'.split()
-        doublePair2and8 = 'JS QS JC 2D QD'.split()
-        self.assertEqual(
-            poker([doublePair2and8high, doublePair2and8]),
-            [doublePair2and8high])
+        hands = [
+            "JD QH JS 8D QC",
+            "JS QS JC 2D QD",
+        ]
+        expected = ["JD QH JS 8D QC"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def three_beats_two_pair(self):
-        doublePair2and8 = '2S 8H 2H 8D JH'.split()
-        threeOf4 = '4S 5H 4C 8S 4H'.split()
-        self.assertEqual(poker([doublePair2and8, threeOf4]), [threeOf4])
+    def test_three_of_a_kind_beats_two_pair(self):
+        hands = [
+            "2S 8H 2H 8D JH",
+            "4S 5H 4C 8S 4H",
+        ]
+        expected = ["4S 5H 4C 8S 4H"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def test_two_three(self):
-        threeOf2 = '2S 2H 2C 8D JH'.split()
-        threeOf1 = '4S AH AS 8C AD'.split()
-        self.assertEqual(poker([threeOf2, threeOf1]), [threeOf1])
+    def test_two_triple_pair(self):
+        hands = [
+            "2S 2H 2C 8D JH",
+            "4S AH AS 8C AD",
+        ]
+        expected = ["4S AH AS 8C AD"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_three_multiple_decks(self):
-        threeOf1Low = '4S AH AS 7C AD'.split()
-        threeOf1High = '4S AH AS 8C AD'.split()
-        self.assertEqual(poker([threeOf1Low, threeOf1High]), [threeOf1High])
+        hands = [
+            "4S AH AS 7C AD",
+            "4S AH AS 8C AD",
+        ]
+        expected = ["4S AH AS 8C AD"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_three_vs_straight(self):
-        threeOf4 = '4S 5H 4C 8D 4H'.split()
-        straight = '3S 4D 2S 6D 5C'.split()
-        self.assertEqual(poker([threeOf4, straight]), [straight])
+        hands = [
+            "4S 5H 4C 8D 4H",
+            "3S 4D 2S 6D 5C",
+        ]
+        expected = ["3S 4D 2S 6D 5C"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def aces_can_end_straight(self):
-        threeOf4 = '4S 5H 4C 8D 4H'.split()
-        straight = '10D JH QS KD AC'.split()
-        self.assertEqual(poker([threeOf4, straight]), [straight])
+    def test_aces_can_end_straight(self):
+        hands = [
+            "4S 5H 4C 8D 4H",
+            "10D JH QS KD AC",
+        ]
+        expected = ["10D JH QS KD AC"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def aces_can_start_straight(self):
-        threeOf4 = '4S 5H 4C 8D 4H'.split()
-        straight = '4D AH 3S 2D 5C'.split()
-        self.assertEqual(poker([threeOf4, straight]), [straight])
+    def test_aces_can_start_straight(self):
+        hands = [
+            "4S 5H 4C 8D 4H",
+            "4D AH 3S 2D 5C",
+        ]
+        expected = ["4D AH 3S 2D 5C"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_straights(self):
-        straightTo8 = '4S 6C 7S 8D 5H'.split()
-        straightTo9 = '5S 7H 8S 9D 6H'.split()
-        self.assertEqual(poker([straightTo8, straightTo9]), [straightTo9])
+        hands = [
+            "4S 6C 7S 8D 5H",
+            "5S 7H 8S 9D 6H",
+        ]
+        expected = ["5S 7H 8S 9D 6H"]
+        self.assertEqual(best_hands(hands), expected)
 
-    def test_two_straights_lowest(self):
-        straightTo6 = '2H 3C 4D 5D 6H'.split()
-        straightTo5 = '4S AH 3S 2D 5H'.split()
-        self.assertEqual(poker([straightTo6, straightTo5]), [straightTo6])
+    def test_lowest_straight(self):
+        hands = [
+            "2H 3C 4D 5D 6H",
+            "4S AH 3S 2D 5H",
+        ]
+        expected = ["2H 3C 4D 5D 6H"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_straight_vs_flush(self):
-        straightTo8 = '4C 6H 7D 8D 5H'.split()
-        flushTo7 = '2S 4S 5S 6S 7S'.split()
-        self.assertEqual(poker([straightTo8, flushTo7]), [flushTo7])
+        hands = [
+            "4C 6H 7D 8D 5H",
+            "2S 4S 5S 6S 7S",
+        ]
+        expected = ["2S 4S 5S 6S 7S"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_flushes(self):
-        flushTo9 = '4H 7H 8H 9H 6H'.split()
-        flushTo7 = '2S 4S 5S 6S 7S'.split()
-        self.assertEqual(poker([flushTo9, flushTo7]), [flushTo9])
+        hands = [
+            "4H 7H 8H 9H 6H",
+            "2S 4S 5S 6S 7S",
+        ]
+        expected = ["4H 7H 8H 9H 6H"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_flush_vs_full(self):
-        flushTo8 = '3H 6H 7H 8H 5H'.split()
-        full = '4S 5H 4C 5D 4H'.split()
-        self.assertEqual(poker([full, flushTo8]), [full])
+        hands = [
+            "3H 6H 7H 8H 5H",
+            "4S 5H 4C 5D 4H",
+        ]
+        expected = ["4S 5H 4C 5D 4H"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_fulls(self):
-        fullOf4by9 = '4H 4S 4D 9S 9D'.split()
-        fullOf5by8 = '5H 5S 5D 8S 8D'.split()
-        self.assertEqual(poker([fullOf4by9, fullOf5by8]), [fullOf5by8])
+        hands = [
+            "4H 4S 4D 9S 9D",
+            "5H 5S 5D 8S 8D",
+        ]
+        expected = ["5H 5S 5D 8S 8D"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_fulls_same_triplet(self):
-        fullOf5by9 = '5H 5S 5D 9S 9D'.split()
-        fullOf5by8 = '5H 5S 5D 8S 8D'.split()
-        self.assertEqual(poker([fullOf5by9, fullOf5by8]), [fullOf5by9])
+        hands = [
+            "5H 5S 5D 9S 9D",
+            "5H 5S 5D 8S 8D",
+        ]
+        expected = ["5H 5S 5D 9S 9D"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_full_vs_four(self):
-        full = '4S 5H 4D 5D 4H'.split()
-        fourOf3 = '3S 3H 2S 3D 3C'.split()
-        self.assertEqual(poker([full, fourOf3]), [fourOf3])
+        hands = [
+            "4S 5H 4D 5D 4H",
+            "3S 3H 2S 3D 3C",
+        ]
+        expected = ["3S 3H 2S 3D 3C"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_fours(self):
-        fourOf2 = '2S 2H 2C 8D 2D'.split()
-        fourOf5 = '4S 5H 5S 5D 5C'.split()
-        self.assertEqual(poker([fourOf2, fourOf5]), [fourOf5])
+        hands = [
+            "2S 2H 2C 8D 2D",
+            "4S 5H 5S 5D 5C",
+        ]
+        expected = ["4S 5H 5S 5D 5C"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_fours_kicker(self):
-        fourOf3low = '3S 3H 2S 3D 3C'.split()
-        fourOf3high = '3S 3H 4S 3D 3C'.split()
-        self.assertEqual(poker([fourOf3low, fourOf3high]), [fourOf3high])
+        hands = [
+            "3S 3H 2S 3D 3C",
+            "3S 3H 4S 3D 3C",
+        ]
+        expected = ["3S 3H 4S 3D 3C"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_four_vs_straight_flush(self):
-        fourOf5 = '4S 5H 5S 5D 5C'.split()
-        straightFlushTo9 = '7S 8S 9S 6S 5S'.split()
-        self.assertEqual(
-            poker([fourOf5, straightFlushTo9]), [straightFlushTo9])
+        hands = [
+            "4S 5H 5S 5D 5C",
+            "7S 8S 9S 6S 10S",
+        ]
+        expected = ["7S 8S 9S 6S 10S"]
+        self.assertEqual(best_hands(hands), expected)
 
     def test_two_straight_flushes(self):
-        straightFlushTo8 = '4H 6H 7H 8H 5H'.split()
-        straightFlushTo9 = '5S 7S 8S 9S 6S'.split()
-        self.assertEqual(
-            poker([straightFlushTo8, straightFlushTo9]), [straightFlushTo9])
+        hands = [
+            "4H 6H 7H 8H 5H",
+            "5S 7S 8S 9S 6S",
+        ]
+        expected = ["5S 7S 8S 9S 6S"]
+        self.assertEqual(best_hands(hands), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1230. [Canonical Data](https://github.com/exercism/problem-specifications/blob/master/exercises/poker/canonical-data.json).

- Rename test function from `poker` to canonical `best_hands`
- Tidy up input/output formats
- Activate all tests (some are formerly disabled)
- Make some test method names more meaningful

BTW I am quite confused about former contributors deactivating test cases that will break `example.py` by removing `test_` prefix of test case methods.