### PR TITLE
rectangles: update tests to v1.1.0

### DIFF
--- a/exercises/rectangles/rectangles_test.py
+++ b/exercises/rectangles/rectangles_test.py
@@ -3,7 +3,7 @@ import unittest
 from rectangles import count
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class WordTest(unittest.TestCase):
     def test_no_rows(self):


### PR DESCRIPTION
Closes #1232.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/rectangles/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.