### PR TITLE
binary-search: update tests to v1.1.0

### DIFF
--- a/exercises/binary-search/binary_search_test.py
+++ b/exercises/binary-search/binary_search_test.py
@@ -3,7 +3,7 @@ import unittest
 from binary_search import binary_search
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class BinarySearchTests(unittest.TestCase):
     def test_finds_value_in_array_with_one_element(self):


### PR DESCRIPTION
Closes #1233.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/binary-search/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.