### PR TITLE
list-ops: update tests to v2.2.0

### DIFF
--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -4,7 +4,7 @@ import operator
 import list_ops
 
 
-# Tests adapted from problem-specifications//canonical-data.json @ v2.0.0
+# Tests adapted from problem-specifications//canonical-data.json @ v2.2.0
 
 class ListOpsTest(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1234.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/gigasecond/canonical-data.json) was only updated for new input policy and [function formats](https://github.com/exercism/problem-specifications/commit/4efde46d6d2915ff1f2c693c5751e62422ba764b#diff-637e4f7a1434d17126301fcffc3bbcbe), which has nothing to do with test file in Python, so update of version number suffices.