### PR TITLE
diamond: update tests to v1.1.0

### DIFF
--- a/exercises/diamond/diamond_test.py
+++ b/exercises/diamond/diamond_test.py
@@ -3,7 +3,7 @@ import unittest
 from diamond import make_diamond
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class DiamondTests(unittest.TestCase):
     def test_degenerate_case_with_a_single_row(self):


### PR DESCRIPTION
Closes #1236.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/diamond/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.