### PR TITLE
variable-length-quantity: update tests to v1.1.0

### DIFF
--- a/exercises/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.py
@@ -3,7 +3,7 @@ import unittest
 from variable_length_quantity import encode, decode
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class TestVLQ(unittest.TestCase):
     def test_zero(self):


### PR DESCRIPTION
Closes #1237.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/variable-length-quantity/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.