### PR TITLE
word-search: update tests to v1.2.0

### DIFF
--- a/exercises/word-search/word_search.py
+++ b/exercises/word-search/word_search.py
@@ -1,22 +1,6 @@
 class Point(object):
     def __init__(self, x, y):
-        self.x = x
-        self.y = y
-
-    def __repr__(self):
-        return 'Point({}:{})'.format(self.x, self.y)
-
-    def __add__(self, other):
-        return Point(self.x + other.x, self.y + other.y)
-
-    def __sub__(self, other):
-        return Point(self.x - other.x, self.y - other.y)
-
-    def __eq__(self, other):
-        return self.x == other.x and self.y == other.y
-
-    def __ne__(self, other):
-        return not(self == other)
+        pass
 
 
 class WordSearch(object):
@@ -24,4 +8,4 @@ class WordSearch(object):
         pass
 
     def search(self, word):
-        return None
+        pass

--- a/exercises/word-search/word_search.py
+++ b/exercises/word-search/word_search.py
@@ -1,6 +1,10 @@
 class Point(object):
     def __init__(self, x, y):
-        pass
+        self.x = None
+        self.y = None
+
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y
 
 
 class WordSearch(object):

--- a/exercises/word-search/word_search_test.py
+++ b/exercises/word-search/word_search_test.py
@@ -3,7 +3,7 @@ import unittest
 from word_search import WordSearch, Point
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class WordSearchTests(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1241.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/word-search/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.

Besides I have removed unnecessary code in the stub to ensure more freedom of implementing this exercise.