### PR TITLE
tournament: update tests to v1.4.0

### DIFF
--- a/exercises/tournament/tournament_test.py
+++ b/exercises/tournament/tournament_test.py
@@ -3,7 +3,7 @@ import unittest
 from tournament import tally
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
 
 class TestTournament(unittest.TestCase):
     def test_just_the_header_if_no_input(self):


### PR DESCRIPTION
Closes #1243.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/tournament/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.