### PR TITLE
scale-generator: update tests to v1.0.0

### DIFF
--- a/exercises/scale-generator/example.py
+++ b/exercises/scale-generator/example.py
@@ -8,22 +8,21 @@ class Scale(object):
     FLAT_KEYS = ['F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'd', 'g', 'c', 'f', 'bb',
                  'eb']
 
-    def __init__(self, tonic, scale_name, pattern=None):
+    def __init__(self, tonic, intervals=None):
         self.tonic = tonic.capitalize()
-        self.name = self.tonic + ' ' + scale_name
-        self.pattern = pattern
+        self.intervals = intervals
         self.chromatic_scale = (self.FLAT_CHROMATIC_SCALE
                                 if tonic in self.FLAT_KEYS
                                 else self.CHROMATIC_SCALE)
         self.pitches = self._assign_pitches()
 
     def _assign_pitches(self):
-        if self.pattern is None:
+        if self.intervals is None:
             return self._reorder_chromatic_scale()
         last_index = 0
         pitches = []
         scale = self._reorder_chromatic_scale()
-        for i, interval in enumerate(self.pattern):
+        for i, interval in enumerate(self.intervals):
             pitches.append(scale[last_index])
             last_index += self.ASCENDING_INTERVALS.index(interval) + 1
         if pitches[0] != scale[last_index % len(scale)]:

--- a/exercises/scale-generator/scale_generator.py
+++ b/exercises/scale-generator/scale_generator.py
@@ -1,3 +1,3 @@
 class Scale(object):
-    def __init__(self, tonic, scale_name, pattern=None):
-        pass
+    def __init__(self, tonic, intervals=None):
+        self.pitches = None

--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -3,6 +3,8 @@ import unittest
 from scale_generator import Scale
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class ScaleGeneratorTest(unittest.TestCase):
 
     # Test chromatic scales

--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -5,119 +5,82 @@ from scale_generator import Scale
 
 class ScaleGeneratorTest(unittest.TestCase):
 
-    def test_naming_scale(self):
-        chromatic = Scale('c', 'chromatic')
-        expected = 'C chromatic'
-        actual = chromatic.name
-        self.assertEqual(expected, actual)
+    # Test chromatic scales
+    def test_chromatic_scale_with_sharps(self):
+        expected = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#',
+                    'G', 'G#', 'A', 'A#', 'B']
+        self.assertEqual(Scale('C').pitches, expected)
 
-    def test_chromatic_scale(self):
-        chromatic = Scale('C', 'chromatic')
-        expected = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#',
-                    'B']
-        actual = chromatic.pitches
-        self.assertEqual(expected, actual)
+    def test_chromatic_scale_with_flats(self):
+        expected = ['F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B',
+                    'C', 'Db', 'D', 'Eb', 'E']
+        self.assertEqual(Scale('F').pitches, expected)
 
-    def test_another_chromatic_scale(self):
-        chromatic = Scale('F', 'chromatic')
-        expected = ['F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B', 'C', 'Db', 'D', 'Eb',
-                    'E']
-        actual = chromatic.pitches
-        self.assertEqual(expected, actual)
-
-    def test_naming_major_scale(self):
-        major = Scale('G', 'major', 'MMmMMMm')
-        expected = 'G major'
-        actual = major.name
-        self.assertEqual(expected, actual)
-
-    def test_major_scale(self):
-        major = Scale('C', 'major', 'MMmMMMm')
+    # Test scales with specified intervals
+    def test_simple_major_scale(self):
         expected = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
-        actual = major.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('C', 'MMmMMMm').pitches, expected)
 
-    def test_another_major_scale(self):
-        major = Scale('G', 'major', 'MMmMMMm')
+    def test_major_scale_with_sharps(self):
         expected = ['G', 'A', 'B', 'C', 'D', 'E', 'F#']
-        actual = major.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('G', 'MMmMMMm').pitches, expected)
 
-    def test_minor_scale(self):
-        minor = Scale('f#', 'minor', 'MmMMmMM')
+    def test_major_scale_with_flats(self):
+        expected = ['F', 'G', 'A', 'Bb', 'C', 'D', 'E']
+        self.assertEqual(Scale('F', 'MMmMMMm').pitches, expected)
+
+    def test_minor_scale_with_sharps(self):
         expected = ['F#', 'G#', 'A', 'B', 'C#', 'D', 'E']
-        actual = minor.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('f#', 'MmMMmMM').pitches, expected)
 
-    def test_another_minor_scale(self):
-        minor = Scale('bb', 'minor', 'MmMMmMM')
+    def test_minor_scale_with_flats(self):
         expected = ['Bb', 'C', 'Db', 'Eb', 'F', 'Gb', 'Ab']
-        actual = minor.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('bb', 'MmMMmMM').pitches, expected)
 
     def test_dorian_mode(self):
-        dorian = Scale('d', 'dorian', 'MmMMMmM')
         expected = ['D', 'E', 'F', 'G', 'A', 'B', 'C']
-        actual = dorian.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('d', 'MmMMMmM').pitches, expected)
 
     def test_mixolydian_mode(self):
-        mixolydian = Scale('Eb', 'mixolydian', 'MMmMMmM')
         expected = ['Eb', 'F', 'G', 'Ab', 'Bb', 'C', 'Db']
-        actual = mixolydian.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('Eb', 'MMmMMmM').pitches, expected)
 
     def test_lydian_mode(self):
-        lydian = Scale('a', 'lydian', 'MMMmMMm')
         expected = ['A', 'B', 'C#', 'D#', 'E', 'F#', 'G#']
-        actual = lydian.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('a', 'MMMmMMm').pitches, expected)
 
     def test_phrygian_mode(self):
-        phrygian = Scale('e', 'phrygian', 'mMMMmMM')
         expected = ['E', 'F', 'G', 'A', 'B', 'C', 'D']
-        actual = phrygian.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('e', 'mMMMmMM').pitches, expected)
 
     def test_locrian_mode(self):
-        locrian = Scale('g', 'locrian', 'mMMmMMM')
         expected = ['G', 'Ab', 'Bb', 'C', 'Db', 'Eb', 'F']
-        actual = locrian.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('g', 'mMMmMMM').pitches, expected)
 
     def test_harmonic_minor(self):
-        harmonic_minor = Scale('d', 'harmonic_minor', 'MmMMmAm')
         expected = ['D', 'E', 'F', 'G', 'A', 'Bb', 'Db']
-        actual = harmonic_minor.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('d', 'MmMMmAm').pitches, expected)
 
     def test_octatonic(self):
-        octatonic = Scale('C', 'octatonic', 'MmMmMmMm')
         expected = ['C', 'D', 'D#', 'F', 'F#', 'G#', 'A', 'B']
-        actual = octatonic.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('C', 'MmMmMmMm').pitches, expected)
 
     def test_hexatonic(self):
-        hexatonic = Scale('Db', 'hexatonic', 'MMMMMM')
         expected = ['Db', 'Eb', 'F', 'G', 'A', 'B']
-        actual = hexatonic.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('Db', 'MMMMMM').pitches, expected)
 
     def test_pentatonic(self):
-        pentatonic = Scale('A', 'pentatonic', 'MMAMA')
         expected = ['A', 'B', 'C#', 'E', 'F#']
-        actual = pentatonic.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('A', 'MMAMA').pitches, expected)
 
     def test_enigmatic(self):
-        enigmatic = Scale('G', 'enigmatic', 'mAMMMmm')
         expected = ['G', 'G#', 'B', 'C#', 'D#', 'F', 'F#']
-        actual = enigmatic.pitches
-        self.assertEqual(expected, actual)
+        self.assertEqual(Scale('G', 'mAMMMmm').pitches, expected)
 
+    # Track-specific tests
     def test_brokeninterval(self):
         with self.assertRaisesWithMessage(ValueError):
-            Scale('G', 'enigmatic', 'mAMMMmM')
+            Scale('G', 'mAMMMmM')
 
     # Utility functions
     def setUp(self):


### PR DESCRIPTION
Closes #1244. [Canonical Data](https://github.com/exercism/problem-specifications/blob/master/exercises/scale-generator/canonical-data.json).

* Remove property `name` from class `Scale`
* Refactor property `pattern` to `intervals`
* Remove `name`-related tests
* More descriptive test method names
* More concise test assertions