### PR TITLE
protein-translation: update tests to v1.1.0

### DIFF
--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -8,62 +8,62 @@ from protein_translation import proteins
 class ProteinTranslationTests(unittest.TestCase):
 
     def test_AUG_translates_to_methionine(self):
-        self.assertEqual(['Methionine'], proteins('AUG'))
+        self.assertEqual(proteins('AUG'), ['Methionine'])
 
     def test_identifies_Phenylalanine_codons(self):
         for codon in ['UUU', 'UUC']:
-            self.assertEqual(['Phenylalanine'], proteins(codon))
+            self.assertEqual(proteins(codon), ['Phenylalanine'])
 
     def test_identifies_Leucine_codons(self):
         for codon in ['UUA', 'UUG']:
-            self.assertEqual(['Leucine'], proteins(codon))
+            self.assertEqual(proteins(codon), ['Leucine'])
 
     def test_identifies_Serine_codons(self):
         for codon in ['UCU', 'UCC', 'UCA', 'UCG']:
-            self.assertEqual(['Serine'], proteins(codon))
+            self.assertEqual(proteins(codon), ['Serine'])
 
     def test_identifies_Tyrosine_codons(self):
         for codon in ['UAU', 'UAC']:
-            self.assertEqual(['Tyrosine'], proteins(codon))
+            self.assertEqual(proteins(codon), ['Tyrosine'])
 
     def test_identifies_Cysteine_codons(self):
         for codon in ['UGU', 'UGC']:
-            self.assertEqual(['Cysteine'], proteins(codon))
+            self.assertEqual(proteins(codon), ['Cysteine'])
 
     def test_identifies_Tryptophan_codons(self):
-        self.assertEqual(['Tryptophan'], proteins('UGG'))
+        self.assertEqual(proteins('UGG'), ['Tryptophan'])
 
     def test_identifies_stop_codons(self):
         for codon in ['UAA', 'UAG', 'UGA']:
-            self.assertEqual([], proteins(codon))
+            self.assertEqual(proteins(codon), [])
 
     def test_translates_rna_strand_into_correct_protein_list(self):
         strand = 'AUGUUUUGG'
         expected = ['Methionine', 'Phenylalanine', 'Tryptophan']
-        self.assertEqual(expected, proteins(strand))
+        self.assertEqual(proteins(strand), expected)
 
     def test_stops_translation_if_stop_codon_at_beginning_of_sequence(self):
         strand = 'UAGUGG'
         expected = []
-        self.assertEqual(expected, proteins(strand))
+        self.assertEqual(proteins(strand), expected)
 
     def test_stops_translation_if_stop_codon_at_end_of_two_codon_sequence(
             self):
         strand = 'UGGUAG'
         expected = ['Tryptophan']
-        self.assertEqual(expected, proteins(strand))
+        self.assertEqual(proteins(strand), expected)
 
     def test_stops_translation_if_stop_codon_at_end_of_three_codon_sequence(
             self):
         strand = 'AUGUUUUAA'
         expected = ['Methionine', 'Phenylalanine']
-        self.assertEqual(expected, proteins(strand))
+        self.assertEqual(proteins(strand), expected)
 
     def test_stops_translation_if_stop_codon_in_middle_of_six_codon_sequence(
             self):
         strand = 'UGGUGUUAUUAAUGGUUU'
         expected = ['Tryptophan', 'Cysteine', 'Tyrosine']
-        self.assertEqual(expected, proteins(strand))
+        self.assertEqual(proteins(strand), expected)
 
     # Utility functions
     def setUp(self):

--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -3,7 +3,7 @@ import unittest
 from protein_translation import proteins
 
 
-# Tests adapted from problem-specifications/canonical-data.json @ v1.0.0
+# Tests adapted from problem-specifications/canonical-data.json @ v1.1.0
 
 class ProteinTranslationTests(unittest.TestCase):
 

--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -65,16 +65,6 @@ class ProteinTranslationTests(unittest.TestCase):
         expected = ['Tryptophan', 'Cysteine', 'Tyrosine']
         self.assertEqual(proteins(strand), expected)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #1245.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/protein-translation/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.