### PR TITLE
forth: update tests to v1.5.0

### DIFF
--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -3,7 +3,7 @@ import unittest
 from forth import evaluate, StackUnderflowError
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.0
 # Tests for case-insensitivity are track-specific
 
 class ForthParsingTest(unittest.TestCase):


### PR DESCRIPTION
Closes #1252.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/forth/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.