### PR TITLE
dominoes: update tests to v2.1.0

### DIFF
--- a/exercises/dominoes/dominoes_test.py
+++ b/exercises/dominoes/dominoes_test.py
@@ -3,7 +3,7 @@ import unittest
 from dominoes import chain
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
 
 class DominoesTest(unittest.TestCase):
     def test_empty_input_empty_output(self):


### PR DESCRIPTION
Closes #1255.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/dominoes/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.