### PR TITLE
custom-set: update tests to v1.3.0

### DIFF
--- a/exercises/custom-set/custom_set_test.py
+++ b/exercises/custom-set/custom_set_test.py
@@ -3,7 +3,7 @@ import unittest
 from custom_set import CustomSet
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
 
 class CustomSetTest(unittest.TestCase):
     def test_sets_with_no_elements_are_empty(self):


### PR DESCRIPTION
Closes #1259.

Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/custom-set/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so update of version number suffices.