### PR TITLE
typofix https://github.com/exercism/python/issues/1349

### DIFF
--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -9,7 +9,7 @@ Examples of general descriptions are:
 
 - The first Monday of January 2017
 - The third Tuesday of January 2017
-- The wednesteenth of January 2017
+- The second Wednesday of January 2017
 - The last Thursday of January 2017
 
 The descriptors you are expected to parse are:


### PR DESCRIPTION
changed '- The wednesteenth of January 2017' to '- The second Wednesday of January 2017'