### PR TITLE
Fix typo and minor style issues in all READMEs

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -26,7 +26,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest {{ .Spec.SnakeCaseName }}_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest {{ .Spec.SnakeCaseName }}_test.py`.
+`python -m pytest {{ .Spec.SnakeCaseName }}_test.py`
 
 ### Common `pytest` options
 
@@ -34,7 +34,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -12,7 +12,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -26,14 +26,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest {{ .Spec.SnakeCaseName }}_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest {{ .Spec.SnakeCaseName }}_test.py`
+`python -m pytest {{ .Spec.SnakeCaseName }}_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -49,4 +50,5 @@ please see the [help page](http://exercism.io/languages/python).
 {{ . }}
 {{ end }}
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -33,7 +33,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -47,14 +47,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest accumulate_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest accumulate_test.py`
+`python -m pytest accumulate_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -70,4 +71,5 @@ please see the [help page](http://exercism.io/languages/python).
 Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -47,7 +47,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest accumulate_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest accumulate_test.py`.
+`python -m pytest accumulate_test.py`
 
 ### Common `pytest` options
 
@@ -55,7 +55,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -29,7 +29,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest acronym_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest acronym_test.py`.
+`python -m pytest acronym_test.py`
 
 ### Common `pytest` options
 
@@ -37,7 +37,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -15,7 +15,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -29,14 +29,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest acronym_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest acronym_test.py`
+`python -m pytest acronym_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -52,4 +53,5 @@ please see the [help page](http://exercism.io/languages/python).
 Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -39,7 +39,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -53,14 +53,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest all_your_base_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest all_your_base_test.py`
+`python -m pytest all_your_base_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -72,4 +73,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -53,7 +53,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest all_your_base_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest all_your_base_test.py`.
+`python -m pytest all_your_base_test.py`
 
 ### Common `pytest` options
 
@@ -61,7 +61,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -37,7 +37,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -51,14 +51,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest allergies_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest allergies_test.py`
+`python -m pytest allergies_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -74,4 +75,5 @@ please see the [help page](http://exercism.io/languages/python).
 Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -51,7 +51,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest allergies_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest allergies_test.py`.
+`python -m pytest allergies_test.py`
 
 ### Common `pytest` options
 
@@ -59,7 +59,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -39,7 +39,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -53,14 +53,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest alphametics_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest alphametics_test.py`
+`python -m pytest alphametics_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -72,4 +73,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -53,7 +53,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest alphametics_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest alphametics_test.py`.
+`python -m pytest alphametics_test.py`
 
 ### Common `pytest` options
 
@@ -61,7 +61,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -14,7 +14,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -28,14 +28,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest anagram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest anagram_test.py`
+`python -m pytest anagram_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -51,4 +52,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -28,7 +28,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest anagram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest anagram_test.py`.
+`python -m pytest anagram_test.py`
 
 ### Common `pytest` options
 
@@ -36,7 +36,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -33,7 +33,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest armstrong_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest armstrong_numbers_test.py`.
+`python -m pytest armstrong_numbers_test.py`
 
 ### Common `pytest` options
 
@@ -41,7 +41,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -19,7 +19,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -33,14 +33,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest armstrong_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest armstrong_numbers_test.py`
+`python -m pytest armstrong_numbers_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -56,4 +57,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Narcissistic_number](https://en.wikipedia.org/wiki/Narcissistic_number)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -36,7 +36,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -50,14 +50,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest atbash_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest atbash_cipher_test.py`
+`python -m pytest atbash_cipher_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -73,4 +74,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -50,7 +50,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest atbash_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest atbash_cipher_test.py`.
+`python -m pytest atbash_cipher_test.py`
 
 ### Common `pytest` options
 
@@ -58,7 +58,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -342,7 +342,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest beer_song_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest beer_song_test.py`.
+`python -m pytest beer_song_test.py`
 
 ### Common `pytest` options
 
@@ -350,7 +350,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -328,7 +328,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -342,14 +342,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest beer_song_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest beer_song_test.py`
+`python -m pytest beer_song_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -365,4 +366,5 @@ please see the [help page](http://exercism.io/languages/python).
 Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -75,7 +75,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_search_tree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_search_tree_test.py`.
+`python -m pytest binary_search_tree_test.py`
 
 ### Common `pytest` options
 
@@ -83,7 +83,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -61,7 +61,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -75,14 +75,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_search_tree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_search_tree_test.py`
+`python -m pytest binary_search_tree_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -98,4 +99,5 @@ please see the [help page](http://exercism.io/languages/python).
 Josh Cheek [https://twitter.com/josh_cheek](https://twitter.com/josh_cheek)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -56,7 +56,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_search_test.py`.
+`python -m pytest binary_search_test.py`
 
 ### Common `pytest` options
 
@@ -64,7 +64,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -42,7 +42,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -56,14 +56,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_search_test.py`
+`python -m pytest binary_search_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -79,4 +80,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/Binary_search_algorithm](http://en.wikipedia.org/wiki/Binary_search_algorithm)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -52,7 +52,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_test.py`.
+`python -m pytest binary_test.py`
 
 ### Common `pytest` options
 
@@ -60,7 +60,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -38,7 +38,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -52,14 +52,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest binary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest binary_test.py`
+`python -m pytest binary_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -75,4 +76,5 @@ please see the [help page](http://exercism.io/languages/python).
 All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -21,7 +21,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -35,14 +35,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bob_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bob_test.py`
+`python -m pytest bob_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -58,4 +59,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -35,7 +35,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bob_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bob_test.py`.
+`python -m pytest bob_test.py`
 
 ### Common `pytest` options
 
@@ -43,7 +43,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -89,7 +89,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest book_store_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest book_store_test.py`.
+`python -m pytest book_store_test.py`
 
 ### Common `pytest` options
 
@@ -97,7 +97,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -75,7 +75,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -89,14 +89,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest book_store_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest book_store_test.py`
+`python -m pytest book_store_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -112,4 +113,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the harry potter kata from Cyber-Dojo. [http://cyber-dojo.org](http://cyber-dojo.org)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -68,7 +68,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -82,14 +82,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bowling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bowling_test.py`
+`python -m pytest bowling_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -105,4 +106,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Bowling Game Kata at but UncleBob [http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -82,7 +82,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bowling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bowling_test.py`.
+`python -m pytest bowling_test.py`
 
 ### Common `pytest` options
 
@@ -90,7 +90,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -25,7 +25,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bracket_push_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bracket_push_test.py`.
+`python -m pytest bracket_push_test.py`
 
 ### Common `pytest` options
 
@@ -33,7 +33,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -11,7 +11,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -25,14 +25,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest bracket_push_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest bracket_push_test.py`
+`python -m pytest bracket_push_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -48,4 +49,5 @@ please see the [help page](http://exercism.io/languages/python).
 Ginna Baker
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -38,7 +38,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest change_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest change_test.py`.
+`python -m pytest change_test.py`
 
 ### Common `pytest` options
 
@@ -46,7 +46,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -24,7 +24,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -38,14 +38,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest change_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest change_test.py`
+`python -m pytest change_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -61,4 +62,5 @@ please see the [help page](http://exercism.io/languages/python).
 Software Craftsmanship - Coin Change Kata [https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata](https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -72,7 +72,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest circular_buffer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest circular_buffer_test.py`.
+`python -m pytest circular_buffer_test.py`
 
 ### Common `pytest` options
 
@@ -80,7 +80,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -58,7 +58,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -72,14 +72,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest circular_buffer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest circular_buffer_test.py`
+`python -m pytest circular_buffer_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -95,4 +96,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/Circular_buffer](http://en.wikipedia.org/wiki/Circular_buffer)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -28,7 +28,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest clock_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest clock_test.py`.
+`python -m pytest clock_test.py`
 
 ### Common `pytest` options
 
@@ -36,7 +36,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -14,7 +14,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -28,14 +28,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest clock_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest clock_test.py`
+`python -m pytest clock_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -51,4 +52,5 @@ please see the [help page](http://exercism.io/languages/python).
 Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -39,7 +39,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -53,14 +53,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest collatz_conjecture_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest collatz_conjecture_test.py`
+`python -m pytest collatz_conjecture_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -76,4 +77,5 @@ please see the [help page](http://exercism.io/languages/python).
 An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -53,7 +53,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest collatz_conjecture_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest collatz_conjecture_test.py`.
+`python -m pytest collatz_conjecture_test.py`
 
 ### Common `pytest` options
 
@@ -61,7 +61,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -58,7 +58,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest complex_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest complex_numbers_test.py`.
+`python -m pytest complex_numbers_test.py`
 
 ### Common `pytest` options
 
@@ -66,7 +66,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -44,7 +44,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -58,14 +58,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest complex_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest complex_numbers_test.py`
+`python -m pytest complex_numbers_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -81,4 +82,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Complex_number](https://en.wikipedia.org/wiki/Complex_number)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -38,7 +38,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -52,14 +52,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest connect_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest connect_test.py`
+`python -m pytest connect_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -52,7 +52,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest connect_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest connect_test.py`.
+`python -m pytest connect_test.py`
 
 ### Common `pytest` options
 
@@ -60,7 +60,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -77,7 +77,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -91,14 +91,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest crypto_square_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest crypto_square_test.py`
+`python -m pytest crypto_square_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -114,4 +115,5 @@ please see the [help page](http://exercism.io/languages/python).
 J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -91,7 +91,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest crypto_square_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest crypto_square_test.py`.
+`python -m pytest crypto_square_test.py`
 
 ### Common `pytest` options
 
@@ -99,7 +99,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -29,7 +29,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest custom_set_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest custom_set_test.py`.
+`python -m pytest custom_set_test.py`
 
 ### Common `pytest` options
 
@@ -37,7 +37,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -15,7 +15,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -29,14 +29,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest custom_set_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest custom_set_test.py`
+`python -m pytest custom_set_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -48,4 +49,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -60,7 +60,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -74,14 +74,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest diamond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest diamond_test.py`
+`python -m pytest diamond_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -97,4 +98,5 @@ please see the [help page](http://exercism.io/languages/python).
 Seb Rose [http://claysnow.co.uk/recycling-tests-in-tdd/](http://claysnow.co.uk/recycling-tests-in-tdd/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -74,7 +74,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest diamond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest diamond_test.py`.
+`python -m pytest diamond_test.py`
 
 ### Common `pytest` options
 
@@ -82,7 +82,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -34,7 +34,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest difference_of_squares_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest difference_of_squares_test.py`.
+`python -m pytest difference_of_squares_test.py`
 
 ### Common `pytest` options
 
@@ -42,7 +42,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -20,7 +20,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -34,14 +34,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest difference_of_squares_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest difference_of_squares_test.py`
+`python -m pytest difference_of_squares_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -57,4 +58,5 @@ please see the [help page](http://exercism.io/languages/python).
 Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -62,7 +62,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -76,14 +76,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest diffie_hellman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest diffie_hellman_test.py`
+`python -m pytest diffie_hellman_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -99,4 +100,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia, 1024 bit key from www.cryptopp.com/wiki. [http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange](http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -76,7 +76,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest diffie_hellman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest diffie_hellman_test.py`.
+`python -m pytest diffie_hellman_test.py`
 
 ### Common `pytest` options
 
@@ -84,7 +84,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -36,7 +36,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest dominoes_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest dominoes_test.py`.
+`python -m pytest dominoes_test.py`
 
 ### Common `pytest` options
 
@@ -44,7 +44,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -22,7 +22,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -36,14 +36,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest dominoes_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest dominoes_test.py`
+`python -m pytest dominoes_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -55,4 +56,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -62,7 +62,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest dot_dsl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest dot_dsl_test.py`.
+`python -m pytest dot_dsl_test.py`
 
 ### Common `pytest` options
 
@@ -70,7 +70,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -48,7 +48,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -62,14 +62,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest dot_dsl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest dot_dsl_test.py`
+`python -m pytest dot_dsl_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -81,4 +82,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -27,7 +27,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -41,14 +41,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest error_handling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest error_handling_test.py`
+`python -m pytest error_handling_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -60,4 +61,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -41,7 +41,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest error_handling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest error_handling_test.py`.
+`python -m pytest error_handling_test.py`
 
 ### Common `pytest` options
 
@@ -49,7 +49,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -68,7 +68,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest etl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest etl_test.py`.
+`python -m pytest etl_test.py`
 
 ### Common `pytest` options
 
@@ -76,7 +76,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -54,7 +54,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -68,14 +68,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest etl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest etl_test.py`
+`python -m pytest etl_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -91,4 +92,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -32,7 +32,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest flatten_array_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest flatten_array_test.py`.
+`python -m pytest flatten_array_test.py`
 
 ### Common `pytest` options
 
@@ -40,7 +40,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -18,7 +18,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -32,14 +32,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest flatten_array_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest flatten_array_test.py`
+`python -m pytest flatten_array_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -55,4 +56,5 @@ please see the [help page](http://exercism.io/languages/python).
 Interview Question [https://reference.wolfram.com/language/ref/Flatten.html](https://reference.wolfram.com/language/ref/Flatten.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -71,7 +71,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -85,14 +85,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest food_chain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest food_chain_test.py`
+`python -m pytest food_chain_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -108,4 +109,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly](http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -85,7 +85,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest food_chain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest food_chain_test.py`.
+`python -m pytest food_chain_test.py`
 
 ### Common `pytest` options
 
@@ -93,7 +93,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -47,7 +47,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest forth_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest forth_test.py`.
+`python -m pytest forth_test.py`
 
 ### Common `pytest` options
 
@@ -55,7 +55,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -33,7 +33,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -47,14 +47,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest forth_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest forth_test.py`
+`python -m pytest forth_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -66,4 +67,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -12,7 +12,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -26,14 +26,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest gigasecond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest gigasecond_test.py`
+`python -m pytest gigasecond_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -49,4 +50,5 @@ please see the [help page](http://exercism.io/languages/python).
 Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -26,7 +26,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest gigasecond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest gigasecond_test.py`.
+`python -m pytest gigasecond_test.py`
 
 ### Common `pytest` options
 
@@ -34,7 +34,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -55,7 +55,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest go_counting_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest go_counting_test.py`.
+`python -m pytest go_counting_test.py`
 
 ### Common `pytest` options
 
@@ -63,7 +63,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -41,7 +41,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -55,14 +55,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest go_counting_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest go_counting_test.py`
+`python -m pytest go_counting_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -74,4 +75,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -42,7 +42,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -56,14 +56,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grade_school_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grade_school_test.py`
+`python -m pytest grade_school_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -79,4 +80,5 @@ please see the [help page](http://exercism.io/languages/python).
 A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -56,7 +56,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grade_school_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grade_school_test.py`.
+`python -m pytest grade_school_test.py`
 
 ### Common `pytest` options
 
@@ -64,7 +64,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grains_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grains_test.py`
+`python -m pytest grains_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ please see the [help page](http://exercism.io/languages/python).
 JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grains_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grains_test.py`.
+`python -m pytest grains_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -86,7 +86,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grep_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grep_test.py`.
+`python -m pytest grep_test.py`
 
 ### Common `pytest` options
 
@@ -94,7 +94,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -72,7 +72,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -86,14 +86,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest grep_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest grep_test.py`
+`python -m pytest grep_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -109,4 +110,5 @@ please see the [help page](http://exercism.io/languages/python).
 Conversation with Nate Foster. [http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf](http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -57,7 +57,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hamming_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hamming_test.py`.
+`python -m pytest hamming_test.py`
 
 ### Common `pytest` options
 
@@ -65,7 +65,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -43,7 +43,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -57,14 +57,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hamming_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hamming_test.py`
+`python -m pytest hamming_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -80,4 +81,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -36,7 +36,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hello_world_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hello_world_test.py`.
+`python -m pytest hello_world_test.py`
 
 ### Common `pytest` options
 
@@ -44,7 +44,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -22,7 +22,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -36,14 +36,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hello_world_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hello_world_test.py`
+`python -m pytest hello_world_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -59,4 +60,5 @@ please see the [help page](http://exercism.io/languages/python).
 This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -15,7 +15,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -29,14 +29,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hexadecimal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hexadecimal_test.py`
+`python -m pytest hexadecimal_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -52,4 +53,5 @@ please see the [help page](http://exercism.io/languages/python).
 All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -29,7 +29,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest hexadecimal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest hexadecimal_test.py`.
+`python -m pytest hexadecimal_test.py`
 
 ### Common `pytest` options
 
@@ -37,7 +37,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -127,7 +127,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest house_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest house_test.py`.
+`python -m pytest house_test.py`
 
 ### Common `pytest` options
 
@@ -135,7 +135,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -113,7 +113,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -127,14 +127,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest house_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest house_test.py`
+`python -m pytest house_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -150,4 +151,5 @@ please see the [help page](http://exercism.io/languages/python).
 British nursery rhyme [http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built](http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -62,7 +62,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest isbn_verifier_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest isbn_verifier_test.py`.
+`python -m pytest isbn_verifier_test.py`
 
 ### Common `pytest` options
 
@@ -70,7 +70,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -48,7 +48,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -62,14 +62,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest isbn_verifier_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest isbn_verifier_test.py`
+`python -m pytest isbn_verifier_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -85,4 +86,5 @@ please see the [help page](http://exercism.io/languages/python).
 Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -21,7 +21,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -35,14 +35,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest isogram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest isogram_test.py`
+`python -m pytest isogram_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -58,4 +59,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Isogram](https://en.wikipedia.org/wiki/Isogram)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -35,7 +35,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest isogram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest isogram_test.py`.
+`python -m pytest isogram_test.py`
 
 ### Common `pytest` options
 
@@ -43,7 +43,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -67,7 +67,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -81,14 +81,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest kindergarten_garden_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest kindergarten_garden_test.py`
+`python -m pytest kindergarten_garden_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -104,4 +105,5 @@ please see the [help page](http://exercism.io/languages/python).
 Random musings during airplane trip. [http://jumpstartlab.com](http://jumpstartlab.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -81,7 +81,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest kindergarten_garden_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest kindergarten_garden_test.py`.
+`python -m pytest kindergarten_garden_test.py`
 
 ### Common `pytest` options
 
@@ -89,7 +89,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -35,7 +35,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest largest_series_product_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest largest_series_product_test.py`.
+`python -m pytest largest_series_product_test.py`
 
 ### Common `pytest` options
 
@@ -43,7 +43,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -21,7 +21,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -35,14 +35,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest largest_series_product_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest largest_series_product_test.py`
+`python -m pytest largest_series_product_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -58,4 +59,5 @@ please see the [help page](http://exercism.io/languages/python).
 A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest leap_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest leap_test.py`
+`python -m pytest leap_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ please see the [help page](http://exercism.io/languages/python).
 JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest leap_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest leap_test.py`.
+`python -m pytest leap_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -49,7 +49,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest linked_list_test.py`.
+`python -m pytest linked_list_test.py`
 
 ### Common `pytest` options
 
@@ -57,7 +57,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -35,7 +35,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -49,14 +49,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest linked_list_test.py`
+`python -m pytest linked_list_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -72,4 +73,5 @@ please see the [help page](http://exercism.io/languages/python).
 Classic computer science topic
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -14,7 +14,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -28,14 +28,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest list_ops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest list_ops_test.py`
+`python -m pytest list_ops_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -47,4 +48,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -28,7 +28,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest list_ops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest list_ops_test.py`.
+`python -m pytest list_ops_test.py`
 
 ### Common `pytest` options
 
@@ -36,7 +36,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -72,7 +72,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -86,14 +86,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest luhn_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest luhn_test.py`
+`python -m pytest luhn_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -109,4 +110,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -86,7 +86,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest luhn_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest luhn_test.py`.
+`python -m pytest luhn_test.py`
 
 ### Common `pytest` options
 
@@ -94,7 +94,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -36,7 +36,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest markdown_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest markdown_test.py`.
+`python -m pytest markdown_test.py`
 
 ### Common `pytest` options
 
@@ -44,7 +44,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -22,7 +22,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -36,14 +36,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest markdown_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest markdown_test.py`
+`python -m pytest markdown_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -55,4 +56,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -48,7 +48,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -62,14 +62,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest matrix_test.py`
+`python -m pytest matrix_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -85,4 +86,5 @@ please see the [help page](http://exercism.io/languages/python).
 Warmup to the `saddle-points` warmup. [http://jumpstartlab.com](http://jumpstartlab.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -62,7 +62,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest matrix_test.py`.
+`python -m pytest matrix_test.py`
 
 ### Common `pytest` options
 
@@ -70,7 +70,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest meetup_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest meetup_test.py`
+`python -m pytest meetup_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ please see the [help page](http://exercism.io/languages/python).
 Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest meetup_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest meetup_test.py`.
+`python -m pytest meetup_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest minesweeper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest minesweeper_test.py`
+`python -m pytest minesweeper_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -67,4 +68,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest minesweeper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest minesweeper_test.py`.
+`python -m pytest minesweeper_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -16,7 +16,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -30,14 +30,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest nth_prime_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest nth_prime_test.py`
+`python -m pytest nth_prime_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -53,4 +54,5 @@ please see the [help page](http://exercism.io/languages/python).
 A variation on Problem 7 at Project Euler [http://projecteuler.net/problem=7](http://projecteuler.net/problem=7)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -30,7 +30,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest nth_prime_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest nth_prime_test.py`.
+`python -m pytest nth_prime_test.py`
 
 ### Common `pytest` options
 
@@ -38,7 +38,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -20,7 +20,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -34,14 +34,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest nucleotide_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest nucleotide_count_test.py`
+`python -m pytest nucleotide_count_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -57,4 +58,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -34,7 +34,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest nucleotide_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest nucleotide_count_test.py`.
+`python -m pytest nucleotide_count_test.py`
 
 ### Common `pytest` options
 
@@ -42,7 +42,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -100,7 +100,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest ocr_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest ocr_numbers_test.py`.
+`python -m pytest ocr_numbers_test.py`
 
 ### Common `pytest` options
 
@@ -108,7 +108,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -86,7 +86,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -100,14 +100,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest ocr_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest ocr_numbers_test.py`
+`python -m pytest ocr_numbers_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -123,4 +124,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -68,7 +68,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest octal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest octal_test.py`.
+`python -m pytest octal_test.py`
 
 ### Common `pytest` options
 
@@ -76,7 +76,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -54,7 +54,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -68,14 +68,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest octal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest octal_test.py`
+`python -m pytest octal_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -91,4 +92,5 @@ please see the [help page](http://exercism.io/languages/python).
 All of Computer Science [http://www.wolframalpha.com/input/?i=base+8](http://www.wolframalpha.com/input/?i=base+8)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -40,7 +40,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -54,14 +54,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest palindrome_products_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest palindrome_products_test.py`
+`python -m pytest palindrome_products_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -77,4 +78,5 @@ please see the [help page](http://exercism.io/languages/python).
 Problem 4 at Project Euler [http://projecteuler.net/problem=4](http://projecteuler.net/problem=4)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -54,7 +54,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest palindrome_products_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest palindrome_products_test.py`.
+`python -m pytest palindrome_products_test.py`
 
 ### Common `pytest` options
 
@@ -62,7 +62,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -30,7 +30,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pangram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pangram_test.py`.
+`python -m pytest pangram_test.py`
 
 ### Common `pytest` options
 
@@ -38,7 +38,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -16,7 +16,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -30,14 +30,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pangram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pangram_test.py`
+`python -m pytest pangram_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -53,4 +54,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -29,7 +29,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest parallel_letter_frequency_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest parallel_letter_frequency_test.py`.
+`python -m pytest parallel_letter_frequency_test.py`
 
 ### Common `pytest` options
 
@@ -37,7 +37,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -15,7 +15,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -29,14 +29,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest parallel_letter_frequency_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest parallel_letter_frequency_test.py`
+`python -m pytest parallel_letter_frequency_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -48,4 +49,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -22,7 +22,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -36,14 +36,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pascals_triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pascals_triangle_test.py`
+`python -m pytest pascals_triangle_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -59,4 +60,5 @@ please see the [help page](http://exercism.io/languages/python).
 Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -36,7 +36,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pascals_triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pascals_triangle_test.py`.
+`python -m pytest pascals_triangle_test.py`
 
 ### Common `pytest` options
 
@@ -44,7 +44,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest perfect_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest perfect_numbers_test.py`
+`python -m pytest perfect_numbers_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -62,4 +63,5 @@ please see the [help page](http://exercism.io/languages/python).
 Taken from Chapter 2 of Functional Thinking by Neal Ford. [http://shop.oreilly.com/product/0636920029687.do](http://shop.oreilly.com/product/0636920029687.do)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest perfect_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest perfect_numbers_test.py`.
+`python -m pytest perfect_numbers_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -36,7 +36,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -50,14 +50,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest phone_number_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest phone_number_test.py`
+`python -m pytest phone_number_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -73,4 +74,5 @@ please see the [help page](http://exercism.io/languages/python).
 Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -50,7 +50,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest phone_number_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest phone_number_test.py`.
+`python -m pytest phone_number_test.py`
 
 ### Common `pytest` options
 
@@ -58,7 +58,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pig_latin_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pig_latin_test.py`.
+`python -m pytest pig_latin_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pig_latin_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pig_latin_test.py`
+`python -m pytest pig_latin_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -62,4 +63,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Pig Latin exercise at Test First Teaching by Ultrasaurus [https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/](https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -56,7 +56,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest point_mutations_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest point_mutations_test.py`.
+`python -m pytest point_mutations_test.py`
 
 ### Common `pytest` options
 
@@ -64,7 +64,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -42,7 +42,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -56,14 +56,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest point_mutations_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest point_mutations_test.py`
+`python -m pytest point_mutations_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -79,4 +80,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -27,7 +27,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest poker_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest poker_test.py`.
+`python -m pytest poker_test.py`
 
 ### Common `pytest` options
 
@@ -35,7 +35,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -13,7 +13,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -27,14 +27,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest poker_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest poker_test.py`
+`python -m pytest poker_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -50,4 +51,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the training course from Udacity. [https://www.udacity.com/course/viewer#!/c-cs212/](https://www.udacity.com/course/viewer#!/c-cs212/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -45,7 +45,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -59,14 +59,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pov_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pov_test.py`
+`python -m pytest pov_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -82,4 +83,5 @@ please see the [help page](http://exercism.io/languages/python).
 Adaptation of exercise from 4clojure [https://www.4clojure.com/](https://www.4clojure.com/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -59,7 +59,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pov_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pov_test.py`.
+`python -m pytest pov_test.py`
 
 ### Common `pytest` options
 
@@ -67,7 +67,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -51,7 +51,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest prime_factors_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest prime_factors_test.py`.
+`python -m pytest prime_factors_test.py`
 
 ### Common `pytest` options
 
@@ -59,7 +59,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -37,7 +37,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -51,14 +51,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest prime_factors_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest prime_factors_test.py`
+`python -m pytest prime_factors_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -74,4 +75,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Prime Factors Kata by Uncle Bob [http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata](http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -63,7 +63,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest protein_translation_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest protein_translation_test.py`.
+`python -m pytest protein_translation_test.py`
 
 ### Common `pytest` options
 
@@ -71,7 +71,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -49,7 +49,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -63,14 +63,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest protein_translation_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest protein_translation_test.py`
+`python -m pytest protein_translation_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -86,4 +87,5 @@ please see the [help page](http://exercism.io/languages/python).
 Tyler Long
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -38,7 +38,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest proverb_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest proverb_test.py`.
+`python -m pytest proverb_test.py`
 
 ### Common `pytest` options
 
@@ -46,7 +46,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -24,7 +24,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -38,14 +38,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest proverb_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest proverb_test.py`
+`python -m pytest proverb_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -61,4 +62,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/For_Want_of_a_Nail](http://en.wikipedia.org/wiki/For_Want_of_a_Nail)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pythagorean_triplet_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pythagorean_triplet_test.py`.
+`python -m pytest pythagorean_triplet_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest pythagorean_triplet_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest pythagorean_triplet_test.py`
+`python -m pytest pythagorean_triplet_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -62,4 +63,5 @@ please see the [help page](http://exercism.io/languages/python).
 Problem 9 at Project Euler [http://projecteuler.net/problem=9](http://projecteuler.net/problem=9)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest queen_attack_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest queen_attack_test.py`
+`python -m pytest queen_attack_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ please see the [help page](http://exercism.io/languages/python).
 J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest queen_attack_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest queen_attack_test.py`.
+`python -m pytest queen_attack_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -80,7 +80,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rail_fence_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rail_fence_cipher_test.py`.
+`python -m pytest rail_fence_cipher_test.py`
 
 ### Common `pytest` options
 
@@ -88,7 +88,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -66,7 +66,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -80,14 +80,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rail_fence_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rail_fence_cipher_test.py`
+`python -m pytest rail_fence_cipher_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -103,4 +104,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher](https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest raindrops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest raindrops_test.py`.
+`python -m pytest raindrops_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest raindrops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest raindrops_test.py`
+`python -m pytest raindrops_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -62,4 +63,5 @@ please see the [help page](http://exercism.io/languages/python).
 A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -50,7 +50,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rational_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rational_numbers_test.py`.
+`python -m pytest rational_numbers_test.py`
 
 ### Common `pytest` options
 
@@ -58,7 +58,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -36,11 +36,29 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
 ```
+
+## Running the tests
+
+To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+
+- Python 2.7: `py.test rational_numbers_test.py`
+- Python 3.3+: `pytest rational_numbers_test.py`
+
+Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+`python -m pytest rational_numbers_test.py`.
+
+### Common `pytest` options
+
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -56,4 +74,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Rational_number](https://en.wikipedia.org/wiki/Rational_number)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -37,7 +37,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest react_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest react_test.py`.
+`python -m pytest react_test.py`
 
 ### Common `pytest` options
 
@@ -45,7 +45,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -23,7 +23,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -37,14 +37,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest react_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest react_test.py`
+`python -m pytest react_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -56,4 +57,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -71,7 +71,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -85,14 +85,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rectangles_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rectangles_test.py`
+`python -m pytest rectangles_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -104,4 +105,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -85,7 +85,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rectangles_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rectangles_test.py`.
+`python -m pytest rectangles_test.py`
 
 ### Common `pytest` options
 
@@ -93,7 +93,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -28,7 +28,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest reverse_string_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest reverse_string_test.py`.
+`python -m pytest reverse_string_test.py`
 
 ### Common `pytest` options
 
@@ -36,7 +36,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -14,7 +14,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -28,14 +28,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest reverse_string_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest reverse_string_test.py`
+`python -m pytest reverse_string_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -51,4 +52,5 @@ please see the [help page](http://exercism.io/languages/python).
 Introductory challenge to reverse an input string [https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb](https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -43,7 +43,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rna_transcription_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rna_transcription_test.py`.
+`python -m pytest rna_transcription_test.py`
 
 ### Common `pytest` options
 
@@ -51,7 +51,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -29,7 +29,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -43,14 +43,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rna_transcription_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rna_transcription_test.py`
+`python -m pytest rna_transcription_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -66,4 +67,5 @@ please see the [help page](http://exercism.io/languages/python).
 Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -23,7 +23,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -37,14 +37,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest robot_name_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest robot_name_test.py`
+`python -m pytest robot_name_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -60,4 +61,5 @@ please see the [help page](http://exercism.io/languages/python).
 A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -37,7 +37,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest robot_name_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest robot_name_test.py`.
+`python -m pytest robot_name_test.py`
 
 ### Common `pytest` options
 
@@ -45,7 +45,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -35,7 +35,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -49,14 +49,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest robot_simulator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest robot_simulator_test.py`
+`python -m pytest robot_simulator_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -72,4 +73,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by an interview question at a famous company.
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -49,7 +49,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest robot_simulator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest robot_simulator_test.py`.
+`python -m pytest robot_simulator_test.py`
 
 ### Common `pytest` options
 
@@ -57,7 +57,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -50,7 +50,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -64,14 +64,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest roman_numerals_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest roman_numerals_test.py`
+`python -m pytest roman_numerals_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -87,4 +88,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -64,7 +64,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest roman_numerals_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest roman_numerals_test.py`.
+`python -m pytest roman_numerals_test.py`
 
 ### Common `pytest` options
 
@@ -72,7 +72,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -38,7 +38,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -52,14 +52,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rotational_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rotational_cipher_test.py`
+`python -m pytest rotational_cipher_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -75,4 +76,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -52,7 +52,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest rotational_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest rotational_cipher_test.py`.
+`python -m pytest rotational_cipher_test.py`
 
 ### Common `pytest` options
 
@@ -60,7 +60,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -31,7 +31,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -45,14 +45,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest run_length_encoding_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest run_length_encoding_test.py`
+`python -m pytest run_length_encoding_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -68,4 +69,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -45,7 +45,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest run_length_encoding_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest run_length_encoding_test.py`.
+`python -m pytest run_length_encoding_test.py`
 
 ### Common `pytest` options
 
@@ -53,7 +53,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest saddle_points_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest saddle_points_test.py`
+`python -m pytest saddle_points_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -71,4 +72,5 @@ please see the [help page](http://exercism.io/languages/python).
 J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest saddle_points_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest saddle_points_test.py`.
+`python -m pytest saddle_points_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -84,7 +84,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest say_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest say_test.py`.
+`python -m pytest say_test.py`
 
 ### Common `pytest` options
 
@@ -92,7 +92,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -70,7 +70,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -84,14 +84,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest say_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest say_test.py`
+`python -m pytest say_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -107,4 +108,5 @@ please see the [help page](http://exercism.io/languages/python).
 A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -77,7 +77,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest scale_generator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest scale_generator_test.py`.
+`python -m pytest scale_generator_test.py`
 
 ### Common `pytest` options
 
@@ -85,7 +85,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -63,7 +63,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -77,14 +77,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest scale_generator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest scale_generator_test.py`
+`python -m pytest scale_generator_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -96,4 +97,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -61,7 +61,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest scrabble_score_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest scrabble_score_test.py`.
+`python -m pytest scrabble_score_test.py`
 
 ### Common `pytest` options
 
@@ -69,7 +69,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -47,7 +47,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -61,14 +61,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest scrabble_score_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest scrabble_score_test.py`
+`python -m pytest scrabble_score_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -84,4 +85,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -50,7 +50,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest secret_handshake_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest secret_handshake_test.py`.
+`python -m pytest secret_handshake_test.py`
 
 ### Common `pytest` options
 
@@ -58,7 +58,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -36,7 +36,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -50,14 +50,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest secret_handshake_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest secret_handshake_test.py`
+`python -m pytest secret_handshake_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -73,4 +74,5 @@ please see the [help page](http://exercism.io/languages/python).
 Bert, in Mary Poppins [http://www.imdb.com/title/tt0058331/quotes/qt0437047](http://www.imdb.com/title/tt0058331/quotes/qt0437047)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -42,7 +42,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest series_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest series_test.py`.
+`python -m pytest series_test.py`
 
 ### Common `pytest` options
 
@@ -50,7 +50,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -28,7 +28,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -42,14 +42,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest series_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest series_test.py`
+`python -m pytest series_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -65,4 +66,5 @@ please see the [help page](http://exercism.io/languages/python).
 A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -35,7 +35,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -49,14 +49,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sieve_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sieve_test.py`
+`python -m pytest sieve_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -72,4 +73,5 @@ please see the [help page](http://exercism.io/languages/python).
 Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -49,7 +49,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sieve_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sieve_test.py`.
+`python -m pytest sieve_test.py`
 
 ### Common `pytest` options
 
@@ -57,7 +57,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -107,7 +107,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -121,14 +121,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest simple_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest simple_cipher_test.py`
+`python -m pytest simple_cipher_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -144,4 +145,5 @@ please see the [help page](http://exercism.io/languages/python).
 Substitution Cipher at Wikipedia [http://en.wikipedia.org/wiki/Substitution_cipher](http://en.wikipedia.org/wiki/Substitution_cipher)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -121,7 +121,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest simple_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest simple_cipher_test.py`.
+`python -m pytest simple_cipher_test.py`
 
 ### Common `pytest` options
 
@@ -129,7 +129,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -55,7 +55,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest simple_linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest simple_linked_list_test.py`.
+`python -m pytest simple_linked_list_test.py`
 
 ### Common `pytest` options
 
@@ -63,7 +63,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -41,7 +41,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -55,14 +55,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest simple_linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest simple_linked_list_test.py`
+`python -m pytest simple_linked_list_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -78,4 +79,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists. [http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000](http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest space_age_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest space_age_test.py`.
+`python -m pytest space_age_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest space_age_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest space_age_test.py`
+`python -m pytest space_age_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -62,4 +63,5 @@ please see the [help page](http://exercism.io/languages/python).
 Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -45,7 +45,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest spiral_matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest spiral_matrix_test.py`.
+`python -m pytest spiral_matrix_test.py`
 
 ### Common `pytest` options
 
@@ -53,7 +53,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -31,7 +31,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -45,14 +45,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest spiral_matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest spiral_matrix_test.py`
+`python -m pytest spiral_matrix_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -68,4 +69,5 @@ please see the [help page](http://exercism.io/languages/python).
 Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension. [https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/](https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -41,7 +41,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -55,14 +55,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest strain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest strain_test.py`
+`python -m pytest strain_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -78,4 +79,5 @@ please see the [help page](http://exercism.io/languages/python).
 Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -55,7 +55,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest strain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest strain_test.py`.
+`python -m pytest strain_test.py`
 
 ### Common `pytest` options
 
@@ -63,7 +63,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -39,7 +39,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sublist_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sublist_test.py`.
+`python -m pytest sublist_test.py`
 
 ### Common `pytest` options
 
@@ -47,7 +47,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -25,7 +25,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -39,14 +39,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sublist_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sublist_test.py`
+`python -m pytest sublist_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -58,4 +59,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -16,7 +16,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -30,14 +30,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sum_of_multiples_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sum_of_multiples_test.py`
+`python -m pytest sum_of_multiples_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -53,4 +54,5 @@ please see the [help page](http://exercism.io/languages/python).
 A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -30,7 +30,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest sum_of_multiples_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest sum_of_multiples_test.py`.
+`python -m pytest sum_of_multiples_test.py`
 
 ### Common `pytest` options
 
@@ -38,7 +38,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -86,7 +86,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest tournament_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest tournament_test.py`.
+`python -m pytest tournament_test.py`
 
 ### Common `pytest` options
 
@@ -94,7 +94,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -72,7 +72,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -86,14 +86,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest tournament_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest tournament_test.py`
+`python -m pytest tournament_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -105,4 +106,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -80,7 +80,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest transpose_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest transpose_test.py`.
+`python -m pytest transpose_test.py`
 
 ### Common `pytest` options
 
@@ -88,7 +88,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -66,7 +66,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -80,14 +80,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest transpose_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest transpose_test.py`
+`python -m pytest transpose_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -103,4 +104,5 @@ please see the [help page](http://exercism.io/languages/python).
 Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest tree_building_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest tree_building_test.py`.
+`python -m pytest tree_building_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest tree_building_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest tree_building_test.py`
+`python -m pytest tree_building_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -67,4 +68,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -44,7 +44,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest triangle_test.py`.
+`python -m pytest triangle_test.py`
 
 ### Common `pytest` options
 
@@ -52,7 +52,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -30,7 +30,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -44,14 +44,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest triangle_test.py`
+`python -m pytest triangle_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -67,4 +68,5 @@ please see the [help page](http://exercism.io/languages/python).
 The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -43,7 +43,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest trinary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest trinary_test.py`.
+`python -m pytest trinary_test.py`
 
 ### Common `pytest` options
 
@@ -51,7 +51,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -29,7 +29,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -43,14 +43,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest trinary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest trinary_test.py`
+`python -m pytest trinary_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -66,4 +67,5 @@ please see the [help page](http://exercism.io/languages/python).
 All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -36,7 +36,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -50,14 +50,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest twelve_days_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest twelve_days_test.py`
+`python -m pytest twelve_days_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -73,4 +74,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)](http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song))
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -50,7 +50,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest twelve_days_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest twelve_days_test.py`.
+`python -m pytest twelve_days_test.py`
 
 ### Common `pytest` options
 
@@ -58,7 +58,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -27,7 +27,7 @@ To conclude, the only valid moves are:
 - emptying one bucket and doing nothing to the other
 - filling one bucket and doing nothing to the other
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.
 
 ## Exception messages
 
@@ -37,7 +37,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -51,14 +51,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest two_bucket_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest two_bucket_test.py`
+`python -m pytest two_bucket_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -74,4 +75,5 @@ please see the [help page](http://exercism.io/languages/python).
 Water Pouring Problem [http://demonstrations.wolfram.com/WaterPouringProblem/](http://demonstrations.wolfram.com/WaterPouringProblem/)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -51,7 +51,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest two_bucket_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest two_bucket_test.py`.
+`python -m pytest two_bucket_test.py`
 
 ### Common `pytest` options
 
@@ -59,7 +59,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -34,7 +34,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest two_fer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest two_fer_test.py`.
+`python -m pytest two_fer_test.py`
 
 ### Common `pytest` options
 
@@ -42,7 +42,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -20,7 +20,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -34,14 +34,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest two_fer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest two_fer_test.py`
+`python -m pytest two_fer_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -57,4 +58,5 @@ please see the [help page](http://exercism.io/languages/python).
 [https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -39,7 +39,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -53,14 +53,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest variable_length_quantity_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest variable_length_quantity_test.py`
+`python -m pytest variable_length_quantity_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -76,4 +77,5 @@ please see the [help page](http://exercism.io/languages/python).
 A poor Splice developer having to implement MIDI encoding/decoding. [https://splice.com](https://splice.com)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -53,7 +53,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest variable_length_quantity_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest variable_length_quantity_test.py`.
+`python -m pytest variable_length_quantity_test.py`
 
 ### Common `pytest` options
 
@@ -61,7 +61,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -19,7 +19,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -33,14 +33,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest word_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest word_count_test.py`
+`python -m pytest word_count_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -56,4 +57,5 @@ please see the [help page](http://exercism.io/languages/python).
 This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -33,7 +33,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest word_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest word_count_test.py`.
+`python -m pytest word_count_test.py`
 
 ### Common `pytest` options
 
@@ -41,7 +41,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -34,7 +34,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -48,14 +48,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest word_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest word_search_test.py`
+`python -m pytest word_search_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -67,4 +68,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -48,7 +48,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest word_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest word_search_test.py`.
+`python -m pytest word_search_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -73,7 +73,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest wordy_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest wordy_test.py`.
+`python -m pytest wordy_test.py`
 
 ### Common `pytest` options
 
@@ -81,7 +81,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -59,7 +59,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -73,14 +73,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest wordy_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest wordy_test.py`
+`python -m pytest wordy_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -96,4 +97,5 @@ please see the [help page](http://exercism.io/languages/python).
 Inspired by one of the generated questions in the Extreme Startup game. [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -33,7 +33,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -47,14 +47,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest zebra_puzzle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest zebra_puzzle_test.py`
+`python -m pytest zebra_puzzle_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -70,4 +71,5 @@ please see the [help page](http://exercism.io/languages/python).
 Wikipedia [https://en.wikipedia.org/wiki/Zebra_Puzzle](https://en.wikipedia.org/wiki/Zebra_Puzzle)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -47,7 +47,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest zebra_puzzle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest zebra_puzzle_test.py`.
+`python -m pytest zebra_puzzle_test.py`
 
 ### Common `pytest` options
 
@@ -55,7 +55,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -49,7 +49,7 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest zipper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest zipper_test.py`.
+`python -m pytest zipper_test.py`
 
 ### Common `pytest` options
 
@@ -57,7 +57,7 @@ Alternatively, you can tell Python to run the pytest module (allowing the same c
 - `-x` : stop running tests on first failure
 - `--ff` : run failures from previous test before running other test cases
 
-For other options, see `python -m pytest -h`.
+For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -35,7 +35,7 @@ every exercise will require you to raise an exception, but for those that do, th
 a message.
 
 To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
-`raise Exception`, you shold write:
+`raise Exception`, you should write:
 
 ```python
 raise Exception("Meaningful message indicating the source of the error")
@@ -49,14 +49,15 @@ To run the tests, run the appropriate command below ([why they are different](ht
 - Python 3.3+: `pytest zipper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest zipper_test.py`
+`python -m pytest zipper_test.py`.
 
-### Common pytest options
-- -v : enable verbose output
-- -x : stop running tests on first failure
-- --ff : run failures from previous test before running other test cases
+### Common `pytest` options
 
-For other options, see `python -m pytest -h`
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`.
 
 ## Submitting Exercises
 
@@ -68,4 +69,5 @@ For more detailed information about running tests, code style and linting,
 please see the [help page](http://exercism.io/languages/python).
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
I've fixed minor issues below and then regenerate all READMEs using configlet.

- Typo: **shold** to **should**.
- Create code spans for `pytest` and its options in `Common pytest options` section.
- Add missing periods in `Common pytest options` section.
- Add a blank line after `### Common pytest options` and `## Submitting Incomplete Solutions`, which is required in [MD022](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md022---headers-should-be-surrounded-by-blank-lines) from the [markdownlint](https://github.com/markdownlint/markdownlint) project.