### PR TITLE
grains: update tests to v1.1.0

### DIFF
--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -6,7 +6,7 @@ from grains import (
 )
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class GrainsTest(unittest.TestCase):
     def test_square_1(self):


### PR DESCRIPTION
Since [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/grains/canonical-data.json) was only updated for new input policy, which has nothing to do with test file in Python, so bumping version suffices.