### PR TITLE
alphametics: mark computationally intensive test as extra-credit

### DIFF
--- a/exercises/alphametics/alphametics_test.py
+++ b/exercises/alphametics/alphametics_test.py
@@ -66,6 +66,7 @@ class TestAlphametics(unittest.TestCase):
              "S": 6,
              "T": 9})
 
+    @unittest.skip("extra-credit")
     def test_puzzle_with_ten_letters_and_199_addends(self):
         self.assertEqual(
             solve(

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -10,7 +10,7 @@ import tempfile
 import json
 
 # Allow high-performance tests to be skipped
-ALLOW_SKIP = ['largest-series-product']
+ALLOW_SKIP = ['alphametics', 'largest-series-product']
 
 
 def python_executable_name():


### PR DESCRIPTION
While this test is canonical, it does not technically add additional coverage. This test serves as a test for efficiency (https://github.com/exercism/problem-specifications/pull/1024#issuecomment-347316485) of a solution, not completeness.

Furthermore, here are the run-times for this exercise from the [latest Travis build](https://travis-ci.org/exercism/python/builds/349382228) (at the time of this writing):
| Python Version | Run-time (seconds) |
| --- | --- |
| 2.7 | 3.155 |
| 3.3 | 2.461 |
| 3.4 | 3.567 |
| 3.5 | 7.270 |
| 3.6 | 0.774 |

Notice that the optimized example solution is only "fast" in 3.6.

@nikamirrr I know you're put in a lot of discussion on this exercise, both in this track (as the author of the current solution) and in exercism/problem-specifications (to add this test case). I welcome your input here.