### PR TITLE
go-counting: adapt tests to canonical data v1.0.0

### DIFF
--- a/exercises/go-counting/example.py
+++ b/exercises/go-counting/example.py
@@ -8,7 +8,7 @@ DIRECTIONS = [(0, 1), (0, -1), (1, 0), (-1, 0)]
 
 class Board:
     def __init__(self, board):
-        self.board = board.splitlines()
+        self.board = board
         self.width = len(self.board[0])
         self.height = len(self.board)
 
@@ -35,10 +35,10 @@ class Board:
 
         return (visited_territory, visited_stones)
 
-    def territoryFor(self, coord):
-        assert len(coord) == 2
-        x, y = coord[0], coord[1]
-        if not self.valid(x, y) or self.board[y][x] in STONES:
+    def territory(self, x, y):
+        if not self.valid(x, y):
+            raise ValueError('invalid coordinate')
+        if self.board[y][x] in STONES:
             return (NONE, set())
 
         visited_territory, visited_stones = self.walk(x, y)
@@ -55,7 +55,7 @@ class Board:
         for y in range(self.height):
             for x in range(self.width):
                 if not (x, y) in visited:
-                    owner, owned_territories = self.territoryFor((x, y))
+                    owner, owned_territories = self.territory(x, y)
                     result[owner].update(owned_territories)
                     visited.update(owned_territories)
 

--- a/exercises/go-counting/go_counting.py
+++ b/exercises/go-counting/go_counting.py
@@ -9,12 +9,13 @@ class Board:
     def __init__(self, board):
         pass
 
-    def territoryFor(self, coord):
+    def territory(self, x, y):
         """Find the owner and the territories given a coordinate on
            the board
 
         Args:
-            coord ((int,int)): Coordinate on the board
+            x (int): Column on the board
+            y (int): Row on the board
 
         Returns:
             (str, set): A tuple, the first element being the owner

--- a/exercises/go-counting/go_counting_test.py
+++ b/exercises/go-counting/go_counting_test.py
@@ -2,7 +2,7 @@ import unittest
 import go_counting
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
 board5x5 = "\n".join([
     "  B  ",

--- a/exercises/go-counting/go_counting_test.py
+++ b/exercises/go-counting/go_counting_test.py
@@ -18,25 +18,25 @@ class GoCountingTest(unittest.TestCase):
         board = go_counting.Board(board5x5)
         stone, territory = board.territory(x=0, y=1)
         self.assertEqual(stone, go_counting.BLACK)
-        self.assertEqual(territory, {(0, 0), (0, 1), (1, 0)})
+        self.assertSetEqual(territory, {(0, 0), (0, 1), (1, 0)})
 
     def test_white_center_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
         stone, territory = board.territory(x=2, y=3)
         self.assertEqual(stone, go_counting.WHITE)
-        self.assertEqual(territory, {(2, 3)})
+        self.assertSetEqual(territory, {(2, 3)})
 
     def test_open_corner_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
         stone, territory = board.territory(x=1, y=4)
         self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory, {(0, 3), (0, 4), (1, 4)})
+        self.assertSetEqual(territory, {(0, 3), (0, 4), (1, 4)})
 
     def test_a_stone_and_not_a_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
         stone, territory = board.territory(x=1, y=1)
         self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory, set())
+        self.assertSetEqual(territory, set())
 
     def test_invalid_because_x_is_too_low(self):
         board = go_counting.Board(board5x5)
@@ -72,17 +72,17 @@ class GoCountingTest(unittest.TestCase):
         ]
         board = go_counting.Board(input_board)
         territories = board.territories()
-        self.assertEqual(territories[go_counting.BLACK], {(0, 0), (0, 1)})
-        self.assertEqual(territories[go_counting.WHITE], {(3, 0), (3, 1)})
-        self.assertEqual(territories[go_counting.NONE], set())
+        self.assertSetEqual(territories[go_counting.BLACK], {(0, 0), (0, 1)})
+        self.assertSetEqual(territories[go_counting.WHITE], {(3, 0), (3, 1)})
+        self.assertSetEqual(territories[go_counting.NONE], set())
 
     def test_two_region_rectangular_board(self):
         input_board = [" B "]
         board = go_counting.Board(input_board)
         territories = board.territories()
-        self.assertEqual(territories[go_counting.BLACK], {(0, 0), (2, 0)})
-        self.assertEqual(territories[go_counting.WHITE], set())
-        self.assertEqual(territories[go_counting.NONE], set())
+        self.assertSetEqual(territories[go_counting.BLACK], {(0, 0), (2, 0)})
+        self.assertSetEqual(territories[go_counting.WHITE], set())
+        self.assertSetEqual(territories[go_counting.NONE], set())
 
     # Utility functions
     def setUp(self):

--- a/exercises/go-counting/go_counting_test.py
+++ b/exercises/go-counting/go_counting_test.py
@@ -4,88 +4,95 @@ import go_counting
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
-board5x5 = "\n".join([
+board5x5 = [
     "  B  ",
     " B B ",
     "B W B",
     " W W ",
     "  W  "
-])
-
-board9x9 = "\n".join([
-    "  B   B  ",
-    "B   B   B",
-    "WBBBWBBBW",
-    "W W W W W",
-    "         ",
-    " W W W W ",
-    "B B   B B",
-    " W BBB W ",
-    "   B B   "
-])
+]
 
 
 class GoCountingTest(unittest.TestCase):
-    def test_5x5_for_black(self):
+    def test_black_corner_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((0, 1))
+        stone, territory = board.territory(x=0, y=1)
         self.assertEqual(stone, go_counting.BLACK)
-        self.assertEqual(territory, set([(0, 0), (0, 1), (1, 0)]))
+        self.assertEqual(territory, {(0, 0), (0, 1), (1, 0)})
 
-    def test_5x5_for_white(self):
+    def test_white_center_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((2, 3))
+        stone, territory = board.territory(x=2, y=3)
         self.assertEqual(stone, go_counting.WHITE)
-        self.assertEqual(territory, set([(2, 3)]))
+        self.assertEqual(territory, {(2, 3)})
 
-    def test_5x5_for_open_territory(self):
+    def test_open_corner_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((1, 4))
+        stone, territory = board.territory(x=1, y=4)
         self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory, set([(0, 3), (0, 4), (1, 4)]))
+        self.assertEqual(territory, {(0, 3), (0, 4), (1, 4)})
 
-    def test_5x5_for_non_territory(self):
+    def test_a_stone_and_not_a_territory_on_5x5_board(self):
         board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((1, 1))
-        self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory, set())
-
-    def test_5x5_for_valid_coordinate(self):
-        board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((-1, 1))
+        stone, territory = board.territory(x=1, y=1)
         self.assertEqual(stone, go_counting.NONE)
         self.assertEqual(territory, set())
 
-    def test_5x5_for_valid_coordinate2(self):
+    def test_invalid_because_x_is_too_low(self):
         board = go_counting.Board(board5x5)
-        stone, territory = board.territoryFor((1, 5))
-        self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory, set())
+        with self.assertRaisesWithMessage(ValueError):
+            board.territory(x=-1, y=1)
 
-    def test_one_territory_whole_board(self):
-        board = go_counting.Board(" ")
+    def test_invalid_because_x_is_too_high(self):
+        board = go_counting.Board(board5x5)
+        with self.assertRaisesWithMessage(ValueError):
+            board.territory(x=5, y=1)
+
+    def test_invalid_because_y_is_too_low(self):
+        board = go_counting.Board(board5x5)
+        with self.assertRaisesWithMessage(ValueError):
+            board.territory(x=1, y=-1)
+
+    def test_invalid_because_y_is_too_high(self):
+        board = go_counting.Board(board5x5)
+        with self.assertRaisesWithMessage(ValueError):
+            board.territory(x=1, y=5)
+
+    def test_one_territory_is_the_whole_board(self):
+        board = go_counting.Board([" "])
         territories = board.territories()
-        self.assertEqual(territories[go_counting.BLACK], set())
-        self.assertEqual(territories[go_counting.WHITE], set())
-        self.assertEqual(territories[go_counting.NONE], set([(0, 0)]))
+        self.assertSetEqual(territories[go_counting.BLACK], set())
+        self.assertSetEqual(territories[go_counting.WHITE], set())
+        self.assertSetEqual(territories[go_counting.NONE], {(0, 0)})
 
     def test_two_territories_rectangular_board(self):
-        input_board = "\n".join([
+        input_board = [
             " BW ",
             " BW "
-        ])
+        ]
         board = go_counting.Board(input_board)
         territories = board.territories()
-        self.assertEqual(territories[go_counting.BLACK], set([(0, 0), (0, 1)]))
-        self.assertEqual(territories[go_counting.WHITE], set([(3, 0), (3, 1)]))
+        self.assertEqual(territories[go_counting.BLACK], {(0, 0), (0, 1)})
+        self.assertEqual(territories[go_counting.WHITE], {(3, 0), (3, 1)})
         self.assertEqual(territories[go_counting.NONE], set())
 
-    def test_9x9_for_open_territory(self):
-        board = go_counting.Board(board9x9)
-        stone, territory = board.territoryFor((0, 8))
-        self.assertEqual(stone, go_counting.NONE)
-        self.assertEqual(territory,
-                         set([(2, 7), (2, 8), (1, 8), (0, 8), (0, 7)]))
+    def test_two_region_rectangular_board(self):
+        input_board = [" B "]
+        board = go_counting.Board(input_board)
+        territories = board.territories()
+        self.assertEqual(territories[go_counting.BLACK], {(0, 0), (2, 0)})
+        self.assertEqual(territories[go_counting.WHITE], set())
+        self.assertEqual(territories[go_counting.NONE], set())
+
+    # Utility functions
+    def setUp(self):
+        try:
+            self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed that, while the existing test file referenced canonical data v1.1.0, until exercism/problem-specifications#1195 was merged just recently, there was no such data (I suspect that another test file was copied as a template and this line was assumed to be correct, both by author and reviewer(s)). As there is now canonical data, this PR conforms the tests to that data.