### PR TITLE
Add ValueError test to rna_transcription

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -22,6 +22,9 @@ class RNATranscriptionTests(unittest.TestCase):
     def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
 
+    def test_handles_invalid_input(self):
+        with self.assertRaises(ValueError):
+            to_rna('ABCD')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a test to assert that a ValueError is raised when an invalid string is submitted for transcription (the invalid string that is tested in this case is 'ABCD', which could conceivably be transcribed to 'U_G_' or similar)