### PR TITLE
Verify the ValueError is raised when an improper strand is passed for rna-transcription

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -22,6 +22,9 @@ class RNATranscriptionTests(unittest.TestCase):
     def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
 
+    def test_raises_valueerror(self):
+        self.assertRaises(ValueError, to_rna, 'BBB')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The rna-transcription exercise requests that a ValueError be raised if an invalid strand is provided.