### PR TITLE
food-chain: Enforce the same output format as canonical data

### DIFF
--- a/exercises/food-chain/example.py
+++ b/exercises/food-chain/example.py
@@ -50,5 +50,14 @@ def verses(letter):
 
 
 def recite(start_verse, end_verse):
-    generated = [verse.replace("\n", "") for verse in verses(chain())]
-    return generated[start_verse-1:end_verse]
+    generated = [verse.strip().split("\n") for verse in verses(chain())]
+    if start_verse == end_verse:
+        return generated[start_verse-1]
+    else:
+        result = []
+        for i in range(start_verse-1, end_verse):
+            result += generated[i] + [""]
+
+        # Pop out the last empty string
+        result.pop()
+        return result

--- a/exercises/food-chain/food_chain_test.py
+++ b/exercises/food-chain/food_chain_test.py
@@ -9,98 +9,101 @@ class FoodChainTest(unittest.TestCase):
 
     def test_fly(self):
         expected = [
-            "I know an old lady who swallowed a fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "I know an old lady who swallowed a fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(1, 1), expected)
 
     def test_spider(self):
         expected = [
-            "I know an old lady who swallowed a spider."
-            "It wriggled and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "I know an old lady who swallowed a spider.",
+            "It wriggled and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(2, 2), expected)
 
     def test_bird(self):
         expected = [
-            "I know an old lady who swallowed a bird."
-            "How absurd to swallow a bird!"
+            "I know an old lady who swallowed a bird.",
+            "How absurd to swallow a bird!",
             "She swallowed the bird to catch the spider that "
-            "wriggled and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "wriggled and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(3, 3), expected)
 
     def test_cat(self):
         expected = [
-            "I know an old lady who swallowed a cat."
-            "Imagine that, to swallow a cat!"
-            "She swallowed the cat to catch the bird."
+            "I know an old lady who swallowed a cat.",
+            "Imagine that, to swallow a cat!",
+            "She swallowed the cat to catch the bird.",
             "She swallowed the bird to catch the spider that "
-            "wriggled and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "wriggled and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(4, 4), expected)
 
     def test_dog(self):
         expected = [
-            "I know an old lady who swallowed a dog."
-            "What a hog, to swallow a dog!"
-            "She swallowed the dog to catch the cat."
-            "She swallowed the cat to catch the bird."
+            "I know an old lady who swallowed a dog.",
+            "What a hog, to swallow a dog!",
+            "She swallowed the dog to catch the cat.",
+            "She swallowed the cat to catch the bird.",
             "She swallowed the bird to catch the spider that wriggled "
-            "and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(5, 5), expected)
 
     def test_goat(self):
         expected = [
-            "I know an old lady who swallowed a goat."
-            "Just opened her throat and swallowed a goat!"
-            "She swallowed the goat to catch the dog."
-            "She swallowed the dog to catch the cat."
-            "She swallowed the cat to catch the bird."
+            "I know an old lady who swallowed a goat.",
+            "Just opened her throat and swallowed a goat!",
+            "She swallowed the goat to catch the dog.",
+            "She swallowed the dog to catch the cat.",
+            "She swallowed the cat to catch the bird.",
             "She swallowed the bird to catch the spider that "
-            "wriggled and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "wriggled and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(6, 6), expected)
 
     def test_cow(self):
         expected = [
-            "I know an old lady who swallowed a cow."
-            "I don't know how she swallowed a cow!"
-            "She swallowed the cow to catch the goat."
-            "She swallowed the goat to catch the dog."
-            "She swallowed the dog to catch the cat."
-            "She swallowed the cat to catch the bird."
+            "I know an old lady who swallowed a cow.",
+            "I don't know how she swallowed a cow!",
+            "She swallowed the cow to catch the goat.",
+            "She swallowed the goat to catch the dog.",
+            "She swallowed the dog to catch the cat.",
+            "She swallowed the cat to catch the bird.",
             "She swallowed the bird to catch the spider that "
-            "wriggled and jiggled and tickled inside her."
-            "She swallowed the spider to catch the fly."
-            "I don't know why she swallowed the fly. Perhaps she'll die."
+            "wriggled and jiggled and tickled inside her.",
+            "She swallowed the spider to catch the fly.",
+            "I don't know why she swallowed the fly. Perhaps she'll die.",
         ]
         self.assertEqual(recite(7, 7), expected)
 
     def test_horse(self):
         expected = [
-            "I know an old lady who swallowed a horse."
-            "She's dead, of course!"
+            "I know an old lady who swallowed a horse.",
+            "She's dead, of course!",
         ]
         self.assertEqual(recite(8, 8), expected)
 
     def test_multiple_verses(self):
-        expected = [recite(n, n)[0] for n in range(1, 4)]
+        expected = recite(1, 1) + [""] + recite(2, 2) + [""] + recite(3, 3)
         self.assertEqual(recite(1, 3), expected)
 
     def test_full_song(self):
-        expected = [recite(n, n)[0] for n in range(1, 9)]
+        expected = []
+        for n in range(1, 9):
+            expected += recite(n, n) + [""]
+        expected.pop()
         self.assertEqual(recite(1, 8), expected)
 
 


### PR DESCRIPTION
Closes #1381. Use a list of individual lines as expected output instead of implicit string concatenation.