### PR TITLE
Python doesn't seem to have 'null'.

### DIFF
--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -1,12 +1,12 @@
 # Flatten Array
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested list and return a single flattened list with all values except nil/null/None.
 
-The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null/None values.
 
 For Example
 
-input: [1,[2,3,null,4],[null],5]
+input: [1,[2,3,None,4],[None],5]
 
 output: [1,2,3,4,5]
 


### PR DESCRIPTION
Instead 'None' is in the test suit.
The header should change to "nil/null/None" as well, which I couldn't do in here. Check http://exercism.io/exercises/python/flatten-array/readme