### PR TITLE
rna-transcription: Removed HINTS.md ValueError reference

### DIFF
--- a/exercises/rna-transcription/.meta/hints.md
+++ b/exercises/rna-transcription/.meta/hints.md
@@ -1,1 +1,0 @@
-Your function will need to be able to handle invalid inputs by raising a `ValueError` with a meaningful message.

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -21,10 +21,7 @@ class RNATranscriptionTests(unittest.TestCase):
 
     def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
-        
-    def test_value_error_on_bad_base(self):
-        with self.assertRaises(ValueError):
-            to_rna('BDEFHIJKLMNOPQRSTVWXYZ')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -21,7 +21,10 @@ class RNATranscriptionTests(unittest.TestCase):
 
     def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
-
+        
+    def test_value_error_on_bad_base(self):
+        with self.assertRaises(ValueError):
+            to_rna('BDEFHIJKLMNOPQRSTVWXYZ')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The README for the python "rna_transcription" exercise reads:

Your function will need to be able to handle invalid inputs by raising a `ValueError` with a meaningful message.

The test suite doesn't check for this currently, so I've added a test case where it checks for bad bases which are any capital letters that are not G,C,T,A. There is probably room for another 3 - 4 tests; testing lower case, testing numbers, testing punctuation.