### PR TITLE
reverse-string: Don't redefine builting function 'input'

### DIFF
--- a/exercises/reverse-string/example.py
+++ b/exercises/reverse-string/example.py
@@ -1,2 +1,2 @@
-def reverse(input=''):
-    return input[::-1]
+def reverse(text=''):
+    return text[::-1]

--- a/exercises/reverse-string/reverse_string.py
+++ b/exercises/reverse-string/reverse_string.py
@@ -1,2 +1,2 @@
-def reverse(input=''):
+def reverse(text=''):
     pass


### PR DESCRIPTION
It hurts readability to redefine the meaning of well-known builtins such
as 'input', and pylint rightfully warns about this, saying

  W:  1,12: Redefining built-in 'input' (redefined-builtin)

It's a little unfortunate that Python grabs this part of the namespace,
but let's fix the issue by using a different word for 'the input text'.