### PR TITLE
linked-list: Don't redefine builting function 'next'

### DIFF
--- a/exercises/linked-list/example.py
+++ b/exercises/linked-list/example.py
@@ -1,7 +1,7 @@
 class Node(object):
-    def __init__(self, value, next=None, prev=None):
+    def __init__(self, value, succeeding=None, prev=None):
         self.value = value
-        self.next = next
+        self.succeeding = succeeding
         self.prev = prev
 
 
@@ -17,7 +17,7 @@ class LinkedList(object):
             self.head = self.tail = new_node
         else:
             new_node.prev = self.tail
-            self.tail.next = new_node
+            self.tail.succeeding = new_node
             self.tail = new_node
         self.length += 1
 
@@ -27,16 +27,16 @@ class LinkedList(object):
             self.head = self.tail = None
         else:
             self.tail = self.tail.prev
-            self.tail.next = None
+            self.tail.succeeding = None
         self.length -= 1
         return node.value
 
     def shift(self):
         node = self.head
-        if node is None or node.next is None:
+        if node is None or node.succeeding is None:
             self.head = self.tail = None
         else:
-            self.head = self.head.next
+            self.head = self.head.succeeding
             self.head.prev = None
         self.length -= 1
         return node.value
@@ -46,7 +46,7 @@ class LinkedList(object):
         if not self.head:
             self.head = self.tail = new_node
         else:
-            new_node.next = self.head
+            new_node.succeeding = self.head
             self.head.prev = new_node
             self.head = new_node
         self.length += 1
@@ -58,4 +58,4 @@ class LinkedList(object):
         current_node = self.head
         while (current_node):
             yield current_node.value
-            current_node = current_node.next
+            current_node = current_node.succeeding

--- a/exercises/linked-list/linked_list.py
+++ b/exercises/linked-list/linked_list.py
@@ -1,5 +1,5 @@
 class Node(object):
-    def __init__(self, value, next=None, previous=None):
+    def __init__(self, value, succeeding=None, previous=None):
         pass
 
 


### PR DESCRIPTION
It hurts readability to redefine the meaning of well-known builtins such
as 'next', and pylint rightfully warns about this, saying

  W:  2,30: Redefining built-in 'next' (redefined-builtin)

It's a little unfortunate that Python grabs this part of the namespace,
but let's fix the issue by using slightly different words for 'the item
before' and the 'the item next'.