### PR TITLE
Add test for saddle points in row

### DIFF
--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -10,7 +10,7 @@ import unittest
 from saddle_points import saddle_points
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class SaddlePointsTest(unittest.TestCase):
     def test_identify_single_saddle_point(self):
@@ -30,7 +30,7 @@ class SaddlePointsTest(unittest.TestCase):
         self.assertEqual(saddle_points(matrix), expected)
 
     def test_identify_multiple_saddle_points_in_row(self):
-        matrix = [[6, 7, 8], [5, 5, 5], [6, 5, 6]]
+        matrix = [[6, 7, 8], [5, 5, 5], [7, 5, 6]]
         expected = set([(1, 0), (1, 1), (1, 2)])
         self.assertEqual(saddle_points(matrix), expected)
 

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -29,6 +29,11 @@ class SaddlePointsTest(unittest.TestCase):
         expected = set([(0, 1), (1, 1), (2, 1)])
         self.assertEqual(saddle_points(matrix), expected)
 
+    def test_identify_multiple_saddle_points_in_row(self):
+        matrix = [[6, 7, 8], [5, 5, 5], [6, 5, 6]]
+        expected = set([(1, 0), (1, 1), (1, 2)])
+        self.assertEqual(saddle_points(matrix), expected)
+
     def test_identify_saddle_point_in_bottom_right_corner(self):
         matrix = [[8, 7, 9], [6, 7, 6], [3, 2, 5]]
         expected = set([(2, 2)])

--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -24,7 +24,7 @@ class SaddlePointsTest(unittest.TestCase):
         matrix = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]
         self.assertEqual(saddle_points(matrix), set())
 
-    def test_identify_multiple_saddle_points(self):
+    def test_identify_multiple_saddle_points_in_column(self):
         matrix = [[4, 5, 4], [3, 5, 5], [1, 5, 4]]
         expected = set([(0, 1), (1, 1), (2, 1)])
         self.assertEqual(saddle_points(matrix), expected)


### PR DESCRIPTION
There is a test for multiple saddle points in a column, but there is no test for multiple points in a row. 

These changes rename the existing test to indicate it tests for saddle points in a column and adds a test for multiple points in a row.