### PR TITLE
saddle-points: Add tests for non-square matrices

### DIFF
--- a/exercises/saddle-points/saddle_points_test.py
+++ b/exercises/saddle-points/saddle_points_test.py
@@ -10,7 +10,7 @@ import unittest
 from saddle_points import saddle_points
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
 
 class SaddlePointsTest(unittest.TestCase):
     def test_identify_single_saddle_point(self):
@@ -19,6 +19,10 @@ class SaddlePointsTest(unittest.TestCase):
 
     def test_empty_matrix_has_no_saddle_points(self):
         self.assertEqual(saddle_points([]), set())
+
+    def test_matrix_with_one_elem_has_single_saddle_point(self):
+        matrix = [[1]]
+        self.assertEqual(saddle_points(matrix), set([(0, 0)]))
 
     def test_identify_lack_of_saddle_points_when_there_are_none(self):
         matrix = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]
@@ -38,6 +42,18 @@ class SaddlePointsTest(unittest.TestCase):
         matrix = [[8, 7, 9], [6, 7, 6], [3, 2, 5]]
         expected = set([(2, 2)])
         self.assertEqual(saddle_points(matrix), expected)
+
+    def test_non_square_matrix_with_2_saddle_points(self):
+        matrix = [[3, 1, 3], [3, 2, 4]]
+        self.assertEqual(saddle_points(matrix), set([(0, 2), (0, 0)]))
+
+    def test_single_column_matrix_has_saddle_point_min_value(self):
+        matrix = [[2], [1], [4], [1]]
+        self.assertEqual(saddle_points(matrix), set([(1, 0), (3, 0)]))
+
+    def test_single_row_matrix_has_saddle_point_in_max_value(self):
+        matrix = [[2, 5, 3, 5]]
+        self.assertEqual(saddle_points(matrix), set([(0, 1), (0, 3)]))
 
     # Additional tests for this track
 


### PR DESCRIPTION
The saddle-points exercise made no indication that it was just for NxN matrices but tests for NxM matrices were non-existent.

This pull request depends on the successful merge of [exercism/problem-specifications/pull/1288](https://github.com/exercism/problem-specifications/pull/1288)

