### PR TITLE
Add a test case to prevent favoring the first books

### DIFF
--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -30,6 +30,9 @@ class BookStoreTest(unittest.TestCase):
     def test_two_groups_of_4_is_cheaper_than_group_of_5_plus_group_of_3(self):
         self.assertEqual(calculate_total([1, 1, 2, 2, 3, 3, 4, 5]), 5120)
 
+    def test_two_groups_of_4_is_best_without_favoring_first_books(self):
+        self.assertEqual(calculate_total([1, 1, 2, 3, 4, 4, 5, 5]), 5120)
+
     def test_group_of_4_plus_group_of_2_is_cheaper_than_2_groups_of_3(self):
         self.assertEqual(calculate_total([1, 1, 2, 2, 3, 4]), 4080)
 


### PR DESCRIPTION
The previously existing `test_two_groups_of_4...` had multiple copies of the
first few books, which allowed a solution that greedily added books in order to
pass the tests despite not handling all cases correctly. This is one of those
cases, added to prevent that.