### PR TITLE
affine-cipher: implement exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1377,9 +1377,6 @@
       "topics": [
         "algorithms",
         "cryptography",
-        "exception_handling",
-        "loops",
-        "math",
         "strings"
       ]
     },

--- a/config.json
+++ b/config.json
@@ -1369,19 +1369,19 @@
       ]
     },
     {
-        "slug": "affine-cipher",
-        "uuid": "02bf6783-fc74-47e9-854f-44d22eb1b6f8",
-        "core": false,
-        "unlocked_by": "atbash-cipher",
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "cryptography",
-          "exception_handling",
-          "loops",
-          "math",
-          "strings"
-        ]
+      "slug": "affine-cipher",
+      "uuid": "02bf6783-fc74-47e9-854f-44d22eb1b6f8",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "exception_handling",
+        "loops",
+        "math",
+        "strings"
+      ]
     },
     {
       "slug": "accumulate",

--- a/config.json
+++ b/config.json
@@ -1369,6 +1369,21 @@
       ]
     },
     {
+        "slug": "affine-cipher",
+        "uuid": "02bf6783-fc74-47e9-854f-44d22eb1b6f8",
+        "core": false,
+        "unlocked_by": "atbash-cipher",
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "cryptography",
+          "exception_handling",
+          "loops",
+          "math",
+          "strings"
+        ]
+    },
+    {
       "slug": "accumulate",
       "uuid": "e7351e8e-d3ff-4621-b818-cd55cf05bffd",
       "core": false,

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -1,0 +1,119 @@
+# Affine Cipher
+
+Create an implementation of the affine cipher,
+an ancient encryption system created in the Middle East.
+ 
+The affine cipher is a type of monoalphabetic substitution cipher.
+Each character is mapped to its numeric equivalent, encrypted with
+a mathematical function and then converted to the letter relating to
+its new numeric value. Although all monoalphabetic ciphers are weak,
+the affine cypher is much stronger than the atbash cipher,
+because it has many more keys.
+ 
+the encryption function is:
+ 
+  `E(x) = (ax + b) mod m`
+  -  where `x` is the letter's index from 0 - length of alphabet - 1
+  -  `m` is the length of the alphabet. For the roman alphabet `m == 26`.
+  -  and `a` and `b` make the key
+ 
+the decryption function is:
+ 
+  `D(y) = a^-1(y - b) mod m`
+  -  where `y` is the numeric value of an encrypted letter, ie. `y = E(x)`
+  -  it is important to note that `a^-1` is the modular multiplicative inverse
+     of `a mod m`
+  -  the modular multiplicative inverse of `a` only exists if `a` and `m` are
+     coprime.
+ 
+To find the MMI of `a`:
+
+  `an mod m = 1`
+  -  where `n` is the modular multiplicative inverse of `a mod m`
+
+More information regarding how to find a Modular Multiplicative Inverse
+and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse) 
+
+Because automatic decryption fails if `a` is not coprime to `m` your
+program should return status 1 and `"Error: a and m must be coprime."`
+if they are not.  Otherwise it should encode or decode with the
+provided key.
+ 
+The Caesar (shift) cipher is a simple affine cipher where `a` is 1 and
+`b` as the magnitude results in a static displacement of the letters.
+This is much less secure than a full implementation of the affine cipher.
+
+Ciphertext is written out in groups of fixed length, the traditional group
+size being 5 letters, and punctuation is excluded. This is to make it
+harder to guess things based on word boundaries.
+
+## Examples
+ 
+ - Encoding `test` gives `ybty` with the key a=5 b=7
+ - Decoding `ybty` gives `test` with the key a=5 b=7
+ - Decoding `ybty` gives `lqul` with the wrong key a=11 b=7
+ - Decoding `kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx`
+   - gives `thequickbrownfoxjumpsoverthelazydog` with the key a=19 b=13
+ - Encoding `test` with the key a=18 b=13
+   - gives `Error: a and m must be coprime.`
+   - because a and m are not relatively prime
+
+### Examples of finding a Modular Multiplicative Inverse (MMI)
+
+  - simple example:
+    - `9 mod 26 = 9`
+    - `9 * 3 mod 26 = 27 mod 26 = 1`
+    - `3` is the MMI of `9 mod 26`
+  - a more complicated example:
+    - `15 mod 26 = 15`
+    - `15 * 7 mod 26 = 105 mod 26 = 1`
+    - `7` is the MMI of `15 mod 26`
+
+## Exception messages
+
+Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
+indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. Not
+every exercise will require you to raise an exception, but for those that do, the tests will only pass if you include
+a message.
+
+To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
+`raise Exception`, you should write:
+
+```python
+raise Exception("Meaningful message indicating the source of the error")
+```
+
+## Running the tests
+
+To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+
+- Python 2.7: `py.test affine_cipher_test.py`
+- Python 3.4+: `pytest affine_cipher_test.py`
+
+Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+`python -m pytest affine_cipher_test.py`
+
+### Common `pytest` options
+
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`
+
+## Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/python/affine-cipher` directory.
+
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Workspace`.
+
+For more detailed information about running tests, code style and linting,
+please see [Running the Tests](http://exercism.io/tracks/python/tests).
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Affine_cipher](http://en.wikipedia.org/wiki/Affine_cipher)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/affine-cipher/affine_cipher.py
+++ b/exercises/affine-cipher/affine_cipher.py
@@ -1,0 +1,6 @@
+def encode(plain_text, a, b):
+    pass
+
+
+def decode(ciphered_text, a, b):
+    pass

--- a/exercises/affine-cipher/affine_cipher_test.py
+++ b/exercises/affine-cipher/affine_cipher_test.py
@@ -1,0 +1,68 @@
+import unittest
+
+from affine_cipher import decode, encode
+
+
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
+
+class AffineCipherTest(unittest.TestCase):
+    def test_encode_yes(self):
+        self.assertMultiLineEqual(encode("yes", 5, 7), "xbt")
+
+    def test_encode_no(self):
+        self.assertMultiLineEqual(encode("no", 15, 18), "fu")
+
+    def test_encode_OMG(self):
+        self.assertMultiLineEqual(encode("OMG", 21, 3), "lvz")
+
+    def test_encode_O_M_G(self):
+        self.assertMultiLineEqual(encode("O M G", 25, 47), "hjp")
+
+    def test_encode_mindblowingly(self):
+        self.assertMultiLineEqual(encode("mindblowingly", 11, 15),
+                                  "rzcwa gnxzc dgt")
+
+    def test_encode_numbers(self):
+        self.assertMultiLineEqual(encode("Testing,1 2 3, testing.", 3, 4),
+                                  "jqgjc rw123 jqgjc rw")
+
+    def test_encode_deep_thought(self):
+        self.assertMultiLineEqual(encode("Truth is fiction.", 5, 17),
+                                  "iynia fdqfb ifje")
+
+    def test_encode_all_the_letters(self):
+        self.assertMultiLineEqual(
+            encode("The quick brown fox jumps over the lazy dog.", 17, 33),
+            "swxtj npvyk lruol iejdc blaxk swxmh qzglf")
+
+    def test_encode_with_a_not_coprime_to_alphabet_size(self):
+        self.assertRaises(ValueError, encode, "This is a test.", 6, 17)
+
+    def test_decode_exercism(self):
+        self.assertMultiLineEqual(decode("tytgn fjr", 3, 7), "exercism")
+
+    def test_decode_sentence(self):
+        self.assertMultiLineEqual(
+        decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
+            "anobstacleisoftenasteppingstone")
+
+    def test_decode_numbers(self):
+        self.assertMultiLineEqual(decode("odpoz ub123 odpoz ub", 25, 7),
+                                  "testing123testing")
+
+    def test_decode_all_the_letters(self):
+        self.assertMultiLineEqual(
+            decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf", 17, 33),
+            "thequickbrownfoxjumpsoverthelazydog")
+
+    def test_decode_with_no_spaces(self):
+        self.assertMultiLineEqual(
+            decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf", 17, 33),
+            "thequickbrownfoxjumpsoverthelazydog")
+
+    def test_decode_with_too_many_spaces(self):
+        self.assertMultiLineEqual(decode("vszzm    cly   yd cg    qdp", 15, 16),
+                                  "jollygreengiant")
+
+    def test_decode_with_a_not_coprime_to_alphabet_size(self):
+        self.assertRaises(ValueError, decode, "Test", 13, 5)

--- a/exercises/affine-cipher/affine_cipher_test.py
+++ b/exercises/affine-cipher/affine_cipher_test.py
@@ -7,62 +7,77 @@ from affine_cipher import decode, encode
 
 class AffineCipherTest(unittest.TestCase):
     def test_encode_yes(self):
-        self.assertMultiLineEqual(encode("yes", 5, 7), "xbt")
+        self.assertEqual(encode("yes", 5, 7), "xbt")
 
     def test_encode_no(self):
-        self.assertMultiLineEqual(encode("no", 15, 18), "fu")
+        self.assertEqual(encode("no", 15, 18), "fu")
 
     def test_encode_OMG(self):
-        self.assertMultiLineEqual(encode("OMG", 21, 3), "lvz")
+        self.assertEqual(encode("OMG", 21, 3), "lvz")
 
     def test_encode_O_M_G(self):
-        self.assertMultiLineEqual(encode("O M G", 25, 47), "hjp")
+        self.assertEqual(encode("O M G", 25, 47), "hjp")
 
     def test_encode_mindblowingly(self):
-        self.assertMultiLineEqual(encode("mindblowingly", 11, 15),
-                                  "rzcwa gnxzc dgt")
+        self.assertEqual(encode("mindblowingly", 11, 15), "rzcwa gnxzc dgt")
 
     def test_encode_numbers(self):
-        self.assertMultiLineEqual(encode("Testing,1 2 3, testing.", 3, 4),
-                                  "jqgjc rw123 jqgjc rw")
+        self.assertEqual(encode("Testing,1 2 3, testing.", 3, 4),
+                         "jqgjc rw123 jqgjc rw")
 
     def test_encode_deep_thought(self):
-        self.assertMultiLineEqual(encode("Truth is fiction.", 5, 17),
-                                  "iynia fdqfb ifje")
+        self.assertEqual(encode("Truth is fiction.", 5, 17),
+                         "iynia fdqfb ifje")
 
     def test_encode_all_the_letters(self):
-        self.assertMultiLineEqual(
+        self.assertEqual(
             encode("The quick brown fox jumps over the lazy dog.", 17, 33),
             "swxtj npvyk lruol iejdc blaxk swxmh qzglf")
 
-    def test_encode_with_a_not_coprime_to_alphabet_size(self):
-        self.assertRaises(ValueError, encode, "This is a test.", 6, 17)
+    def test_encode_raises_meaningful_exception(self):
+        with self.assertRaisesWithMessage(ValueError):
+            encode("This is a test", 6, 17)
 
     def test_decode_exercism(self):
-        self.assertMultiLineEqual(decode("tytgn fjr", 3, 7), "exercism")
+        self.assertEqual(decode("tytgn fjr", 3, 7), "exercism")
 
     def test_decode_sentence(self):
-        self.assertMultiLineEqual(
+        self.assertEqual(
             decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
             "anobstacleisoftenasteppingstone")
 
     def test_decode_numbers(self):
-        self.assertMultiLineEqual(decode("odpoz ub123 odpoz ub", 25, 7),
-                                  "testing123testing")
+        self.assertEqual(decode("odpoz ub123 odpoz ub", 25, 7),
+                         "testing123testing")
 
     def test_decode_all_the_letters(self):
-        self.assertMultiLineEqual(
+        self.assertEqual(
             decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf", 17, 33),
             "thequickbrownfoxjumpsoverthelazydog")
 
     def test_decode_with_no_spaces(self):
-        self.assertMultiLineEqual(
+        self.assertEqual(
             decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf", 17, 33),
             "thequickbrownfoxjumpsoverthelazydog")
 
     def test_decode_with_too_many_spaces(self):
-        self.assertMultiLineEqual(
+        self.assertEqual(
             decode("vszzm    cly   yd cg    qdp", 15, 16), "jollygreengiant")
 
-    def test_decode_with_a_not_coprime_to_alphabet_size(self):
-        self.assertRaises(ValueError, decode, "Test", 13, 5)
+    def test_decode_raises_meaningful_exception(self):
+        with self.assertRaisesWithMessage(ValueError):
+            decode("Test", 13, 5)
+
+    # Utility functions
+    def setUp(self):
+        try:
+            self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/exercises/affine-cipher/affine_cipher_test.py
+++ b/exercises/affine-cipher/affine_cipher_test.py
@@ -43,7 +43,7 @@ class AffineCipherTest(unittest.TestCase):
 
     def test_decode_sentence(self):
         self.assertMultiLineEqual(
-        decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
+            decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
             "anobstacleisoftenasteppingstone")
 
     def test_decode_numbers(self):
@@ -61,8 +61,8 @@ class AffineCipherTest(unittest.TestCase):
             "thequickbrownfoxjumpsoverthelazydog")
 
     def test_decode_with_too_many_spaces(self):
-        self.assertMultiLineEqual(decode("vszzm    cly   yd cg    qdp", 15, 16),
-                                  "jollygreengiant")
+        self.assertMultiLineEqual(
+            decode("vszzm    cly   yd cg    qdp", 15, 16), "jollygreengiant")
 
     def test_decode_with_a_not_coprime_to_alphabet_size(self):
         self.assertRaises(ValueError, decode, "Test", 13, 5)

--- a/exercises/affine-cipher/example.py
+++ b/exercises/affine-cipher/example.py
@@ -1,0 +1,41 @@
+BLKSZ = 5
+ALPHSZ = 26
+
+
+def modInverse(a, ALPHSZ):
+    a = a % ALPHSZ
+    for x in range(1, ALPHSZ):
+        if ((a * x) % ALPHSZ == 1):
+            return x
+    return 1
+
+
+def translate(text, a, b, mode):
+    inv = modInverse(a, ALPHSZ)
+    if inv == 1:
+        raise ValueError("a and alphabet size must be coprime.")
+
+    chars = []
+    for c in text:
+        if c.isalnum():
+            orig = ord(c.lower()) - 97
+            if orig < 0:
+                chars.append(c)
+                continue
+            if mode == 0:
+                new = (a * orig + b) % ALPHSZ
+            elif mode == 1:
+                new = (inv * (orig - b)) % ALPHSZ
+            chars.append(chr(new + 97))
+
+    return ''.join(chars)
+
+
+def encode(plain, a, b):
+    cipher = translate(plain, a, b, 0)
+    return " ".join([cipher[i:i + BLKSZ]
+                     for i in range(0, len(cipher), BLKSZ)])
+
+
+def decode(ciphered, a, b):
+    return translate(ciphered, a, b, 1)


### PR DESCRIPTION
Closes #1448. [Canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/affine-cipher/canonical-data.json)