### PR TITLE
grains: updated tests to v1.2.0

### DIFF
--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -6,7 +6,7 @@ from grains import (
 )
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class GrainsTest(unittest.TestCase):
     def test_square_1(self):


### PR DESCRIPTION
Closes #1504

Note that no changes were made to the tests since Python is in-line with the [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/grains/canonical-data.json). The canonical-data was updated to have error objects instead of -1 when an error would occur, and the Python tests are already in-line with that policy.