### PR TITLE
forth: Refactor duplicate utility functions

### DIFF
--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -5,14 +5,26 @@ from forth import evaluate, StackUnderflowError
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.6.0
 
-class ForthParsingTest(unittest.TestCase):
+class ForthUtilities(unittest.TestCase):
+    # Utility functions
+    def setUp(self):
+        try:
+            self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
+
+
+class ForthParsingTest(ForthUtilities):
     def test_numbers_just_get_pushed_to_stack(self):
         input_data = ["1 2 3 4 5"]
         expected = [1, 2, 3, 4, 5]
         self.assertEqual(evaluate(input_data), expected)
 
 
-class ForthAdditionTest(unittest.TestCase):
+class ForthAdditionTest(ForthUtilities):
     def test_can_add_two_numbers(self):
         input_data = ["1 2 +"]
         expected = [3]
@@ -28,18 +40,8 @@ class ForthAdditionTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthSubtractionTest(unittest.TestCase):
+class ForthSubtractionTest(ForthUtilities):
     def test_can_subtract_two_numbers(self):
         input_data = ["3 4 -"]
         expected = [-1]
@@ -55,18 +57,8 @@ class ForthSubtractionTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthMultiplicationTest(unittest.TestCase):
+class ForthMultiplicationTest(ForthUtilities):
     def test_can_multiply_two_numbers(self):
         input_data = ["2 4 *"]
         expected = [8]
@@ -82,18 +74,8 @@ class ForthMultiplicationTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthDivisionTest(unittest.TestCase):
+class ForthDivisionTest(ForthUtilities):
     def test_can_divide_two_numbers(self):
         input_data = ["12 3 /"]
         expected = [4]
@@ -119,18 +101,8 @@ class ForthDivisionTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthCombinedArithmeticTest(unittest.TestCase):
+class ForthCombinedArithmeticTest(ForthUtilities):
     def test_addition_and_subtraction(self):
         input_data = ["1 2 + 4 -"]
         expected = [-1]
@@ -142,7 +114,7 @@ class ForthCombinedArithmeticTest(unittest.TestCase):
         self.assertEqual(evaluate(input_data), expected)
 
 
-class ForthDupTest(unittest.TestCase):
+class ForthDupTest(ForthUtilities):
     def test_copies_a_value_on_the_stack(self):
         input_data = ["1 dup"]
         expected = [1, 1]
@@ -158,18 +130,8 @@ class ForthDupTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthDropTest(unittest.TestCase):
+class ForthDropTest(ForthUtilities):
     def test_removes_the_top_value_on_the_stack_if_it_is_the_only_one(self):
         input_data = ["1 DROP"]
         expected = []
@@ -185,18 +147,8 @@ class ForthDropTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthSwapTest(unittest.TestCase):
+class ForthSwapTest(ForthUtilities):
     def test_swaps_only_two_values_on_stack(self):
         input_data = ["1 2 SWAP"]
         expected = [2, 1]
@@ -217,18 +169,8 @@ class ForthSwapTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthOverTest(unittest.TestCase):
+class ForthOverTest(ForthUtilities):
     def test_copies_the_second_element_if_there_are_only_two(self):
         input_data = ["1 2 OVER"]
         expected = [1, 2, 1]
@@ -249,18 +191,8 @@ class ForthOverTest(unittest.TestCase):
         with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthUserDefinedWordsTest(unittest.TestCase):
+class ForthUserDefinedWordsTest(ForthUtilities):
     def test_can_consist_of_built_in_words(self):
         input_data = [
             ": dup-twice dup dup ;",
@@ -331,18 +263,8 @@ class ForthUserDefinedWordsTest(unittest.TestCase):
         with self.assertRaisesWithMessage(ValueError):
             evaluate(input_data)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-class ForthCaseInsensitivityTest(unittest.TestCase):
+class ForthCaseInsensitivityTest(ForthUtilities):
     def test_dup_is_case_insensitive(self):
         input_data = ["1 DUP Dup dup"]
         expected = [1, 1, 1, 1]


### PR DESCRIPTION
Define utility functions in a utility class that inherits
from 'unittest.TestCase'. The test classes inherit from the utility
class.

Reduces line count from 384 to 307. It should also make it easier
for a user to comment out tests without mistakenly breaking
previous tests by commenting out their utility functions.

Resolves #1514 