### PR TITLE
pythagorean-triplet: Update exercise to v1.0.0

### DIFF
--- a/exercises/pythagorean-triplet/example.py
+++ b/exercises/pythagorean-triplet/example.py
@@ -1,6 +1,3 @@
-from math import gcd
-
-
 def triplets_in_range(min, max):
     result = set([x for b in
                   range(4, max + 1, 4) for x in
@@ -11,11 +8,17 @@ def triplets_in_range(min, max):
             if a >= min:
                 result.add((a, b, c))
             a, b, c = (a + x, b + y, c + z)
-    return set([(a, b, c) for a, b, c in result if a >= min and c <= max])
+    return set([(d, e, f) for d, e, f in result if d >= min and f <= max])
 
 
 def maxMin(a, b):
     return (a, b) if a > b else (b, a)
+
+
+def gcd(x, y):
+    while (y != 0):
+        x, y = y, x % y
+    return x
 
 
 def primitive_triplets(b):

--- a/exercises/pythagorean-triplet/example.py
+++ b/exercises/pythagorean-triplet/example.py
@@ -1,70 +1,45 @@
-from itertools import product
-from functools import reduce
-from operator import mul
-from math import sqrt
+from math import gcd
 
 
-def primitive_triplets(nbr):
-    if nbr % 4 != 0:
-        raise ValueError('Argument must be divisible by 4')
-    prime_factors, powers = factor(nbr / 2)
-    args = [(1, prime_factors[i1] ** powers[i1]) for i1 in range(len(powers))]
-    a = [reduce(mul, p) for p in product(*args)]
-    a.sort()
-    factors = [(m, n) for m, n in zip(reversed(a), a) if m > n]
-    ts = set()
-    for m, n in factors:
-        ts.update([tuple(sorted([nbr, m * m - n * n, m * m + n * n]))])
-    return ts
+def triplets_in_range(min, max):
+    result = set([x for b in
+                  range(4, max + 1, 4) for x in
+                  primitive_triplets(b)])
+    for x, y, z in set(result):
+        a, b, c = (2 * x, 2 * y, 2 * z)
+        while c <= max:
+            if a >= min:
+                result.add((a, b, c))
+            a, b, c = (a + x, b + y, c + z)
+    return set([(a, b, c) for a, b, c in result if a >= min and c <= max])
 
 
-def is_triplet(t):
-    t = list(t)
-    t.sort()
-    a, b, c = t
-    return c * c == a * a + b * b
+def maxMin(a, b):
+    return (a, b) if a > b else (b, a)
 
 
-def triplets_in_range(m, n):
-    t = set()
-    for a in range(m, n + 1):
-        for b in range(a + 1, n + 1):
-            c = int(sqrt(a * a + b * b) + 0.5)
-            if c * c == a * a + b * b and c >= m and c <= n:
-                t.update([(a, b, c)])
-    return t
+def primitive_triplets(b):
+    if b % 4 != 0:
+        raise ValueError('b must be divisible by 4')
+    b2 = int(b / 2)
+    return set([(x[1], x[0], c) for x, c in
+                [(maxMin(m2 - n2, b), m2 + n2) for m, n, m2, n2 in
+                 [(m, n, int(m * m), int(n * n)) for m, n in
+                  set([maxMin(m, int(b2 / m)) for m in
+                       range(2, b2 + 1)
+                       if b2 % m == 0])
+                  if (m - n) % 2 == 1 and gcd(m, n) == 1]]])
 
 
-primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,
-          67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137,
-          139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211,
-          223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283,
-          293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379,
-          383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461,
-          463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563,
-          569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643,
-          647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739,
-          743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829,
-          839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937,
-          941, 947, 953, 967, 971, 977, 983, 991, 997]
+def is_triplet(x):
+    a, b, c = sorted(x)
+    return a * a + b * b == c * c
 
 
-def factor(n):
-    global primes
-    if n == 1:
-        return (1,), (0,)
-    factors = []
-    powers = []
-    idx = 0
-    while n > 1:
-        prime = primes[idx]
-        idx += 1
-        if n % prime != 0:
-            continue
-        factors.append(prime)
-        p = 0
-        while n % prime == 0:
-            p += 1
-            n /= prime
-        powers.append(p)
-    return factors, powers
+def triplets_with_sum(triplet_sum):
+    triplets = triplets_in_range(1, triplet_sum // 2)
+    output = set()
+    for triplet in triplets:
+        if sum(triplet) == triplet_sum:
+            output.add(triplet)
+    return output

--- a/exercises/pythagorean-triplet/pythagorean_triplet.py
+++ b/exercises/pythagorean-triplet/pythagorean_triplet.py
@@ -1,4 +1,4 @@
-def primitive_triplets(number_in_triplet):
+def triplets_with_sum(sum_of_triplet):
     pass
 
 

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.py
@@ -1,10 +1,6 @@
 import unittest
 
-from pythagorean_triplet import (
-    triplets_with_sum,
-    triplets_in_range,
-    is_triplet
-)
+from pythagorean_triplet import triplets_with_sum
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
@@ -13,18 +9,18 @@ class PythagoreanTripletTest(unittest.TestCase):
     def test_triplets_sum_12(self):
         expected = set([(3, 4, 5)])
         self.assertEqual(triplets_with_sum(12), expected)
-    
+
     def test_triplets_sum_108(self):
         expected = set([(27, 36, 45)])
-        self.assertEqual(triplets_with_sum(108), expected) 
-        
+        self.assertEqual(triplets_with_sum(108), expected)
+
     def test_triplets_sum_1000(self):
         expected = set([(200, 375, 425)])
         self.assertEqual(triplets_with_sum(1000), expected)
 
     def test_no_triplet_exists(self):
         expected = set([])
-        self.assertEqual(triplets_with_sum(1001), expected)  
+        self.assertEqual(triplets_with_sum(1001), expected)
 
     def test_two_matching_triplets(self):
         expected = set([(9, 40, 41), (15, 36, 39)])
@@ -38,15 +34,15 @@ class PythagoreanTripletTest(unittest.TestCase):
                         (140, 336, 364),
                         (168, 315, 357),
                         (210, 280, 350),
-                        (240, 252, 348),])
+                        (240, 252, 348)])
         self.assertEqual(triplets_with_sum(840), expected)
-        
+
     def test_triplets_for_large_numbers(self):
         expected = set([(1200, 14375, 14425),
                         (1875, 14000, 14125),
                         (5000, 12000, 13000),
                         (6000, 11250, 12750),
-                        (7500, 10000, 12500),])
+                        (7500, 10000, 12500)])
         self.assertEqual(triplets_with_sum(30000), expected)
 
 

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.py
@@ -1,97 +1,53 @@
-#
-# =============================================================================
-# The test cases below assume two functions are defined:
-#
-#   - triplets_in_range(min, max)
-#       Compute all pythagorean triplets (a,b,c) with min <= a,b,c <= max
-#
-#   - primitive_triplets(b)
-#       Find all primitive pythagorean triplets having b as one of their
-#       components
-#
-#       Args:
-#          b - an integer divisible by 4 (see explanantion below)
-#
-# Note that in the latter function the components other than the argument can
-# be quite large.
-#
-# A primitive pythagorean triplet has its 3 componentes coprime. So, (3,4,5) is
-# a primitive pythagorean triplet since 3,4 and 5 don't have a common factor.
-# On the other hand, (6,8,10), although a pythagorean triplet, is not primitive
-# since 2 divides all three components.
-#
-# A method for finding all primitive pythagorean triplet is given in wikipedia
-# (http://en.wikipedia.org/wiki/Pythagorean_triple#Generating_a_triple). The
-# triplet a=(m^2-n^2), b=2*m*n and c=(m^2+n^2), where m and n are coprime and
-# m-n>0 is odd, generate a primitive triplet. Note that this implies that b has
-# to be divisible by 4 and a and c are odd. Also note that we may have either
-# a>b or b>a.
-#
-# The function primitive_triplets should then use the formula above with b set
-# to its argument and find all possible pairs (m,n) such that m>n, m-n is odd,
-# b=2*m*n and m and n are coprime.
-#
-# =============================================================================
-
 import unittest
 
 from pythagorean_triplet import (
-    primitive_triplets,
+    triplets_with_sum,
     triplets_in_range,
     is_triplet
 )
 
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 class PythagoreanTripletTest(unittest.TestCase):
-    def test_triplet1(self):
-        ans = set([(3, 4, 5)])
-        self.assertEqual(primitive_triplets(4), ans)
+    def test_triplets_sum_12(self):
+        expected = set([(3, 4, 5)])
+        self.assertEqual(triplets_with_sum(12), expected)
+    
+    def test_triplets_sum_108(self):
+        expected = set([(27, 36, 45)])
+        self.assertEqual(triplets_with_sum(108), expected) 
+        
+    def test_triplets_sum_1000(self):
+        expected = set([(200, 375, 425)])
+        self.assertEqual(triplets_with_sum(1000), expected)
 
-    def test_triplet2(self):
-        ans = set([(13, 84, 85), (84, 187, 205), (84, 437, 445),
-                   (84, 1763, 1765)])
-        self.assertEqual(primitive_triplets(84), ans)
+    def test_no_triplet_exists(self):
+        expected = set([])
+        self.assertEqual(triplets_with_sum(1001), expected)  
 
-    def test_triplet3(self):
-        ans = set([(29, 420, 421), (341, 420, 541), (420, 851, 949),
-                   (420, 1189, 1261), (420, 1739, 1789), (420, 4891, 4909),
-                   (420, 11021, 11029), (420, 44099, 44101)])
-        self.assertEqual(primitive_triplets(420), ans)
+    def test_two_matching_triplets(self):
+        expected = set([(9, 40, 41), (15, 36, 39)])
+        self.assertEqual(triplets_with_sum(90), expected)
 
-    def test_triplet4(self):
-        ans = set([(175, 288, 337), (288, 20735, 20737)])
-        self.assertEqual(primitive_triplets(288), ans)
-
-    def test_range1(self):
-        ans = set([(3, 4, 5), (6, 8, 10)])
-        self.assertEqual(triplets_in_range(1, 10), ans)
-
-    def test_range2(self):
-        ans = set([(57, 76, 95), (60, 63, 87)])
-        self.assertEqual(triplets_in_range(56, 95), ans)
-
-    def test_is_triplet1(self):
-        self.assertIs(is_triplet((29, 20, 21)), True)
-
-    def test_is_triplet2(self):
-        self.assertIs(is_triplet((25, 25, 1225)), False)
-
-    def test_is_triplet3(self):
-        self.assertIs(is_triplet((924, 43, 925)), True)
-
-    def test_odd_number(self):
-        with self.assertRaisesWithMessage(ValueError):
-            primitive_triplets(5)
-
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
+    def test_several_matching_triplets(self):
+        expected = set([(40, 399, 401),
+                        (56, 390, 394),
+                        (105, 360, 375),
+                        (120, 350, 370),
+                        (140, 336, 364),
+                        (168, 315, 357),
+                        (210, 280, 350),
+                        (240, 252, 348),])
+        self.assertEqual(triplets_with_sum(840), expected)
+        
+    def test_triplets_for_large_numbers(self):
+        expected = set([(1200, 14375, 14425),
+                        (1875, 14000, 14125),
+                        (5000, 12000, 13000),
+                        (6000, 11250, 12750),
+                        (7500, 10000, 12500),])
+        self.assertEqual(triplets_with_sum(30000), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Modify tests to fit latest canonical data. Add additional function to
find triplets with sum. Remove primitive triplets function from
exercise. Replace example.py with @cmccandless solution (with
permission). New solution runs considerably faster.

Brute force solutions that do not use primitive triplets will now
take very long. Perhaps hint should be added. This could be discussed
in problem-specifications.

Resolves #1510