### PR TITLE
phone-number: set correct canonical-data version

### DIFF
--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -3,7 +3,7 @@ import unittest
 from phone_number import Phone
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.6.0
 
 class PhoneNumberTest(unittest.TestCase):
     def test_cleans_number(self):


### PR DESCRIPTION
These tests were updated in #1532 to v1.6.0, but the referenced version
was not updated.