### PR TITLE
Escaped backslash due to `DeprecationWarning`

### DIFF
--- a/exercises/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/sgf-parsing/sgf_parsing_test.py
@@ -75,7 +75,7 @@ class SgfParsingTest(unittest.TestCase):
         self.assertEqual(parse(input_string), expected)
 
     def test_escaped_property(self):
-        input_string = '(;A[\]b\nc\nd\t\te \n\]])'
+        input_string = '(;A[\\]b\nc\nd\t\te \n\\]])'
         expected = SgfTree(
             properties={'A': [']b\nc\nd  e \n]']}
         )


### PR DESCRIPTION
Added an escaped backslash due to `DeprecationWarning: invalid escape sequence \]`.