### PR TITLE
rest-api: update tests to v1.0.2

### DIFF
--- a/exercises/rest-api/rest_api_test.py
+++ b/exercises/rest-api/rest_api_test.py
@@ -4,7 +4,7 @@ import json
 from rest_api import RestAPI
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.2
 
 class RestAPITest(unittest.TestCase):
     def test_no_users(self):


### PR DESCRIPTION
Simple version bump, since https://github.com/exercism/problem-specifications/commit/fd4cb7bd8f30dd10a024b0b8cfa92f8a1442e828 just changes an int to float. Fixes  #1553 .