### PR TITLE
Update rest_api_test.py `get_single_user` case

### DIFF
--- a/exercises/rest-api/rest_api_test.py
+++ b/exercises/rest-api/rest_api_test.py
@@ -47,7 +47,7 @@ class RestAPITest(unittest.TestCase):
         }
         api = RestAPI(database)
         payload = json.dumps({
-            'users': 'Bob'
+            'users': ['Bob']
         })
         response = api.get('/users', payload)
         expected = {


### PR DESCRIPTION
In the [problem specification](https://github.com/exercism/problem-specifications/blob/master/exercises/rest-api/canonical-data.json) (as well as the [README](https://github.com/exercism/problem-specifications/blob/master/exercises/rest-api/description.md)), the GET `/users` endpoint is listed with a payload pattern:

```
{"users": ["Adam", "Bob"]}
```

The canonical tests reflect that pattern in the "one user" case:

```
{"users": ["Bob"]}
```

Note the presence of a list, even with only one user.  This seems correct to me because it makes a single user not a special case for the format of the payload, and no matter whether there's one or many users to GET, I can still do a `for user in users`.  The Python version of the test file was missing those square brackets.  So I added them.