### PR TITLE
bin/check-test-version: look for API token in .github.api_token

### DIFF
--- a/bin/check-test-version.py
+++ b/bin/check-test-version.py
@@ -297,6 +297,10 @@ if __name__ == '__main__':
     opts = parser.parse_args()
     verify_spec_location(opts.spec_path)
     if opts.create_issue:
+        if opts.token is None:
+            if os.path.isfile('.github.api_token'):
+                with open('.github.api_token') as f:
+                    opts.token = f.read().strip()
         if opts.token is not None:
             gh = GitHub(api_token=opts.token)
         else:


### PR DESCRIPTION
`--token` may still be used to override this.