### PR TITLE
Swap parameter order for Bob unit tests

### DIFF
--- a/exercises/bob/bob_test.py
+++ b/exercises/bob/bob_test.py
@@ -7,95 +7,94 @@ from bob import hey
 
 class BobTest(unittest.TestCase):
     def test_stating_something(self):
-        self.assertEqual(hey("Tom-ay-to, tom-aaaah-to."), "Whatever.")
+        self.assertEqual("Whatever.", hey("Tom-ay-to, tom-aaaah-to."))
 
     def test_shouting(self):
-        self.assertEqual(hey("WATCH OUT!"), "Whoa, chill out!")
+        self.assertEqual("Whoa, chill out!", hey("WATCH OUT!"))
 
     def test_shouting_gibberish(self):
-        self.assertEqual(hey("FCECDFCAAB"), "Whoa, chill out!")
+        self.assertEqual("Whoa, chill out!", hey("FCECDFCAAB"))
 
     def test_asking_a_question(self):
         self.assertEqual(
-            hey("Does this cryogenic chamber make me look fat?"), "Sure.")
+            "Sure.", hey("Does this cryogenic chamber make me look fat?"))
 
     def test_asking_a_numeric_question(self):
-        self.assertEqual(hey("You are, what, like 15?"), "Sure.")
+        self.assertEqual("Sure.", hey("You are, what, like 15?"))
 
     def test_asking_gibberish(self):
-        self.assertEqual(hey("fffbbcbeab?"), "Sure.")
+        self.assertEqual("Sure.", hey("fffbbcbeab?"))
 
     def test_talking_forcefully(self):
         self.assertEqual(
-            hey("Let's go make out behind the gym!"), "Whatever.")
+            "Whatever.", hey("Let's go make out behind the gym!"))
 
     def test_using_acronyms_in_regular_speech(self):
         self.assertEqual(
-            hey("It's OK if you don't want to go to the DMV."),
-            "Whatever.")
+            "Whatever.",
+            hey("It's OK if you don't want to go to the DMV."))
 
     def test_forceful_question(self):
         self.assertEqual(
-            hey("WHAT THE HELL WERE YOU THINKING?"),
-            "Calm down, I know what I'm doing!"
-        )
+            "Calm down, I know what I'm doing!",
+            hey("WHAT THE HELL WERE YOU THINKING?"))
 
     def test_shouting_numbers(self):
-        self.assertEqual(hey("1, 2, 3 GO!"), "Whoa, chill out!")
+        self.assertEqual("Whoa, chill out!", hey("1, 2, 3 GO!"))
 
     def test_no_letters(self):
-        self.assertEqual(hey("1, 2, 3"), "Whatever.")
+        self.assertEqual("Whatever.", hey("1, 2, 3"))
 
     def test_question_with_no_letters(self):
-        self.assertEqual(hey("4?"), "Sure.")
+        self.assertEqual("Sure.", hey("4?"))
 
     def test_shouting_with_special_characters(self):
         self.assertEqual(
-            hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"),
-            "Whoa, chill out!")
+            "Whoa, chill out!",
+            hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"))
 
     def test_shouting_with_no_exclamation_mark(self):
-        self.assertEqual(hey("I HATE THE DMV"), "Whoa, chill out!")
+        self.assertEqual("Whoa, chill out!", hey("I HATE THE DMV"))
 
     def test_statement_containing_question_mark(self):
         self.assertEqual(
-            hey("Ending with ? means a question."), "Whatever.")
+            "Whatever.", hey("Ending with ? means a question."))
 
     def test_non_letters_with_question(self):
-        self.assertEqual(hey(":) ?"), "Sure.")
+        self.assertEqual("Sure.", hey(":) ?"))
 
     def test_prattling_on(self):
         self.assertEqual(
-            hey("Wait! Hang on. Are you going to be OK?"), "Sure.")
+            "Sure.", hey("Wait! Hang on. Are you going to be OK?"))
 
     def test_silence(self):
-        self.assertEqual(hey(""), "Fine. Be that way!")
+        self.assertEqual("Fine. Be that way!", hey(""))
 
     def test_prolonged_silence(self):
-        self.assertEqual(hey("          "), "Fine. Be that way!")
+        self.assertEqual("Fine. Be that way!", hey("          "))
 
     def test_alternate_silence(self):
-        self.assertEqual(hey("\t\t\t\t\t\t\t\t\t\t"), "Fine. Be that way!")
+        self.assertEqual("Fine. Be that way!", hey("\t\t\t\t\t\t\t\t\t\t"))
 
     def test_multiple_line_question(self):
         self.assertEqual(
-            hey("\nDoes this cryogenic chamber make me look fat?\nNo."),
-            "Whatever.")
+            "Whatever.",
+            hey("\nDoes this cryogenic chamber make me look fat?\nNo."))
 
     def test_starting_with_whitespace(self):
-        self.assertEqual(hey("         hmmmmmmm..."), "Whatever.")
+        self.assertEqual("Whatever.", hey("         hmmmmmmm..."))
 
     def test_ending_with_whitespace(self):
         self.assertEqual(
-            hey("Okay if like my  spacebar  quite a bit?   "), "Sure.")
+            "Sure.", hey("Okay if like my  spacebar  quite a bit?   "))
 
     def test_other_whitespace(self):
-        self.assertEqual(hey("\n\r \t"), "Fine. Be that way!")
+        self.assertEqual("Fine. Be that way!", hey("\n\r \t"))
 
     def test_non_question_ending_with_whitespace(self):
         self.assertEqual(
-            hey("This is a statement ending with whitespace      "),
-            "Whatever.")
+            "Whatever.",
+            hey("This is a statement ending with whitespace      "),)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the error messages more correct and helpful
since the testing framework expects the first parameter
to be "expected" and the second to be actual.

On an initial run, the first test would fail like this:

> Whatever. != None
>
> Expected :None
> Actual   :Whatever.

After this PR, the wording is corrected:

> None != Whatever.
>
> Expected :Whatever.
> Actual   :None