### PR TITLE
two-fer: Remove default parameter from solution stub

### DIFF
--- a/exercises/two-fer/two_fer.py
+++ b/exercises/two-fer/two_fer.py
@@ -1,2 +1,2 @@
-def two_fer():
+def two_fer(name):
     pass

--- a/exercises/two-fer/two_fer.py
+++ b/exercises/two-fer/two_fer.py
@@ -1,2 +1,2 @@
-def two_fer(name="you"):
+def two_fer():
     pass


### PR DESCRIPTION
The Two-Fer exercise is quite a simple one which really requires only two pieces of knowledge in any language:
- How do you append strings?
- How do you create default parameters?

In Python, the first is trivial, while the second is slightly trickier.  As written, the example code already provides the answer to the second question which is a massive spoiler, making the exercise far too easy in my opinion.  With this PR, I propose that this be dropped from the exercise, leaving the student to work out how default parameters work for themselves.