### PR TITLE
simple-linked-list: fix test name

### DIFF
--- a/exercises/simple-linked-list/simple_linked_list_test.py
+++ b/exercises/simple-linked-list/simple_linked_list_test.py
@@ -42,7 +42,7 @@ class SimpleLinkedListTest(unittest.TestCase):
         self.assertEqual(len(sut), 1)
         self.assertEqual(sut.head().value(), 5)
 
-    def test_can_from_non_empty_list(self):
+    def test_can_pop_from_non_empty_list(self):
         sut = LinkedList([3, 4, 5])
         self.assertEqual(sut.pop(), 5)
         self.assertEqual(len(sut), 2)


### PR DESCRIPTION
There doesn't appear to be cannonical data in [problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/simple-linked-list) however this test name is missing the word `pop`