### PR TITLE
Add pep8-naming to Travis-CI check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+ignore-names =
+    - setUp
+    - tearDown
+    - setUpClass
+    - tearDownClass
+	- setUpTestData
+	- assertRaisesWithMessage
+    - assertFactorsEqual
+    - assertTreeEqual
+    - test_encode_OMG
+    - test_encode_O_M_G

--- a/.flake8
+++ b/.flake8
@@ -1,12 +1,12 @@
 [flake8]
 ignore-names =
-    - setUp
-    - tearDown
-    - setUpClass
-    - tearDownClass
-	- setUpTestData
-	- assertRaisesWithMessage
-    - assertFactorsEqual
-    - assertTreeEqual
-    - test_encode_OMG
-    - test_encode_O_M_G
+  - setUp
+  - tearDown
+  - setUpClass
+  - tearDownClass
+  - setUpTestData
+  - assertRaisesWithMessage
+  - assertFactorsEqual
+  - assertTreeEqual
+  - test_encode_OMG
+  - test_encode_O_M_G

--- a/bin/check-test-version.py
+++ b/bin/check-test-version.py
@@ -39,7 +39,7 @@ class CustomFormatter(
     pass
 
 
-class bcolors:
+class Colors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
@@ -188,12 +188,12 @@ def check_test_version(
     referenced = get_referenced_version(exercise)
     up_to_date = available == referenced
     if up_to_date:
-        status, status_color = 'OK', bcolors.OKGREEN
+        status, status_color = 'OK', Colors.OKGREEN
     else:
-        status, status_color = 'NOT OK', bcolors.FAIL
+        status, status_color = 'NOT OK', Colors.FAIL
     status = cjust(status, 8)
     if not no_color:
-        status = status_color + status + bcolors.ENDC
+        status = status_color + status + Colors.ENDC
     if not up_to_date or print_ok:
         if create_issue:
             issue_number = create_issue_for_exercise(

--- a/exercises/affine-cipher/example.py
+++ b/exercises/affine-cipher/example.py
@@ -2,16 +2,16 @@ BLKSZ = 5
 ALPHSZ = 26
 
 
-def modInverse(a, ALPHSZ):
-    a = a % ALPHSZ
-    for x in range(1, ALPHSZ):
-        if ((a * x) % ALPHSZ == 1):
+def mod_inverse(a, alpha_size):
+    a = a % alpha_size
+    for x in range(1, alpha_size):
+        if ((a * x) % alpha_size == 1):
             return x
     return 1
 
 
 def translate(text, a, b, mode):
-    inv = modInverse(a, ALPHSZ)
+    inv = mod_inverse(a, ALPHSZ)
     if inv == 1:
         raise ValueError("a and alphabet size must be coprime.")
 

--- a/exercises/alphametics/example.py
+++ b/exercises/alphametics/example.py
@@ -11,7 +11,7 @@ to reduce the number of permutations
 """
 
 
-def digPerms(digset, nzcharset, okzcharset):
+def dig_perms(digset, nzcharset, okzcharset):
     """This function creates permutations given the set of digits,
        letters not alllowed to be 0, and letters allowed to be 0
     """
@@ -88,7 +88,7 @@ def check_rec(eqparams, tracecombo=(dict(), 0, set(range(10))), p=0):
             remexp.append((c, v))
     # Generate permutations for the remaining digits and currecnt level
     # non-zero letters and zero-allowed letters
-    for newdigs in digPerms(remdigs, unzchars[p], uokzchars[p]):
+    for newdigs in dig_perms(remdigs, unzchars[p], uokzchars[p]):
         # build the dictionary for the new letters and this level
         newdict = dict(zip(diglets, newdigs))
         # complete the partial sum into test sum using the current permutation

--- a/exercises/book-store/example.py
+++ b/exercises/book-store/example.py
@@ -4,7 +4,7 @@ BASE_COST = 800
 discount = [1.0, 1.0, 0.95, 0.9, 0.8, 0.75]
 
 
-def groupCost(g):
+def group_cost(g):
     return len(g) * discount[len(g)]
 
 
@@ -13,7 +13,7 @@ class Grouping:
         self.groups = [set()] if groups is None else groups
 
     def total(self):
-        return sum(map(groupCost, self.groups)) * BASE_COST
+        return sum(map(group_cost, self.groups)) * BASE_COST
 
     def dup(self):
         return Grouping(list(map(set, self.groups)))

--- a/exercises/change/change_test.py
+++ b/exercises/change/change_test.py
@@ -12,11 +12,11 @@ class ChangeTest(unittest.TestCase):
     def test_multiple_coin_change(self):
         self.assertEqual(find_minimum_coins(15, [1, 5, 10, 25, 100]), [5, 10])
 
-    def test_change_with_Lilliputian_Coins(self):
+    def test_change_with_lilliputian_coins(self):
         self.assertEqual(find_minimum_coins(23, [1, 4, 15, 20, 50]),
                          [4, 4, 15])
 
-    def test_change_with_Lower_Elbonia_Coins(self):
+    def test_change_with_lower_elbonia_coins(self):
         self.assertEqual(find_minimum_coins(63, [1, 5, 10, 21, 25]),
                          [21, 21, 21])
 

--- a/exercises/diffie-hellman/diffie_hellman.py
+++ b/exercises/diffie-hellman/diffie_hellman.py
@@ -1,10 +1,10 @@
-def private_key(p):
+def private_key(prime):
     pass
 
 
-def public_key(p, g, private):
+def public_key(prime_p, prime_g, private):
     pass
 
 
-def secret(p, public, private):
+def secret(prime, public, private):
     pass

--- a/exercises/diffie-hellman/example.py
+++ b/exercises/diffie-hellman/example.py
@@ -1,13 +1,13 @@
 import random
 
 
-def private_key(p):
-    return random.randint(2, p-1)
+def private_key(prime):
+    return random.randint(2, prime - 1)
 
 
-def public_key(p, g, a):
-    return pow(g, a, p)
+def public_key(prime_p, prime_g, private_key):
+    return pow(prime_g, private_key, prime_p)
 
 
-def secret(p, B, a):
-    return pow(B, a, p)
+def secret(prime, public_key_b, private_key_a):
+    return pow(public_key_b, private_key_a, prime)

--- a/exercises/dnd-character/dnd_character_test.py
+++ b/exercises/dnd-character/dnd_character_test.py
@@ -58,20 +58,20 @@ class DnDCharacterTest(unittest.TestCase):
         self.assertIn(Character().ability(), range(3, 19))
 
     def test_random_character_is_valid(self):
-        Char = Character()
-        self.assertIn(Char.strength, range(3, 19))
-        self.assertIn(Char.dexterity, range(3, 19))
-        self.assertIn(Char.constitution, range(3, 19))
-        self.assertIn(Char.intelligence, range(3, 19))
-        self.assertIn(Char.wisdom, range(3, 19))
-        self.assertIn(Char.charisma, range(3, 19))
+        char = Character()
+        self.assertIn(char.strength, range(3, 19))
+        self.assertIn(char.dexterity, range(3, 19))
+        self.assertIn(char.constitution, range(3, 19))
+        self.assertIn(char.intelligence, range(3, 19))
+        self.assertIn(char.wisdom, range(3, 19))
+        self.assertIn(char.charisma, range(3, 19))
         self.assertEqual(
-            Char.hitpoints,
-            10 + modifier(Char.constitution))
+            char.hitpoints,
+            10 + modifier(char.constitution))
 
     def test_each_ability_is_only_calculated_once(self):
-        Char = Character()
-        self.assertEqual(Char.strength, Char.strength)
+        char = Character()
+        self.assertEqual(char.strength, char.strength)
 
 
 if __name__ == '__main__':

--- a/exercises/dot-dsl/dot_dsl_test.py
+++ b/exercises/dot-dsl/dot_dsl_test.py
@@ -100,7 +100,7 @@ class DotDslTest(unittest.TestCase):
                 (NODE, 1, 2, 3)
             ])
 
-    def test_malformed_EDGE(self):
+    def test_malformed_edge(self):
         with self.assertRaisesWithMessage(ValueError):
             Graph([
                 (EDGE, 1, 2)

--- a/exercises/grep/grep_test.py
+++ b/exercises/grep/grep_test.py
@@ -97,16 +97,16 @@ def create_file(name, contents):
 
 class GrepTest(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         # Override builtin open() with mock-file-enabled one
         builtins.open = open
         create_file(ILIADFILENAME, ILIADCONTENTS)
         create_file(MIDSUMMERNIGHTFILENAME, MIDSUMMERNIGHTCONTENTS)
         create_file(PARADISELOSTFILENAME, PARADISELOSTCONTENTS)
-        self.maxDiff = None
+        cls.maxDiff = None
 
     @classmethod
-    def tearDownClass(self):
+    def tearDownClass(cls):
         remove_file(ILIADFILENAME)
         remove_file(MIDSUMMERNIGHTFILENAME)
         remove_file(PARADISELOSTFILENAME)

--- a/exercises/isbn-verifier/isbn_verifier_test.py
+++ b/exercises/isbn-verifier/isbn_verifier_test.py
@@ -13,22 +13,22 @@ class IsbnVerifierTest(unittest.TestCase):
     def test_invalid_check_digit(self):
         self.assertIs(verify('3-598-21508-9'), False)
 
-    def test_valid_with_X_check_digit(self):
+    def test_valid_with_x_check_digit(self):
         self.assertIs(verify('3-598-21507-X'), True)
 
-    def test_invalid_check_digit_other_than_X(self):
+    def test_invalid_check_digit_other_than_x(self):
         self.assertIs(verify('3-598-21507-A'), False)
 
     def test_invalid_character_in_isbn(self):
         self.assertIs(verify('3-598-P1581-X'), False)
 
-    def test_invalid_X_other_than_check_digit(self):
+    def test_invalid_x_other_than_check_digit(self):
         self.assertIs(verify('3-598-2X507-9'), False)
 
     def test_valid_isbn_without_separating_dashes(self):
         self.assertIs(verify('3598215088'), True)
 
-    def test_valid_isbn_without_separating_dashes_with_X_check_digit(self):
+    def test_valid_isbn_without_separating_dashes_with_x_check_digit(self):
         self.assertIs(verify('359821507X'), True)
 
     def test_invalid_isbn_without_check_digit_and_dashes(self):
@@ -43,7 +43,7 @@ class IsbnVerifierTest(unittest.TestCase):
     def test_invalid_isbn_without_check_digit(self):
         self.assertIs(verify('3-598-21507'), False)
 
-    def test_invalid_check_digit_X_used_for_0(self):
+    def test_invalid_check_digit_x_used_for_0(self):
         self.assertIs(verify('3-598-21515-X'), False)
 
     def test_valid_empty_isbn(self):

--- a/exercises/luhn/luhn_test.py
+++ b/exercises/luhn/luhn_test.py
@@ -14,16 +14,16 @@ class LuhnTest(unittest.TestCase):
     def test_a_single_zero_is_invalid(self):
         self.assertIs(Luhn("0").is_valid(), False)
 
-    def test_a_simple_valid_SIN_that_remains_valid_if_reversed(self):
+    def test_a_simple_valid_sin_that_remains_valid_if_reversed(self):
         self.assertIs(Luhn("059").is_valid(), True)
 
-    def test_a_simple_valid_SIN_that_becomes_invalid_if_reversed(self):
+    def test_a_simple_valid_sin_that_becomes_invalid_if_reversed(self):
         self.assertIs(Luhn("59").is_valid(), True)
 
-    def test_a_valid_Canadian_SIN(self):
+    def test_a_valid_canadian_sin(self):
         self.assertIs(Luhn("055 444 285").is_valid(), True)
 
-    def test_invalid_Canadian_SIN(self):
+    def test_invalid_canadian_sin(self):
         self.assertIs(Luhn("055 444 286").is_valid(), False)
 
     def test_invalid_credit_card(self):

--- a/exercises/pov/pov_test.py
+++ b/exercises/pov/pov_test.py
@@ -9,7 +9,7 @@ class PovTest(unittest.TestCase):
 
     def test_singleton_returns_same_tree(self):
         tree = Tree('x')
-        self.assertTreeEquals(tree.from_pov('x'), tree)
+        self.assertTreeEqual(tree.from_pov('x'), tree)
 
     def test_can_reroot_tree_with_parent_and_one_sibling(self):
         tree = Tree('parent', [
@@ -21,7 +21,7 @@ class PovTest(unittest.TestCase):
                 Tree('sibling')
             ])
         ])
-        self.assertTreeEquals(tree.from_pov('x'), expected)
+        self.assertTreeEqual(tree.from_pov('x'), expected)
 
     def test_can_reroot_tree_with_parent_and_many_siblings(self):
         tree = Tree('parent', [
@@ -37,7 +37,7 @@ class PovTest(unittest.TestCase):
                 Tree('c')
             ])
         ])
-        self.assertTreeEquals(tree.from_pov('x'), expected)
+        self.assertTreeEqual(tree.from_pov('x'), expected)
 
     def test_can_reroot_a_tree_with_new_root_deeply_nested(self):
         tree = Tree('level-0', [
@@ -58,7 +58,7 @@ class PovTest(unittest.TestCase):
                 ])
             ])
         ])
-        self.assertTreeEquals(tree.from_pov('x'), expected)
+        self.assertTreeEqual(tree.from_pov('x'), expected)
 
     def test_moves_children_of_new_root_to_same_level_as_former_parent(self):
         tree = Tree('parent', [
@@ -72,7 +72,7 @@ class PovTest(unittest.TestCase):
             Tree('kid-0'),
             Tree('kid-1')
         ])
-        self.assertTreeEquals(tree.from_pov('x'), expected)
+        self.assertTreeEqual(tree.from_pov('x'), expected)
 
     def test_can_reroot_complex_tree_with_cousins(self):
         tree = Tree('grandparent', [
@@ -103,7 +103,7 @@ class PovTest(unittest.TestCase):
                 ])
             ])
         ])
-        self.assertTreeEquals(tree.from_pov('x'), expected)
+        self.assertTreeEqual(tree.from_pov('x'), expected)
 
     def test_errors_if_target_does_not_exist_in_singleton_tree(self):
         tree = Tree('x')
@@ -213,7 +213,7 @@ class PovTest(unittest.TestCase):
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
 
-    def assertTreeEquals(self, result, expected):
+    def assertTreeEqual(self, result, expected):
         self.assertEqual(result, expected,
                          '{} != {}'.format(result, expected))
 

--- a/exercises/protein-translation/protein_translation_test.py
+++ b/exercises/protein-translation/protein_translation_test.py
@@ -7,30 +7,30 @@ from protein_translation import proteins
 
 class ProteinTranslationTest(unittest.TestCase):
 
-    def test_AUG_translates_to_methionine(self):
+    def test_aug_translates_to_methionine(self):
         self.assertEqual(proteins('AUG'), ['Methionine'])
 
-    def test_identifies_Phenylalanine_codons(self):
+    def test_identifies_phenylalanine_codons(self):
         for codon in ['UUU', 'UUC']:
             self.assertEqual(proteins(codon), ['Phenylalanine'])
 
-    def test_identifies_Leucine_codons(self):
+    def test_identifies_leucine_codons(self):
         for codon in ['UUA', 'UUG']:
             self.assertEqual(proteins(codon), ['Leucine'])
 
-    def test_identifies_Serine_codons(self):
+    def test_identifies_serine_codons(self):
         for codon in ['UCU', 'UCC', 'UCA', 'UCG']:
             self.assertEqual(proteins(codon), ['Serine'])
 
-    def test_identifies_Tyrosine_codons(self):
+    def test_identifies_tyrosine_codons(self):
         for codon in ['UAU', 'UAC']:
             self.assertEqual(proteins(codon), ['Tyrosine'])
 
-    def test_identifies_Cysteine_codons(self):
+    def test_identifies_cysteine_codons(self):
         for codon in ['UGU', 'UGC']:
             self.assertEqual(proteins(codon), ['Cysteine'])
 
-    def test_identifies_Tryptophan_codons(self):
+    def test_identifies_tryptophan_codons(self):
         self.assertEqual(proteins('UGG'), ['Tryptophan'])
 
     def test_identifies_stop_codons(self):

--- a/exercises/rectangles/example.py
+++ b/exercises/rectangles/example.py
@@ -1,7 +1,7 @@
 import itertools
 
 
-class corners(object):
+class Corners(object):
     def __init__(self, i, j):
         # i, j are position of corner
         self.i = i
@@ -30,7 +30,7 @@ def search_corners(input):
     for i in range(0, len(input)):
         for j in range(0, len(input[i])):
             if (input[i][j] == "+"):
-                corner_list.append(corners(i, j))
+                corner_list.append(Corners(i, j))
     return corner_list
 
 

--- a/exercises/robot-simulator/robot_simulator_test.py
+++ b/exercises/robot-simulator/robot_simulator_test.py
@@ -18,36 +18,36 @@ class RobotSimulatorTest(unittest.TestCase):
         self.assertEqual(robot.bearing, SOUTH)
 
     def test_rotate_turn_right(self):
-        dirA = [EAST, SOUTH, WEST, NORTH]
-        dirB = [SOUTH, WEST, NORTH, EAST]
-        for x in range(len(dirA)):
-            robot = Robot(dirA[x], 0, 0)
+        dir_a = [EAST, SOUTH, WEST, NORTH]
+        dir_b = [SOUTH, WEST, NORTH, EAST]
+        for x, direction in enumerate(dir_a):
+            robot = Robot(direction, 0, 0)
             robot.turn_right()
-            self.assertEqual(robot.bearing, dirB[x])
+            self.assertEqual(robot.bearing, dir_b[x])
 
-    def test_rotate_simulate_R(self):
-        A = [NORTH, EAST, SOUTH, WEST]
-        B = [EAST, SOUTH, WEST, NORTH]
-        for x in range(len(A)):
-            robot = Robot(A[x], 0, 0)
+    def test_rotate_simulate_right(self):
+        instructions = [NORTH, EAST, SOUTH, WEST]
+        expected = [EAST, SOUTH, WEST, NORTH]
+        for x, instruction in enumerate(instructions):
+            robot = Robot(instruction, 0, 0)
             robot.simulate("R")
-            self.assertEqual(robot.bearing, B[x])
+            self.assertEqual(robot.bearing, expected[x])
 
-    def test_rotate_simulate_L(self):
-        A = [NORTH, WEST, SOUTH, EAST]
-        B = [WEST, SOUTH, EAST, NORTH]
-        for x in range(len(A)):
-            robot = Robot(A[x], 0, 0)
+    def test_rotate_simulate_left(self):
+        instructions = [NORTH, WEST, SOUTH, EAST]
+        expected = [WEST, SOUTH, EAST, NORTH]
+        for x, instruction in enumerate(instructions):
+            robot = Robot(instruction, 0, 0)
             robot.simulate("L")
-            self.assertEqual(robot.bearing, B[x])
+            self.assertEqual(robot.bearing, expected[x])
 
     def test_rotate_turn_left(self):
-        dirA = [EAST, SOUTH, WEST, NORTH]
-        dirB = [NORTH, EAST, SOUTH, WEST]
-        for x in range(len(dirA)):
-            robot = Robot(dirA[x], 0, 0)
+        dir_a = [EAST, SOUTH, WEST, NORTH]
+        dir_b = [NORTH, EAST, SOUTH, WEST]
+        for x, direction in enumerate(dir_a):
+            robot = Robot(direction, 0, 0)
             robot.turn_left()
-            self.assertEqual(robot.bearing, dirB[x])
+            self.assertEqual(robot.bearing, dir_b[x])
 
     def test_advance_positive_north(self):
         robot = Robot(NORTH, 0, 0)
@@ -73,7 +73,7 @@ class RobotSimulatorTest(unittest.TestCase):
         self.assertEqual(robot.coordinates, (-1, 0))
         self.assertEqual(robot.bearing, WEST)
 
-    def test_move_east_north_from_README(self):
+    def test_move_east_north_from_readme(self):
         robot = Robot(NORTH, 7, 3)
         robot.simulate("RAALAL")
         self.assertEqual(robot.coordinates, (9, 4))

--- a/exercises/simple-linked-list/example.py
+++ b/exercises/simple-linked-list/example.py
@@ -46,9 +46,9 @@ class LinkedList(object):
         return self._head
 
     def push(self, value):
-        newNode = Node(value)
-        newNode._next = self._head
-        self._head = newNode
+        new_node = Node(value)
+        new_node._next = self._head
+        self._head = new_node
         self._len += 1
 
     def pop(self):

--- a/exercises/tree-building/example.py
+++ b/exercises/tree-building/example.py
@@ -13,19 +13,19 @@ class Node():
         self.children = []
 
 
-def validateRecord(record):
+def validate_record(record):
     if record.equal_id() and record.record_id != 0:
         raise ValueError("Only root should have equal record and parent id")
     elif not record.equal_id() and record.parent_id >= record.record_id:
         raise ValueError("Node record_id should be smaller than its parent_id")
 
 
-def BuildTree(records):
+def build_tree(records):
     parent_dict = {}
     node_dict = {}
     ordered_id = sorted((i.record_id for i in records))
     for record in records:
-        validateRecord(record)
+        validate_record(record)
         parent_dict[record.record_id] = record.parent_id
         node_dict[record.record_id] = Node(record.record_id)
 

--- a/exercises/tree-building/tree_building.py
+++ b/exercises/tree-building/tree_building.py
@@ -10,7 +10,7 @@ class Node():
         self.children = []
 
 
-def BuildTree(records):
+def build_tree(records):
     root = None
     records.sort(key=lambda x: x.record_id)
     ordered_id = [i.record_id for i in records]

--- a/exercises/tree-building/tree_building_test.py
+++ b/exercises/tree-building/tree_building_test.py
@@ -1,26 +1,26 @@
 import unittest
 
-from tree_building import Record, BuildTree
+from tree_building import Record, build_tree
 
 
 class TreeBuildingTest(unittest.TestCase):
     """
         Record(record_id, parent_id): records given to be processed
         Node(node_id): Node in tree
-        BuildTree(records): records as argument and returns tree
-        BuildTree should raise ValueError if given records are invalid
+        build_tree(records): records as argument and returns tree
+        build_tree should raise ValueError if given records are invalid
     """
 
     def test_empty_list_input(self):
         records = []
-        root = BuildTree(records)
+        root = build_tree(records)
         self.assertIsNone(root)
 
     def test_one_node(self):
         records = [
             Record(0, 0)
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_leaf(root, node_id=0)
 
@@ -30,7 +30,7 @@ class TreeBuildingTest(unittest.TestCase):
             Record(1, 0),
             Record(2, 0)
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_branch(root, node_id=0, children_count=2)
         self.assert_node_is_leaf(root.children[0], node_id=1)
@@ -42,7 +42,7 @@ class TreeBuildingTest(unittest.TestCase):
             Record(1, 0),
             Record(0, 0)
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_branch(root, node_id=0, children_count=2)
         self.assert_node_is_leaf(root.children[0], node_id=1)
@@ -55,7 +55,7 @@ class TreeBuildingTest(unittest.TestCase):
             Record(2, 0),
             Record(3, 0)
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_branch(root, node_id=0, children_count=3)
         self.assert_node_is_leaf(root.children[0], node_id=1)
@@ -72,7 +72,7 @@ class TreeBuildingTest(unittest.TestCase):
             Record(5, 2),
             Record(1, 0)
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_branch(root, 0, 2)
         self.assert_node_is_branch(root.children[0], 1, 2)
@@ -92,7 +92,7 @@ class TreeBuildingTest(unittest.TestCase):
             Record(5, 1),
             Record(6, 2),
         ]
-        root = BuildTree(records)
+        root = build_tree(records)
 
         self.assert_node_is_branch(root, 0, 2)
         self.assert_node_is_branch(root.children[0], 1, 3)
@@ -109,7 +109,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Root parent_id should be equal to record_id(0)
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def test_no_root_node(self):
         records = [
@@ -118,7 +118,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Record with record_id 0 (root) is missing
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def test_non_continuous(self):
         records = [
@@ -129,7 +129,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Record with record_id 3 is missing
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def test_cycle_directly(self):
         records = [
@@ -143,7 +143,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Cycle caused by Record 2 with parent_id pointing to itself
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def test_cycle_indirectly(self):
         records = [
@@ -157,7 +157,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Cycle caused by Record 2 with parent_id(6) greater than record_id(2)
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def test_higher_id_parent_of_lower_id(self):
         records = [
@@ -167,7 +167,7 @@ class TreeBuildingTest(unittest.TestCase):
         ]
         # Record 1 have parent_id(2) greater than record_id(1)
         with self.assertRaisesWithMessage(ValueError):
-            BuildTree(records)
+            build_tree(records)
 
     def assert_node_is_branch(self, node, node_id, children_count):
         self.assertEqual(node.node_id, node_id)

--- a/exercises/triangle/triangle_test.py
+++ b/exercises/triangle/triangle_test.py
@@ -5,7 +5,7 @@ from triangle import is_equilateral, is_isosceles, is_scalene
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
-class is_equilateralTests(unittest.TestCase):
+class IsEquilateralTests(unittest.TestCase):
     def test_true_if_all_sides_are_equal(self):
         self.assertIs(is_equilateral([2, 2, 2]), True)
 
@@ -22,7 +22,7 @@ class is_equilateralTests(unittest.TestCase):
         self.assertIs(is_equilateral([0.5, 0.5, 0.5]), True)
 
 
-class is_isoscelesTests(unittest.TestCase):
+class IsIsoscelesTests(unittest.TestCase):
     def test_true_if_last_two_sides_are_equal(self):
         self.assertIs(is_isosceles([3, 4, 4]), True)
 
@@ -51,7 +51,7 @@ class is_isoscelesTests(unittest.TestCase):
         self.assertIs(is_isosceles([0.5, 0.4, 0.5]), True)
 
 
-class is_scaleneTests(unittest.TestCase):
+class IsScaleneTests(unittest.TestCase):
     def test_true_if_no_sides_are_equal(self):
         self.assertIs(is_scalene([5, 4, 6]), True)
 

--- a/exercises/two-bucket/example.py
+++ b/exercises/two-bucket/example.py
@@ -7,7 +7,7 @@
 
 def measure(bucket_one, bucket_two, goal, start_bucket):
     sizes = [bucket_one, bucket_two]
-    goalIndex = 0 if start_bucket == 'one' else 1
+    goal_index = 0 if start_bucket == 'one' else 1
 
     def empty(buckets, i):
         return [0, buckets[1]] if i == 0 else [buckets[0], 0]
@@ -25,29 +25,29 @@ def measure(bucket_one, bucket_two, goal, start_bucket):
         return '{},{}'.format(*buckets)
 
     invalid = [0, 0]
-    invalid[1 - goalIndex] = sizes[1 - goalIndex]
-    invalidStr = bucket_str(invalid)
+    invalid[1 - goal_index] = sizes[1 - goal_index]
+    invalid_str = bucket_str(invalid)
     buckets = [0, 0]
-    buckets[goalIndex] = sizes[goalIndex]
-    toVisit = []
+    buckets[goal_index] = sizes[goal_index]
+    to_visit = []
     visited = set()
     count = 1
     while goal not in buckets:
         key = bucket_str(buckets)
-        if key != invalidStr and key not in visited:
+        if key != invalid_str and key not in visited:
             visited.add(key)
             nc = count + 1
             for i in range(2):
                 if buckets[i] != 0:
-                    toVisit.append((empty(buckets, i), nc))
+                    to_visit.append((empty(buckets, i), nc))
                 if buckets[i] != sizes[i]:
-                    toVisit.append((fill(buckets, i), nc))
-                    toVisit.append((consolidate(buckets, i), nc))
-        if not any(toVisit):
+                    to_visit.append((fill(buckets, i), nc))
+                    to_visit.append((consolidate(buckets, i), nc))
+        if not any(to_visit):
             raise ValueError('No more moves!')
-        buckets, count = toVisit.pop(0)
+        buckets, count = to_visit.pop(0)
 
-    goalIndex = buckets.index(goal)
-    goalBucket = ['one', 'two'][goalIndex]
-    otherBucket = buckets[1 - goalIndex]
-    return (count, goalBucket, otherBucket)
+    goal_index = buckets.index(goal)
+    goal_bucket = ['one', 'two'][goal_index]
+    other_bucket = buckets[1 - goal_index]
+    return (count, goal_bucket, other_bucket)

--- a/exercises/word-search/word_search_test.py
+++ b/exercises/word-search/word_search_test.py
@@ -9,41 +9,41 @@ class WordSearchTest(unittest.TestCase):
 
     def test_initial_game_grid(self):
         puzzle = ['jefblpepre']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertIsNone(searchAnswer)
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertIsNone(search_answer)
 
     def test_left_to_right_word(self):
         puzzle = ['clojurermt']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(0, 0), Point(6, 0)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(0, 0), Point(6, 0)))
 
     def test_left_to_right_word_different_position(self):
         puzzle = ['mtclojurer']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(2, 0), Point(8, 0)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(2, 0), Point(8, 0)))
 
     def test_different_left_to_right_word(self):
         puzzle = ['coffeelplx']
-        searchAnswer = WordSearch(puzzle).search('coffee')
-        self.assertEqual(searchAnswer, (Point(0, 0), Point(5, 0)))
+        search_answer = WordSearch(puzzle).search('coffee')
+        self.assertEqual(search_answer, (Point(0, 0), Point(5, 0)))
 
     def test_different_left_to_right_word_different_position(self):
         puzzle = ['xcoffeezlp']
-        searchAnswer = WordSearch(puzzle).search('coffee')
-        self.assertEqual(searchAnswer, (Point(1, 0), Point(6, 0)))
+        search_answer = WordSearch(puzzle).search('coffee')
+        self.assertEqual(search_answer, (Point(1, 0), Point(6, 0)))
 
     def test_left_to_right_word_two_lines(self):
         puzzle = ['jefblpepre',
                   'tclojurerm']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(1, 1), Point(7, 1)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(1, 1), Point(7, 1)))
 
     def test_left_to_right_word_three_lines(self):
         puzzle = ['camdcimgtc',
                   'jefblpepre',
                   'clojurermt']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(0, 2), Point(6, 2)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(0, 2), Point(6, 2)))
 
     def test_left_to_right_word_ten_lines(self):
         puzzle = ['jefblpepre',
@@ -56,8 +56,8 @@ class WordSearchTest(unittest.TestCase):
                   'alxhpburyi',
                   'jalaycalmp',
                   'clojurermt']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(0, 9), Point(6, 9)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(0, 9), Point(6, 9)))
 
     def test_left_to_right_word_ten_lines_different_position(self):
         puzzle = ['jefblpepre',
@@ -70,8 +70,8 @@ class WordSearchTest(unittest.TestCase):
                   'alxhpburyi',
                   'clojurermt',
                   'jalaycalmp']
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(0, 8), Point(6, 8)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(0, 8), Point(6, 8)))
 
     def test_different_left_to_right_word_ten_lines(self):
         puzzle = ['jefblpepre',
@@ -84,8 +84,8 @@ class WordSearchTest(unittest.TestCase):
                   'alxhpburyi',
                   'clojurermt',
                   'jalaycalmp']
-        searchAnswer = WordSearch(puzzle).search('fortran')
-        self.assertEqual(searchAnswer, (Point(0, 6), Point(6, 6)))
+        search_answer = WordSearch(puzzle).search('fortran')
+        self.assertEqual(search_answer, (Point(0, 6), Point(6, 6)))
 
     def test_multiple_words(self):
         puzzle = ['jefblpepre',
@@ -98,15 +98,15 @@ class WordSearchTest(unittest.TestCase):
                   'alxhpburyi',
                   'jalaycalmp',
                   'clojurermt']
-        searchAnswer = WordSearch(puzzle).search('fortran')
-        self.assertEqual(searchAnswer, (Point(0, 6), Point(6, 6)))
-        searchAnswer = WordSearch(puzzle).search('clojure')
-        self.assertEqual(searchAnswer, (Point(0, 9), Point(6, 9)))
+        search_answer = WordSearch(puzzle).search('fortran')
+        self.assertEqual(search_answer, (Point(0, 6), Point(6, 6)))
+        search_answer = WordSearch(puzzle).search('clojure')
+        self.assertEqual(search_answer, (Point(0, 9), Point(6, 9)))
 
     def test_single_word_right_to_left(self):
         puzzle = ['rixilelhrs']
-        searchAnswer = WordSearch(puzzle).search('elixir')
-        self.assertEqual(searchAnswer, (Point(5, 0), Point(0, 0)))
+        search_answer = WordSearch(puzzle).search('elixir')
+        self.assertEqual(search_answer, (Point(5, 0), Point(0, 0)))
 
     @classmethod
     def setUpClass(cls):

--- a/exercises/zipper/zipper_test.py
+++ b/exercises/zipper/zipper_test.py
@@ -47,22 +47,22 @@ class ZipperTest(unittest.TestCase):
     def test_set_value(self):
         t1, t2, _, _ = self.create_trees()
         zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_value(5)
-        tree = updatedZipper.to_tree()
+        updated_zipper = zipper.left().set_value(5)
+        tree = updated_zipper.to_tree()
         self.assertEqual(tree, t2)
 
     def test_set_left_with_value(self):
         t1, _, t3, _ = self.create_trees()
         zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_left(self.leaf(5))
-        tree = updatedZipper.to_tree()
+        updated_zipper = zipper.left().set_left(self.leaf(5))
+        tree = updated_zipper.to_tree()
         self.assertEqual(tree, t3)
 
     def test_set_right_to_none(self):
         t1, _, _, t4 = self.create_trees()
         zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_right(None)
-        tree = updatedZipper.to_tree()
+        updated_zipper = zipper.left().set_right(None)
+        tree = updated_zipper.to_tree()
         self.assertEqual(tree, t4)
 
     def test_different_paths_to_same_zipper(self):

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,1 +1,2 @@
 flake8==3.6.0
+pep8-naming==0.7.0


### PR DESCRIPTION
- add `pep8-naming` to `requirements-travis.txt`
- add `.flake8` to cover exceptions
- correct naming violations in various exercises

Resolves #1659 