### PR TITLE
Added test for 10 numbers a 1 letter invalid

### DIFF
--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -40,7 +40,11 @@ class PhoneNumberTest(unittest.TestCase):
 
     def test_invalid_with_letters(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("123-abc-7890")
+            Phone("123-abc-7890")    
+
+    def test_invalid_with_letter_and_ten_numbers(self):
+        with self.assertRaisesWithMessage(ValueError):
+            Phone("223a4567890")
 
     def test_invalid_with_punctuation(self):
         with self.assertRaisesWithMessage(ValueError):


### PR DESCRIPTION
It is possible, with the current tests, to test an input of 11 characters made up of a letter and 10 numbers and not receive an error. The test included is to solve the issue.