### PR TITLE
Track Restructure (First pass)

### DIFF
--- a/config.json
+++ b/config.json
@@ -173,6 +173,20 @@
       ]
     },
     {
+      "slug": "luhn",
+      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "pattern_matching",
+        "security"
+      ]
+    },
+    {
       "slug": "clock",
       "uuid": "459fda78-851e-4bb0-a416-953528f46bd7",
       "core": true,
@@ -219,20 +233,6 @@
         "lists",
         "loops",
         "recursion"
-      ]
-    },
-    {
-      "slug": "luhn",
-      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "conditionals",
-        "loops",
-        "pattern_matching",
-        "security"
       ]
     },
     {
@@ -393,7 +393,7 @@
       "slug": "rotational-cipher",
       "uuid": "4c408aab-80b9-475d-9c06-b01cd0fcd08f",
       "core": false,
-      "unlocked_by": "grade-school",
+      "unlocked_by": "luhn",
       "difficulty": 1,
       "topics": [
         "logic",
@@ -986,7 +986,7 @@
       "slug": "binary-search",
       "uuid": "a8288e93-93c5-4e0f-896c-2a376f6f6e5e",
       "core": false,
-      "unlocked_by": "grade-school",
+      "unlocked_by": "luhn",
       "difficulty": 1,
       "topics": [
         "algorithms",
@@ -1066,7 +1066,7 @@
       "slug": "variable-length-quantity",
       "uuid": "aa4332bd-fc38-47a4-8bff-e1b660798418",
       "core": false,
-      "unlocked_by": "grade-school",
+      "unlocked_by": "luhn",
       "difficulty": 1,
       "topics": [
         "algorithms",
@@ -1228,7 +1228,7 @@
       "slug": "two-bucket",
       "uuid": "6f530d0c-d13e-4270-b120-e42c16691a66",
       "core": false,
-      "unlocked_by": "grade-school",
+      "unlocked_by": "luhn",
       "difficulty": 5,
       "topics": [
         "algorithms",

--- a/config.json
+++ b/config.json
@@ -32,17 +32,6 @@
       ]
     },
     {
-      "slug": "acronym",
-      "uuid": "038c7f7f-02f6-496f-9e16-9372621cc4cd",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "regular_expressions",
-        "strings"
-      ]
-    },
-    {
       "uuid": "574d6323-5ff5-4019-9ebe-0067daafba13",
       "slug": "high-scores",
       "core": true,
@@ -65,20 +54,6 @@
         "loops",
         "matrices",
         "type_conversion"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "04316811-0bc3-4377-8ff5-5a300ba41d61",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "logic",
-        "pattern_recognition",
-        "strings",
-        "text_formatting"
       ]
     },
     {
@@ -120,6 +95,32 @@
       ]
     },
     {
+      "slug": "twelve-days",
+      "uuid": "d41238ce-359c-4a9a-81ea-ca5d2c4bb50d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "lists",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "04316811-0bc3-4377-8ff5-5a300ba41d61",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "logic",
+        "pattern_recognition",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "scrabble-score",
       "uuid": "d081446b-f26b-41a2-ab7f-dd7f6736ecfe",
       "core": true,
@@ -129,6 +130,17 @@
         "games",
         "loops",
         "maps",
+        "strings"
+      ]
+    },
+    {
+      "slug": "acronym",
+      "uuid": "038c7f7f-02f6-496f-9e16-9372621cc4cd",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "regular_expressions",
         "strings"
       ]
     },
@@ -161,20 +173,6 @@
       ]
     },
     {
-      "slug": "luhn",
-      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "conditionals",
-        "loops",
-        "pattern_matching",
-        "security"
-      ]
-    },
-    {
       "slug": "clock",
       "uuid": "459fda78-851e-4bb0-a416-953528f46bd7",
       "core": true,
@@ -195,18 +193,6 @@
       "difficulty": 3,
       "topics": [
         "refactoring",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "twelve-days",
-      "uuid": "d41238ce-359c-4a9a-81ea-ca5d2c4bb50d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "lists",
-        "strings",
         "text_formatting"
       ]
     },
@@ -233,6 +219,20 @@
         "lists",
         "loops",
         "recursion"
+      ]
+    },
+    {
+      "slug": "luhn",
+      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "pattern_matching",
+        "security"
       ]
     },
     {
@@ -393,7 +393,7 @@
       "slug": "rotational-cipher",
       "uuid": "4c408aab-80b9-475d-9c06-b01cd0fcd08f",
       "core": false,
-      "unlocked_by": "luhn",
+      "unlocked_by": "grade-school",
       "difficulty": 1,
       "topics": [
         "logic",
@@ -986,7 +986,7 @@
       "slug": "binary-search",
       "uuid": "a8288e93-93c5-4e0f-896c-2a376f6f6e5e",
       "core": false,
-      "unlocked_by": "luhn",
+      "unlocked_by": "grade-school",
       "difficulty": 1,
       "topics": [
         "algorithms",
@@ -1066,7 +1066,7 @@
       "slug": "variable-length-quantity",
       "uuid": "aa4332bd-fc38-47a4-8bff-e1b660798418",
       "core": false,
-      "unlocked_by": "luhn",
+      "unlocked_by": "grade-school",
       "difficulty": 1,
       "topics": [
         "algorithms",
@@ -1228,7 +1228,7 @@
       "slug": "two-bucket",
       "uuid": "6f530d0c-d13e-4270-b120-e42c16691a66",
       "core": false,
-      "unlocked_by": "luhn",
+      "unlocked_by": "grade-school",
       "difficulty": 5,
       "topics": [
         "algorithms",


### PR DESCRIPTION
This is a first pass of many, designed to improve the track exercise progression.

This pass:
- Removes 'mathy' exercises and those that require the student to re-implement functionality that is already part of the core modules.
- Fix obvious issues in ordering of `core` exercises