### PR TITLE
high-scores: add `classes` topic

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,6 +38,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+        "classes",
         "control-flow (if-else statements)",
         "sequences",
         "text_formatting"


### PR DESCRIPTION
`high-scores` is the first core test suite to require the student to use a class. This jump should be noted in the topics.