### PR TITLE
list-ops: update tests to v2.4.0

### DIFF
--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -4,7 +4,7 @@ import operator
 import list_ops
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v2.3.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.4.0
 
 class ListOpsTest(unittest.TestCase):
 
@@ -89,6 +89,10 @@ class ListOpsTest(unittest.TestCase):
 
     def test_reverse_nonempty_list(self):
         self.assertEqual(list_ops.reverse([1, 3, 5, 7]), [7, 5, 3, 1])
+
+    def test_reverse_list_of_lists_not_flattened(self):
+        self.assertEqual(list_ops.reverse([[1, 2], [3], [], [4, 5, 6]]),
+                         [[4, 5, 6], [], [3], [1, 2]])
 
     # additional test for reverse
     def test_reverse_mixed_types(self):


### PR DESCRIPTION
closes #1677 

Updated list-ops to v2.4.0
See [list_ops_test.py](https://github.com/exercism/python/blob/master/exercises/list-ops/list_ops_test.py)
See [v2.4.0 commit](https://github.com/exercism/problem-specifications/commit/779fa9c6ffb915bd87305be13507f243e7db5cbb#diff-637e4f7a1434d17126301fcffc3bbcbe)