### PR TITLE
remove reference to logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,5 @@ If you're interested, Tim Pope even has an [entire blog post](http://tbaggery.co
 
 If you're new to Git, take a look at [this short guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md#git-basics).
 
-
-## Python icon
-The Python logo is an unregistered trademark. We are using a derived logo with the permission of the Python Software Foundation.
-
 ## License
 This repository uses the [MIT License](/LICENSE).


### PR DESCRIPTION
Since there is no longer a copy of the Python logo stored in this repository, remove the reference to it from the README.