### PR TITLE
Remove Python 2.7 reference on README

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,6 +38,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+        "classes",
         "control_flow_if_else_statements",
         "sequences",
         "text_formatting"

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test accumulate_test.py`
 - Python 3.4+: `pytest accumulate_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test acronym_test.py`
 - Python 3.4+: `pytest acronym_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -87,7 +87,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test affine_cipher_test.py`
 - Python 3.4+: `pytest affine_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test all_your_base_test.py`
 - Python 3.4+: `pytest all_your_base_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test allergies_test.py`
 - Python 3.4+: `pytest allergies_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test alphametics_test.py`
 - Python 3.4+: `pytest alphametics_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test anagram_test.py`
 - Python 3.4+: `pytest anagram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -29,7 +29,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test armstrong_numbers_test.py`
 - Python 3.4+: `pytest armstrong_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test atbash_cipher_test.py`
 - Python 3.4+: `pytest atbash_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bank_account_test.py`
 - Python 3.4+: `pytest bank_account_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -338,7 +338,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test beer_song_test.py`
 - Python 3.4+: `pytest beer_song_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -71,7 +71,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_search_tree_test.py`
 - Python 3.4+: `pytest binary_search_tree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_search_test.py`
 - Python 3.4+: `pytest binary_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_test.py`
 - Python 3.4+: `pytest binary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bob_test.py`
 - Python 3.4+: `pytest bob_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -85,7 +85,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test book_store_test.py`
 - Python 3.4+: `pytest book_store_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -78,7 +78,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bowling_test.py`
 - Python 3.4+: `pytest bowling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -22,7 +22,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bracket_push_test.py`
 - Python 3.4+: `pytest bracket_push_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -34,7 +34,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test change_test.py`
 - Python 3.4+: `pytest change_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -68,7 +68,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test circular_buffer_test.py`
 - Python 3.4+: `pytest circular_buffer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test clock_test.py`
 - Python 3.4+: `pytest clock_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test collatz_conjecture_test.py`
 - Python 3.4+: `pytest collatz_conjecture_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -54,7 +54,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test complex_numbers_test.py`
 - Python 3.4+: `pytest complex_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test connect_test.py`
 - Python 3.4+: `pytest connect_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -90,7 +90,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test crypto_square_test.py`
 - Python 3.4+: `pytest crypto_square_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test custom_set_test.py`
 - Python 3.4+: `pytest custom_set_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test darts_test.py`
 - Python 3.4+: `pytest darts_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -70,7 +70,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test diamond_test.py`
 - Python 3.4+: `pytest diamond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test difference_of_squares_test.py`
 - Python 3.4+: `pytest difference_of_squares_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -72,7 +72,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test diffie_hellman_test.py`
 - Python 3.4+: `pytest diffie_hellman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dnd-character/README.md
+++ b/exercises/dnd-character/README.md
@@ -50,7 +50,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dnd_character_test.py`
 - Python 3.4+: `pytest dnd_character_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dominoes_test.py`
 - Python 3.4+: `pytest dominoes_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dot_dsl_test.py`
 - Python 3.4+: `pytest dot_dsl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -37,7 +37,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test error_handling_test.py`
 - Python 3.4+: `pytest error_handling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -64,7 +64,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test etl_test.py`
 - Python 3.4+: `pytest etl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -28,7 +28,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test flatten_array_test.py`
 - Python 3.4+: `pytest flatten_array_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -81,7 +81,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test food_chain_test.py`
 - Python 3.4+: `pytest food_chain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test forth_test.py`
 - Python 3.4+: `pytest forth_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -22,7 +22,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test gigasecond_test.py`
 - Python 3.4+: `pytest gigasecond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -53,7 +53,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test go_counting_test.py`
 - Python 3.4+: `pytest go_counting_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grade_school_test.py`
 - Python 3.4+: `pytest grade_school_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grains_test.py`
 - Python 3.4+: `pytest grains_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grep_test.py`
 - Python 3.4+: `pytest grep_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hamming_test.py`
 - Python 3.4+: `pytest hamming_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -40,7 +40,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hangman_test.py`
 - Python 3.4+: `pytest hangman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hello_world_test.py`
 - Python 3.4+: `pytest hello_world_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hexadecimal_test.py`
 - Python 3.4+: `pytest hexadecimal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -123,7 +123,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test house_test.py`
 - Python 3.4+: `pytest house_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test isbn_verifier_test.py`
 - Python 3.4+: `pytest isbn_verifier_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test isogram_test.py`
 - Python 3.4+: `pytest isogram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -77,7 +77,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test kindergarten_garden_test.py`
 - Python 3.4+: `pytest kindergarten_garden_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test largest_series_product_test.py`
 - Python 3.4+: `pytest largest_series_product_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test leap_test.py`
 - Python 3.4+: `pytest leap_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ledger/README.md
+++ b/exercises/ledger/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test ledger_test.py`
 - Python 3.4+: `pytest ledger_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test linked_list_test.py`
 - Python 3.4+: `pytest linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -37,7 +37,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test list_ops_test.py`
 - Python 3.4+: `pytest list_ops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test luhn_test.py`
 - Python 3.4+: `pytest luhn_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test markdown_test.py`
 - Python 3.4+: `pytest markdown_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test matrix_test.py`
 - Python 3.4+: `pytest matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test meetup_test.py`
 - Python 3.4+: `pytest meetup_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test minesweeper_test.py`
 - Python 3.4+: `pytest minesweeper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test nth_prime_test.py`
 - Python 3.4+: `pytest nth_prime_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test nucleotide_count_test.py`
 - Python 3.4+: `pytest nucleotide_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -96,7 +96,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test ocr_numbers_test.py`
 - Python 3.4+: `pytest ocr_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -64,7 +64,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test octal_test.py`
 - Python 3.4+: `pytest octal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -50,7 +50,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test palindrome_products_test.py`
 - Python 3.4+: `pytest palindrome_products_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pangram_test.py`
 - Python 3.4+: `pytest pangram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test parallel_letter_frequency_test.py`
 - Python 3.4+: `pytest parallel_letter_frequency_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pascals_triangle_test.py`
 - Python 3.4+: `pytest pascals_triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test perfect_numbers_test.py`
 - Python 3.4+: `pytest perfect_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test phone_number_test.py`
 - Python 3.4+: `pytest phone_number_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pig_latin_test.py`
 - Python 3.4+: `pytest pig_latin_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test point_mutations_test.py`
 - Python 3.4+: `pytest point_mutations_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -23,7 +23,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test poker_test.py`
 - Python 3.4+: `pytest poker_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -55,7 +55,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pov_test.py`
 - Python 3.4+: `pytest pov_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test prime_factors_test.py`
 - Python 3.4+: `pytest prime_factors_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -59,7 +59,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test protein_translation_test.py`
 - Python 3.4+: `pytest protein_translation_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -34,7 +34,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test proverb_test.py`
 - Python 3.4+: `pytest proverb_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pythagorean_triplet_test.py`
 - Python 3.4+: `pytest pythagorean_triplet_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test queen_attack_test.py`
 - Python 3.4+: `pytest queen_attack_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -76,7 +76,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rail_fence_cipher_test.py`
 - Python 3.4+: `pytest rail_fence_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test raindrops_test.py`
 - Python 3.4+: `pytest raindrops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rational_numbers_test.py`
 - Python 3.4+: `pytest rational_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test react_test.py`
 - Python 3.4+: `pytest react_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -81,7 +81,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rectangles_test.py`
 - Python 3.4+: `pytest rectangles_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -38,7 +38,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test resistor_color_test.py`
 - Python 3.4+: `pytest resistor_color_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rest-api/README.md
+++ b/exercises/rest-api/README.md
@@ -56,7 +56,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rest_api_test.py`
 - Python 3.4+: `pytest rest_api_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/retree/README.md
+++ b/exercises/retree/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422$
 
-- Python 2.7: `py.test retree_test.py`
 - Python 3.4+: `pytest retree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test reverse_string_test.py`
 - Python 3.4+: `pytest reverse_string_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -36,7 +36,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rna_transcription_test.py`
 - Python 3.4+: `pytest rna_transcription_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test robot_name_test.py`
 - Python 3.4+: `pytest robot_name_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test robot_simulator_test.py`
 - Python 3.4+: `pytest robot_simulator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -60,7 +60,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test roman_numerals_test.py`
 - Python 3.4+: `pytest roman_numerals_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rotational_cipher_test.py`
 - Python 3.4+: `pytest rotational_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -41,7 +41,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test run_length_encoding_test.py`
 - Python 3.4+: `pytest run_length_encoding_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test saddle_points_test.py`
 - Python 3.4+: `pytest saddle_points_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -80,7 +80,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test say_test.py`
 - Python 3.4+: `pytest say_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -66,7 +66,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test scale_generator_test.py`
 - Python 3.4+: `pytest scale_generator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -57,7 +57,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test scrabble_score_test.py`
 - Python 3.4+: `pytest scrabble_score_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test secret_handshake_test.py`
 - Python 3.4+: `pytest secret_handshake_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -38,7 +38,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test series_test.py`
 - Python 3.4+: `pytest series_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sgf_parsing_test.py`
 - Python 3.4+: `pytest sgf_parsing_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sieve_test.py`
 - Python 3.4+: `pytest sieve_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -114,7 +114,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test simple_cipher_test.py`
 - Python 3.4+: `pytest simple_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -51,7 +51,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test simple_linked_list_test.py`
 - Python 3.4+: `pytest simple_linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test space_age_test.py`
 - Python 3.4+: `pytest space_age_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -41,7 +41,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test spiral_matrix_test.py`
 - Python 3.4+: `pytest spiral_matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -51,7 +51,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test strain_test.py`
 - Python 3.4+: `pytest strain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sublist_test.py`
 - Python 3.4+: `pytest sublist_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sum_of_multiples_test.py`
 - Python 3.4+: `pytest sum_of_multiples_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test tournament_test.py`
 - Python 3.4+: `pytest tournament_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -76,7 +76,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test transpose_test.py`
 - Python 3.4+: `pytest transpose_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test tree_building_test.py`
 - Python 3.4+: `pytest tree_building_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -40,7 +40,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test triangle_test.py`
 - Python 3.4+: `pytest triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -39,7 +39,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test trinary_test.py`
 - Python 3.4+: `pytest trinary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test twelve_days_test.py`
 - Python 3.4+: `pytest twelve_days_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test two_bucket_test.py`
 - Python 3.4+: `pytest two_bucket_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test two_fer_test.py`
 - Python 3.4+: `pytest two_fer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test variable_length_quantity_test.py`
 - Python 3.4+: `pytest variable_length_quantity_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -29,7 +29,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test word_count_test.py`
 - Python 3.4+: `pytest word_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test word_search_test.py`
 - Python 3.4+: `pytest word_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -69,7 +69,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test wordy_test.py`
 - Python 3.4+: `pytest wordy_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/yacht/README.md
+++ b/exercises/yacht/README.md
@@ -53,7 +53,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test yacht_test.py`
 - Python 3.4+: `pytest yacht_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test zebra_puzzle_test.py`
 - Python 3.4+: `pytest zebra_puzzle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test zipper_test.py`
 - Python 3.4+: `pytest zipper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):


### PR DESCRIPTION
@cmccandless I deleted all Python 2.7 references in README. Does this look good for you? I can do that for other files too if this works.