### PR TITLE
Remove Python 2 references in exercise README template

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -21,11 +21,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest {{ .Spec.SnakeCaseName }}_test.py`
 
-- Python 3.4+: `pytest {{ .Spec.SnakeCaseName }}_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest {{ .Spec.SnakeCaseName }}_test.py`
 
 ### Common `pytest` options

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -23,7 +23,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test {{ .Spec.SnakeCaseName }}_test.py`
 - Python 3.4+: `pytest {{ .Spec.SnakeCaseName }}_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -25,6 +25,7 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -41,11 +42,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest accumulate_test.py`
 
-- Python 3.4+: `pytest accumulate_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest accumulate_test.py`
 
 ### Common `pytest` options

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test accumulate_test.py`
 - Python 3.4+: `pytest accumulate_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test acronym_test.py`
 - Python 3.4+: `pytest acronym_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -7,6 +7,7 @@ Techies love their TLA (Three Letter Acronyms)!
 Help generate some jargon by writing a program that converts a long name
 like Portable Network Graphics to its acronym (PNG).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -23,11 +24,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest acronym_test.py`
 
-- Python 3.4+: `pytest acronym_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest acronym_test.py`
 
 ### Common `pytest` options

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -69,6 +69,7 @@ harder to guess things based on word boundaries.
     - `15 * 7 mod 26 = 105 mod 26 = 1`
     - `7` is the MMI of `15 mod 26`
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -85,11 +86,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest affine_cipher_test.py`
 
-- Python 3.4+: `pytest affine_cipher_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest affine_cipher_test.py`
 
 ### Common `pytest` options

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -87,7 +87,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test affine_cipher_test.py`
 - Python 3.4+: `pytest affine_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -31,6 +31,7 @@ I think you got the idea!
 
 *Yes. Those three numbers above are exactly the same. Congratulations!*
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -47,11 +48,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest all_your_base_test.py`
 
-- Python 3.4+: `pytest all_your_base_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest all_your_base_test.py`
 
 ### Common `pytest` options

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test all_your_base_test.py`
 - Python 3.4+: `pytest all_your_base_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test allergies_test.py`
 - Python 3.4+: `pytest allergies_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -29,6 +29,7 @@ allergens that score 256, 512, 1024, etc.).  Your program should
 ignore those components of the score.  For example, if the allergy
 score is 257, your program should only report the eggs (1) allergy.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -45,11 +46,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest allergies_test.py`
 
-- Python 3.4+: `pytest allergies_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest allergies_test.py`
 
 ### Common `pytest` options

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test alphametics_test.py`
 - Python 3.4+: `pytest alphametics_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -31,6 +31,7 @@ a multi-digit number must not be zero.
 
 Write a function to solve alphametics puzzles.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -47,11 +48,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest alphametics_test.py`
 
-- Python 3.4+: `pytest alphametics_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest alphametics_test.py`
 
 ### Common `pytest` options

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -6,6 +6,7 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing
 `"inlets"`.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -22,11 +23,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest anagram_test.py`
 
-- Python 3.4+: `pytest anagram_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest anagram_test.py`
 
 ### Common `pytest` options

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test anagram_test.py`
 - Python 3.4+: `pytest anagram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -11,6 +11,7 @@ For example:
 
 Write some code to determine whether a number is an Armstrong number.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -27,11 +28,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest armstrong_numbers_test.py`
 
-- Python 3.4+: `pytest armstrong_numbers_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest armstrong_numbers_test.py`
 
 ### Common `pytest` options

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -29,7 +29,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test armstrong_numbers_test.py`
 - Python 3.4+: `pytest armstrong_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test atbash_cipher_test.py`
 - Python 3.4+: `pytest atbash_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -28,6 +28,7 @@ things based on word boundaries.
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest atbash_cipher_test.py`
 
-- Python 3.4+: `pytest atbash_cipher_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest atbash_cipher_test.py`
 
 ### Common `pytest` options

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bank_account_test.py`
 - Python 3.4+: `pytest bank_account_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -26,6 +26,7 @@ it.
 
 Have fun!
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest bank_account_test.py`
 
-- Python 3.4+: `pytest bank_account_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest bank_account_test.py`
 
 ### Common `pytest` options

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -320,6 +320,7 @@ are some additional things you could try:
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -336,11 +337,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest beer_song_test.py`
 
-- Python 3.4+: `pytest beer_song_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest beer_song_test.py`
 
 ### Common `pytest` options

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -338,7 +338,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test beer_song_test.py`
 - Python 3.4+: `pytest beer_song_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -53,6 +53,7 @@ And if we then added 1, 5, and 7, it would look like this
      / \     / \
     1   3   5   7
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -69,11 +70,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest binary_search_tree_test.py`
 
-- Python 3.4+: `pytest binary_search_tree_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest binary_search_tree_test.py`
 
 ### Common `pytest` options

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -71,7 +71,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_search_tree_test.py`
 - Python 3.4+: `pytest binary_search_tree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -34,6 +34,7 @@ A binary search halves the number of items to check with each iteration,
 so locating an item (or determining its absence) takes logarithmic time.
 A binary search is a dichotomic divide and conquer search algorithm.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -50,11 +51,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest binary_search_test.py`
 
-- Python 3.4+: `pytest binary_search_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest binary_search_test.py`
 
 ### Common `pytest` options

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_search_test.py`
 - Python 3.4+: `pytest binary_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test binary_test.py`
 - Python 3.4+: `pytest binary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -30,6 +30,7 @@ Binary is similar, but uses powers of 2 rather than powers of 10.
 
 So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -46,11 +47,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest binary_test.py`
 
-- Python 3.4+: `pytest binary_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest binary_test.py`
 
 ### Common `pytest` options

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -13,6 +13,9 @@ anything.
 
 He answers 'Whatever.' to anything else.
 
+Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
+
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -29,11 +32,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest bob_test.py`
 
-- Python 3.4+: `pytest bob_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest bob_test.py`
 
 ### Common `pytest` options

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bob_test.py`
 - Python 3.4+: `pytest bob_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -85,7 +85,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test book_store_test.py`
 - Python 3.4+: `pytest book_store_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -67,6 +67,7 @@ For a total of $51.20
 
 And $51.20 is the price with the biggest discount.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -83,11 +84,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest book_store_test.py`
 
-- Python 3.4+: `pytest book_store_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest book_store_test.py`
 
 ### Common `pytest` options

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -60,6 +60,7 @@ support two operations:
 * `score() : int` is called only at the very end of the game.  It
   returns the total score for that game.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -76,11 +77,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest bowling_test.py`
 
-- Python 3.4+: `pytest bowling_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest bowling_test.py`
 
 ### Common `pytest` options

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -78,7 +78,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bowling_test.py`
 - Python 3.4+: `pytest bowling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -22,7 +22,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test bracket_push_test.py`
 - Python 3.4+: `pytest bracket_push_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -4,6 +4,7 @@ Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
 or any combination thereof, verify that any and all pairs are matched
 and nested correctly.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -20,11 +21,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest bracket_push_test.py`
 
-- Python 3.4+: `pytest bracket_push_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest bracket_push_test.py`
 
 ### Common `pytest` options

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -16,6 +16,7 @@ that the sum of the coins' value would equal the correct amount of change.
 - Can you ask for negative change?
 - Can you ask for a change value smaller than the smallest coin value?
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -32,11 +33,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest change_test.py`
 
-- Python 3.4+: `pytest change_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest change_test.py`
 
 ### Common `pytest` options

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -34,7 +34,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test change_test.py`
 - Python 3.4+: `pytest change_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -50,6 +50,7 @@ the buffer is once again full.
 
     [D][7][8][9][A][B][C]
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -66,11 +67,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest circular_buffer_test.py`
 
-- Python 3.4+: `pytest circular_buffer_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest circular_buffer_test.py`
 
 ### Common `pytest` options

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -68,7 +68,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test circular_buffer_test.py`
 - Python 3.4+: `pytest circular_buffer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -6,6 +6,7 @@ You should be able to add and subtract minutes to it.
 
 Two clocks that represent the same time should be equal to each other.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -22,11 +23,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest clock_test.py`
 
-- Python 3.4+: `pytest clock_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest clock_test.py`
 
 ### Common `pytest` options

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test clock_test.py`
 - Python 3.4+: `pytest clock_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -31,6 +31,7 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 The Collatz Conjecture is only concerned with strictly positive integers, so your solution should raise a `ValueError` with a meaningful message if given 0 or a negative integer.
 
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -47,11 +48,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest collatz_conjecture_test.py`
 
-- Python 3.4+: `pytest collatz_conjecture_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest collatz_conjecture_test.py`
 
 ### Common `pytest` options

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test collatz_conjecture_test.py`
 - Python 3.4+: `pytest collatz_conjecture_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -54,7 +54,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test complex_numbers_test.py`
 - Python 3.4+: `pytest complex_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -19,10 +19,7 @@ The reciprocal of a non-zero complex number is
 Dividing a complex number `a + i * b` by another `c + i * d` gives:
 `(a + i * b) / (c + i * d) = (a * c + b * d)/(c^2 + d^2) + (b * c - a * d)/(c^2 + d^2) * i`.
 
-Exponent of a complex number can be expressed as
-`exp(a + i * b) = exp(a) * exp(i * b)`,
-and the last term is given by Euler's formula `exp(i * b) = cos(b) + i * sin(b)`.
-
+Raising e to a complex exponent can be expressed as `e^(a + i * b) = e^a * e^(i * b)`, the last term of which is given by Euler's formula `e^(i * b) = cos(b) + i * sin(b)`.
 
 Implement the following operations:
  - addition, subtraction, multiplication and division of two complex numbers,
@@ -34,6 +31,7 @@ Assume the programming language you are using does not have an implementation of
 ## Hints
 
 See [Emulating numeric types](https://docs.python.org/2/reference/datamodel.html#emulating-numeric-types) for help on operator overloading.
+
 
 
 ## Exception messages
@@ -52,11 +50,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest complex_numbers_test.py`
 
-- Python 3.4+: `pytest complex_numbers_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest complex_numbers_test.py`
 
 ### Common `pytest` options

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test connect_test.py`
 - Python 3.4+: `pytest connect_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -30,6 +30,7 @@ the representation passed to your code):
 the above example `O` has made a connection from left to right but nobody has
 won since `O` didn't connect top and bottom.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -46,11 +47,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest connect_test.py`
 
-- Python 3.4+: `pytest connect_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest connect_test.py`
 
 ### Common `pytest` options

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -59,7 +59,7 @@ chunks with a single trailing space.
 ```
 
 Notice that were we to stack these, we could visually decode the
-cyphertext back in to the original message:
+ciphertext back in to the original message:
 
 ```text
 "imtgdvs"
@@ -71,6 +71,7 @@ cyphertext back in to the original message:
 "aohghn "
 "sseoau "
 ```
+
 
 ## Exception messages
 
@@ -88,11 +89,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest crypto_square_test.py`
 
-- Python 3.4+: `pytest crypto_square_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest crypto_square_test.py`
 
 ### Common `pytest` options

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -90,7 +90,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test crypto_square_test.py`
 - Python 3.4+: `pytest crypto_square_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test custom_set_test.py`
 - Python 3.4+: `pytest custom_set_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -7,6 +7,7 @@ type, like a set. In this exercise you will define your own set. How it
 works internally doesn't matter, as long as it behaves like a set of
 unique elements.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -23,11 +24,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest custom_set_test.py`
 
-- Python 3.4+: `pytest custom_set_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest custom_set_test.py`
 
 ### Common `pytest` options

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -15,6 +15,7 @@ In our particular instance of the game, the target rewards with 4 different amou
 The outer circle has a radius of 10 units (This is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered to the same point (That is, the circles are [concentric](http://mathworld.wolfram.com/ConcentricCircles.html)) defined by the coordinates (0, 0).
 
 Write a function that given a point in the target (defined by its `real` cartesian coordinates `x` and `y`), returns the correct amount earned by a dart landing in that point.
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -31,11 +32,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest darts_test.py`
 
-- Python 3.4+: `pytest darts_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest darts_test.py`
 
 ### Common `pytest` options

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test darts_test.py`
 - Python 3.4+: `pytest darts_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -52,6 +52,7 @@ E·······E
 ····A····
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -68,11 +69,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest diamond_test.py`
 
-- Python 3.4+: `pytest diamond_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest diamond_test.py`
 
 ### Common `pytest` options

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -70,7 +70,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test diamond_test.py`
 - Python 3.4+: `pytest diamond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -12,6 +12,11 @@ Hence the difference between the square of the sum of the first
 ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
+You are not expected to discover an efficient solution to this yourself from
+first principles; research is allowed, indeed, encouraged. Finding the best
+algorithm for the problem is a key skill in software engineering.
+
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -28,11 +33,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest difference_of_squares_test.py`
 
-- Python 3.4+: `pytest difference_of_squares_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest difference_of_squares_test.py`
 
 ### Common `pytest` options

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test difference_of_squares_test.py`
 - Python 3.4+: `pytest difference_of_squares_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -54,6 +54,7 @@ cryptographically strong random numbers that provide the greater security requir
 Since this is only an exercise, `random` is fine to use, but note that **it would be
 very insecure if actually used for cryptography.**
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -70,11 +71,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest diffie_hellman_test.py`
 
-- Python 3.4+: `pytest diffie_hellman_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest diffie_hellman_test.py`
 
 ### Common `pytest` options

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -72,7 +72,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test diffie_hellman_test.py`
 - Python 3.4+: `pytest diffie_hellman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dnd-character/README.md
+++ b/exercises/dnd-character/README.md
@@ -50,7 +50,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dnd_character_test.py`
 - Python 3.4+: `pytest dnd_character_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dnd-character/README.md
+++ b/exercises/dnd-character/README.md
@@ -1,4 +1,4 @@
-# Dnd Character
+# D&D Character
 
 For a game of [Dungeons & Dragons][DND], each player starts by generating a
 character they can play with. This character has, among other things, six
@@ -32,6 +32,7 @@ programming languages are designed to roll dice. One such language is [Troll].
 [DND]: https://en.wikipedia.org/wiki/Dungeons_%26_Dragons
 [Troll]: http://hjemmesider.diku.dk/~torbenm/Troll/
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -48,11 +49,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest dnd_character_test.py`
 
-- Python 3.4+: `pytest dnd_character_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest dnd_character_test.py`
 
 ### Common `pytest` options

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -4,8 +4,8 @@ Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
-neighbouring half of an adjacent stone) and that dots on the halfs of the stones
-which don't have a neighbour (the first and last stone) match each other.
+neighbouring half of an adjacent stone) and that dots on the halves of the
+stones which don't have a neighbour (the first and last stone) match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
@@ -13,6 +13,7 @@ like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, wher
 For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same. 4 != 3
 
 Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
+
 
 ## Exception messages
 
@@ -30,11 +31,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest dominoes_test.py`
 
-- Python 3.4+: `pytest dominoes_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest dominoes_test.py`
 
 ### Common `pytest` options

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dominoes_test.py`
 - Python 3.4+: `pytest dominoes_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test dot_dsl_test.py`
 - Python 3.4+: `pytest dot_dsl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -6,10 +6,9 @@ A [Domain Specific Language
 (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
 small language optimized for a specific domain.
 
-For example the dot language of [Graphviz](http://graphviz.org) allows
-you to write a textual description of a graph which is then transformed
-into a picture by one of the graphviz tools (such as `dot`). A simple
-graph looks like this:
+For example the [DOT language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) allows
+you to write a textual description of a graph which is then transformed into a picture by one of
+the [Graphviz](http://graphviz.org/) tools (such as `dot`). A simple graph looks like this:
 
     graph {
         graph [bgcolor="yellow"]
@@ -40,6 +39,7 @@ The implementations of `Node` and `Edge` provided in `dot_dsl.py`.
 Observe the test cases in `dot_dsl_test.py` to understand the DSL's design.
 
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -56,11 +56,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest dot_dsl_test.py`
 
-- Python 3.4+: `pytest dot_dsl_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest dot_dsl_test.py`
 
 ### Common `pytest` options

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -37,7 +37,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test error_handling_test.py`
 - Python 3.4+: `pytest error_handling_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -19,6 +19,7 @@ class implements the following methods:
 - `do_something`, which may or may not throw an `Exception`.
 
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -35,11 +36,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest error_handling_test.py`
 
-- Python 3.4+: `pytest error_handling_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest error_handling_test.py`
 
 ### Common `pytest` options

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -46,6 +46,7 @@ variety of languages, each with its own unique scoring table. For
 example, an "E" is scored at 2 in the Māori-language version of the
 game while being scored at 4 in the Hawaiian-language version.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -62,11 +63,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest etl_test.py`
 
-- Python 3.4+: `pytest etl_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest etl_test.py`
 
 ### Common `pytest` options

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -64,7 +64,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test etl_test.py`
 - Python 3.4+: `pytest etl_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -10,6 +10,7 @@ input: [1,[2,3,null,4],[null],5]
 
 output: [1,2,3,4,5]
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -26,11 +27,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest flatten_array_test.py`
 
-- Python 3.4+: `pytest flatten_array_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest flatten_array_test.py`
 
 ### Common `pytest` options

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -28,7 +28,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test flatten_array_test.py`
 - Python 3.4+: `pytest flatten_array_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -81,7 +81,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test food_chain_test.py`
 - Python 3.4+: `pytest food_chain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -63,6 +63,7 @@ I know an old lady who swallowed a horse.
 She's dead, of course!
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -79,11 +80,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest food_chain_test.py`
 
-- Python 3.4+: `pytest food_chain_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest food_chain_test.py`
 
 ### Common `pytest` options

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -25,6 +25,7 @@ enough.)
 
 Words are case-insensitive.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -41,11 +42,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest forth_test.py`
 
-- Python 3.4+: `pytest forth_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest forth_test.py`
 
 ### Common `pytest` options

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test forth_test.py`
 - Python 3.4+: `pytest forth_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -22,7 +22,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test gigasecond_test.py`
 - Python 3.4+: `pytest gigasecond_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,8 +1,10 @@
 # Gigasecond
 
-Calculate the moment when someone has lived for 10^9 seconds.
+Given a moment, determine the moment that would be after a gigasecond
+has passed.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.
+
 
 ## Exception messages
 
@@ -20,11 +22,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest gigasecond_test.py`
 
-- Python 3.4+: `pytest gigasecond_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest gigasecond_test.py`
 
 ### Common `pytest` options

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -35,6 +35,7 @@ For more information see
 [wikipedia](https://en.wikipedia.org/wiki/Go_%28game%29) or [Sensei's
 Library](http://senseis.xmp.net/).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -51,11 +52,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest go_counting_test.py`
 
-- Python 3.4+: `pytest go_counting_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest go_counting_test.py`
 
 ### Common `pytest` options

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -53,7 +53,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test go_counting_test.py`
 - Python 3.4+: `pytest go_counting_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grade_school_test.py`
 - Python 3.4+: `pytest grade_school_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -34,6 +34,7 @@ are some additional things you could try:
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -50,11 +51,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest grade_school_test.py`
 
-- Python 3.4+: `pytest grade_school_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest grade_school_test.py`
 
 ### Common `pytest` options

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -6,14 +6,14 @@ on each square doubles.
 There once was a wise servant who saved the life of a prince. The king
 promised to pay whatever the servant could dream up. Knowing that the
 king loved chess, the servant told the king he would like to have grains
-of wheat. One grain on the first square of a chess board. Two grains on
-the next. Four on the third, and so on.
+of wheat. One grain on the first square of a chess board, with the number
+of grains doubling on each successive square.
 
-There are 64 squares on a chessboard.
+There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
 
 Write code that shows:
-- how many grains were on each square, and
-- the total number of grains
+- how many grains were on a given square, and
+- the total number of grains on the chessboard
 
 ## For bonus points
 
@@ -25,6 +25,7 @@ are some additional things you could try:
 
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?
+
 
 ## Exception messages
 
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest grains_test.py`
 
-- Python 3.4+: `pytest grains_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest grains_test.py`
 
 ### Common `pytest` options

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grains_test.py`
 - Python 3.4+: `pytest grains_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -64,6 +64,7 @@ The `grep` command should support multiple flags at once.
 For example, running `grep -l -v "hello" file1.txt file2.txt` should
 print the names of files that do not contain the string "hello".
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -80,11 +81,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest grep_test.py`
 
-- Python 3.4+: `pytest grep_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest grep_test.py`
 
 ### Common `pytest` options

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test grep_test.py`
 - Python 3.4+: `pytest grep_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -2,16 +2,9 @@
 
 Calculate the Hamming Distance between two DNA strands.
 
-Your body is made up of cells that contain DNA. Those cells regularly
-wear out and need replacing, which they achieve by dividing into
-daughter cells. In fact, the average human body experiences about 10
-quadrillion cell divisions in a lifetime!
+Your body is made up of cells that contain DNA. Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells. In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
 
-When cells divide, their DNA replicates too. Sometimes during this
-process mistakes happen and single pieces of DNA get encoded with the
-incorrect information. If we compare two strands of DNA and count the
-differences between them we can see how many mistakes occurred. This is
-known as the "Hamming Distance".
+When cells divide, their DNA replicates too. Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information. If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred. This is known as the "Hamming Distance".
 
 We read DNA using the letters C,A,G and T. Two strands might look like this:
 
@@ -21,8 +14,7 @@ We read DNA using the letters C,A,G and T. Two strands might look like this:
 
 They have 7 differences, and therefore the Hamming Distance is 7.
 
-The Hamming Distance is useful for lots of things in science, not just biology,
-so it's a nice phrase to be familiar with :)
+The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
 
 # Implementation notes
 
@@ -30,6 +22,7 @@ The Hamming distance is only defined for sequences of equal length, so
 an attempt to calculate it between sequences of different lengths should
 not work. The general handling of this situation (e.g., raising an
 exception vs returning a special value) may differ between languages.
+
 
 ## Exception messages
 
@@ -47,11 +40,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest hamming_test.py`
 
-- Python 3.4+: `pytest hamming_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest hamming_test.py`
 
 ### Common `pytest` options

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hamming_test.py`
 - Python 3.4+: `pytest hamming_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -40,7 +40,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hangman_test.py`
 - Python 3.4+: `pytest hangman_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -38,11 +38,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest hangman_test.py`
 
-- Python 3.4+: `pytest hangman_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest hangman_test.py`
 
 ### Common `pytest` options

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -14,6 +14,7 @@ The objectives are simple:
 
 If everything goes well, you will be ready to fetch your first real exercise.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -30,11 +31,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest hello_world_test.py`
 
-- Python 3.4+: `pytest hello_world_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest hello_world_test.py`
 
 ### Common `pytest` options

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hello_world_test.py`
 - Python 3.4+: `pytest hello_world_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test hexadecimal_test.py`
 - Python 3.4+: `pytest hexadecimal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -7,6 +7,7 @@ teal: 008080, navy: 000080).
 
 The program should handle invalid hexadecimal strings.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -23,11 +24,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest hexadecimal_test.py`
 
-- Python 3.4+: `pytest hexadecimal_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest hexadecimal_test.py`
 
 ### Common `pytest` options

--- a/exercises/high-scores/README.md
+++ b/exercises/high-scores/README.md
@@ -4,19 +4,49 @@ Manage a game player's High Score list.
 
 Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.
 
+
+## Exception messages
+
+Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
+indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. Not
+every exercise will require you to raise an exception, but for those that do, the tests will only pass if you include
+a message.
+
+To raise a message with an exception, just write it as an argument to the exception type. For example, instead of
+`raise Exception`, you should write:
+
+```python
+raise Exception("Meaningful message indicating the source of the error")
+```
+
+## Running the tests
+
+To run the tests, run `pytest high_scores_test.py`
+
+Alternatively, you can tell Python to run the pytest module:
+`python -m pytest high_scores_test.py`
+
+### Common `pytest` options
+
+- `-v` : enable verbose output
+- `-x` : stop running tests on first failure
+- `--ff` : run failures from previous test before running other test cases
+
+For other options, see `python -m pytest -h`
+
 ## Submitting Exercises
 
-Note that, when trying to submit an exercise, make sure the solution is in the `exercism/python/<exerciseName>` directory.
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/python/high-scores` directory.
 
-For example, if you're submitting `bob.py` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/python/bob/bob.py`.
-
+You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Workspace`.
 
 For more detailed information about running tests, code style and linting,
-please see the [help page](http://exercism.io/languages/python).
+please see [Running the Tests](http://exercism.io/tracks/python/tests).
 
 ## Source
 
 Tribute to the eighties' arcade game Frogger
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -105,6 +105,7 @@ that ate the malt
 that lay in the house that Jack built.
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -121,11 +122,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest house_test.py`
 
-- Python 3.4+: `pytest house_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest house_test.py`
 
 ### Common `pytest` options

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -123,7 +123,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test house_test.py`
 - Python 3.4+: `pytest house_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -40,6 +40,7 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 * Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
 
 * Generate valid ISBN, maybe even from a given starting ISBN.
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -56,11 +57,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest isbn_verifier_test.py`
 
-- Python 3.4+: `pytest isbn_verifier_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest isbn_verifier_test.py`
 
 ### Common `pytest` options

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test isbn_verifier_test.py`
 - Python 3.4+: `pytest isbn_verifier_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -13,6 +13,7 @@ Examples of isograms:
 
 The word *isograms*, however, is not an isogram, because the s repeats.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -29,11 +30,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest isogram_test.py`
 
-- Python 3.4+: `pytest isogram_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest isogram_test.py`
 
 ### Common `pytest` options

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test isogram_test.py`
 - Python 3.4+: `pytest isogram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -59,6 +59,7 @@ While asking for Bob's plants would yield:
 
 - Clover, grass, clover, clover
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -75,11 +76,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest kindergarten_garden_test.py`
 
-- Python 3.4+: `pytest kindergarten_garden_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest kindergarten_garden_test.py`
 
 ### Common `pytest` options

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -77,7 +77,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test kindergarten_garden_test.py`
 - Python 3.4+: `pytest kindergarten_garden_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -13,6 +13,7 @@ in the input; the digits need not be *numerically consecutive*.
 For the input `'73167176531330624919225119674426574742355349194934'`,
 the largest product for a series of 6 digits is 23520.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -29,11 +30,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest largest_series_product_test.py`
 
-- Python 3.4+: `pytest largest_series_product_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest largest_series_product_test.py`
 
 ### Common `pytest` options

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -31,7 +31,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test largest_series_product_test.py`
 - Python 3.4+: `pytest largest_series_product_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -13,9 +13,6 @@ on every year that is evenly divisible by 4
 For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
 year, but 2000 is.
 
-If your language provides a method in the standard library that does
-this look-up, pretend it doesn't exist and implement it yourself.
-
 ## Notes
 
 Though our exercise adopts some very simple rules, there is more to
@@ -25,6 +22,7 @@ For a delightful, four minute explanation of the whole leap year
 phenomenon, go watch [this youtube video][video].
 
 [video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
 
 ## Exception messages
 
@@ -42,11 +40,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest leap_test.py`
 
-- Python 3.4+: `pytest leap_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest leap_test.py`
 
 ### Common `pytest` options

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test leap_test.py`
 - Python 3.4+: `pytest leap_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ledger/README.md
+++ b/exercises/ledger/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test ledger_test.py`
 - Python 3.4+: `pytest ledger_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ledger/README.md
+++ b/exercises/ledger/README.md
@@ -14,6 +14,7 @@ working version.  Version control tools like git can help here as well.
 Please keep a log of what changes you've made and make a comment on the exercise
 containing that log, this will help reviewers.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -30,11 +31,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest ledger_test.py`
 
-- Python 3.4+: `pytest ledger_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest ledger_test.py`
 
 ### Common `pytest` options

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test linked_list_test.py`
 - Python 3.4+: `pytest linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -27,6 +27,7 @@ empty list.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -43,11 +44,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest linked_list_test.py`
 
-- Python 3.4+: `pytest linked_list_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest linked_list_test.py`
 
 ### Common `pytest` options

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -19,6 +19,7 @@ operations you will implement include:
 * `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
 * `reverse` (*given a list, return a list with all the original items, but in reversed order*);
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -35,11 +36,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest list_ops_test.py`
 
-- Python 3.4+: `pytest list_ops_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest list_ops_test.py`
 
 ### Common `pytest` options

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -37,7 +37,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test list_ops_test.py`
 - Python 3.4+: `pytest list_ops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -64,6 +64,7 @@ Sum the digits
 
 57 is not evenly divisible by 10, so this number is not valid.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -80,11 +81,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest luhn_test.py`
 
-- Python 3.4+: `pytest luhn_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest luhn_test.py`
 
 ### Common `pytest` options

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test luhn_test.py`
 - Python 3.4+: `pytest luhn_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test markdown_test.py`
 - Python 3.4+: `pytest markdown_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -14,6 +14,7 @@ It would be helpful if you made notes of what you did in your refactoring in
 comments so reviewers can see that, but it isn't strictly necessary. The most
 important thing is to make the code better!
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -30,11 +31,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest markdown_test.py`
 
-- Python 3.4+: `pytest markdown_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest markdown_test.py`
 
 ### Common `pytest` options

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -40,6 +40,7 @@ And its columns:
 - 8, 3, 6
 - 7, 2, 7
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -56,11 +57,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest matrix_test.py`
 
-- Python 3.4+: `pytest matrix_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest matrix_test.py`
 
 ### Common `pytest` options

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -58,7 +58,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test matrix_test.py`
 - Python 3.4+: `pytest matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -26,6 +26,7 @@ Given examples of a meetup dates, each containing a month, day, year, and
 descriptor calculate the date of the actual meetup.  For example, if given
 "The first Monday of January 2017", the correct meetup date is 2017/1/2.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest meetup_test.py`
 
-- Python 3.4+: `pytest meetup_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest meetup_test.py`
 
 ### Common `pytest` options

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test meetup_test.py`
 - Python 3.4+: `pytest meetup_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test minesweeper_test.py`
 - Python 3.4+: `pytest minesweeper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -26,6 +26,7 @@ into this:
     | 111 |
     +-----+
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest minesweeper_test.py`
 
-- Python 3.4+: `pytest minesweeper_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest minesweeper_test.py`
 
 ### Common `pytest` options

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -8,6 +8,7 @@ the 6th prime is 13.
 If your language provides methods in the standard library to deal with prime
 numbers, pretend they don't exist and implement them yourself.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -24,11 +25,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest nth_prime_test.py`
 
-- Python 3.4+: `pytest nth_prime_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest nth_prime_test.py`
 
 ### Common `pytest` options

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test nth_prime_test.py`
 - Python 3.4+: `pytest nth_prime_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -12,6 +12,7 @@ Here is an analogy:
 - legos are to lego houses as
 - words are to sentences as...
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -28,11 +29,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest nucleotide_count_test.py`
 
-- Python 3.4+: `pytest nucleotide_count_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest nucleotide_count_test.py`
 
 ### Common `pytest` options

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test nucleotide_count_test.py`
 - Python 3.4+: `pytest nucleotide_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -96,7 +96,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test ocr_numbers_test.py`
 - Python 3.4+: `pytest ocr_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -78,6 +78,7 @@ Update your program to handle multiple numbers, one per line. When converting se
 
 Is converted to "123,456,789"
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -94,11 +95,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest ocr_numbers_test.py`
 
-- Python 3.4+: `pytest ocr_numbers_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest ocr_numbers_test.py`
 
 ### Common `pytest` options

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -46,6 +46,7 @@ So:
  = 155
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -62,11 +63,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest octal_test.py`
 
-- Python 3.4+: `pytest octal_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest octal_test.py`
 
 ### Common `pytest` options

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -64,7 +64,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test octal_test.py`
 - Python 3.4+: `pytest octal_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -32,6 +32,7 @@ Given the range `[10, 99]` (both inclusive)...
 The smallest palindrome product is `121`. Its factors are `(11, 11)`.
 The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -48,11 +49,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest palindrome_products_test.py`
 
-- Python 3.4+: `pytest palindrome_products_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest palindrome_products_test.py`
 
 ### Common `pytest` options

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -50,7 +50,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test palindrome_products_test.py`
 - Python 3.4+: `pytest palindrome_products_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -8,6 +8,7 @@ The best known English pangram is:
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
 insensitive. Input will not contain non-ASCII symbols.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -24,11 +25,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest pangram_test.py`
 
-- Python 3.4+: `pytest pangram_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest pangram_test.py`
 
 ### Common `pytest` options

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pangram_test.py`
 - Python 3.4+: `pytest pangram_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -25,7 +25,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test parallel_letter_frequency_test.py`
 - Python 3.4+: `pytest parallel_letter_frequency_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -7,6 +7,7 @@ sequentially. A common example is counting the frequency of letters.
 Create a function that returns the total frequency of each letter in a
 list of texts and that employs parallelism.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -23,11 +24,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest parallel_letter_frequency_test.py`
 
-- Python 3.4+: `pytest parallel_letter_frequency_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest parallel_letter_frequency_test.py`
 
 ### Common `pytest` options

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -14,6 +14,7 @@ the right and left of the current position in the previous row.
 # ... etc
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -30,11 +31,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest pascals_triangle_test.py`
 
-- Python 3.4+: `pytest pascals_triangle_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest pascals_triangle_test.py`
 
 ### Common `pytest` options

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -32,7 +32,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pascals_triangle_test.py`
 - Python 3.4+: `pytest pascals_triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test perfect_numbers_test.py`
 - Python 3.4+: `pytest perfect_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -17,6 +17,7 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
 
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -33,11 +34,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest perfect_numbers_test.py`
 
-- Python 3.4+: `pytest perfect_numbers_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest perfect_numbers_test.py`
 
 ### Common `pytest` options

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test phone_number_test.py`
 - Python 3.4+: `pytest phone_number_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -28,6 +28,7 @@ should all produce the output
 
 **Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest phone_number_test.py`
 
-- Python 3.4+: `pytest phone_number_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest phone_number_test.py`
 
 ### Common `pytest` options

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -17,6 +17,7 @@ variants too.
 
 See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -33,11 +34,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest pig_latin_test.py`
 
-- Python 3.4+: `pytest pig_latin_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest pig_latin_test.py`
 
 ### Common `pytest` options

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pig_latin_test.py`
 - Python 3.4+: `pytest pig_latin_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -52,7 +52,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test point_mutations_test.py`
 - Python 3.4+: `pytest point_mutations_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -34,6 +34,7 @@ distance function.
 
 **Note: This problem is deprecated, replaced by the one called `hamming`.**
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -50,11 +51,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest point_mutations_test.py`
 
-- Python 3.4+: `pytest point_mutations_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest point_mutations_test.py`
 
 ### Common `pytest` options

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -23,7 +23,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test poker_test.py`
 - Python 3.4+: `pytest poker_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -5,6 +5,7 @@ Pick the best hand(s) from a list of poker hands.
 See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an
 overview of poker hands.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -21,11 +22,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest poker_test.py`
 
-- Python 3.4+: `pytest poker_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest poker_test.py`
 
 ### Common `pytest` options

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -37,6 +37,7 @@ a different leaf node) can be seen to follow the path 6-2-0-3-9
 This exercise involves taking an input graph and re-orientating it from the point
 of view of one of the nodes.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -53,11 +54,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest pov_test.py`
 
-- Python 3.4+: `pytest pov_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest pov_test.py`
 
 ### Common `pytest` options

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -55,7 +55,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pov_test.py`
 - Python 3.4+: `pytest pov_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test prime_factors_test.py`
 - Python 3.4+: `pytest prime_factors_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -29,6 +29,7 @@ You can check this yourself:
 - = 60
 - Success!
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -45,11 +46,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest prime_factors_test.py`
 
-- Python 3.4+: `pytest prime_factors_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest prime_factors_test.py`
 
 ### Common `pytest` options

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -59,7 +59,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test protein_translation_test.py`
 - Python 3.4+: `pytest protein_translation_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -41,6 +41,7 @@ UAA, UAG, UGA         | STOP
 
 Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -57,11 +58,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest protein_translation_test.py`
 
-- Python 3.4+: `pytest protein_translation_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest protein_translation_test.py`
 
 ### Common `pytest` options

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -34,7 +34,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test proverb_test.py`
 - Python 3.4+: `pytest proverb_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -16,6 +16,7 @@ And all for the want of a nail.
 
 Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -32,11 +33,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest proverb_test.py`
 
-- Python 3.4+: `pytest proverb_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest proverb_test.py`
 
 ### Common `pytest` options

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -7,15 +7,22 @@ which,
 a**2 + b**2 = c**2
 ```
 
+and such that,
+
+```text
+a < b < c
+```
+
 For example,
 
 ```text
 3**2 + 4**2 = 9 + 16 = 25 = 5**2.
 ```
 
-There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.
 
-Find the product a * b * c.
+For example, with N = 1000, there is exactly one Pythagorean triplet for which `a + b + c = 1000`: `{200, 375, 425}`.
+
 
 ## Exception messages
 
@@ -33,11 +40,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest pythagorean_triplet_test.py`
 
-- Python 3.4+: `pytest pythagorean_triplet_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest pythagorean_triplet_test.py`
 
 ### Common `pytest` options

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test pythagorean_triplet_test.py`
 - Python 3.4+: `pytest pythagorean_triplet_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -26,6 +26,7 @@ You'd also be able to answer whether the queens can attack each other.
 In this case, that answer would be yes, they can, because both pieces
 share a diagonal.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest queen_attack_test.py`
 
-- Python 3.4+: `pytest queen_attack_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest queen_attack_test.py`
 
 ### Common `pytest` options

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test queen_attack_test.py`
 - Python 3.4+: `pytest queen_attack_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -76,7 +76,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rail_fence_cipher_test.py`
 - Python 3.4+: `pytest rail_fence_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -58,6 +58,7 @@ W . . . E . . . C . . . R . . . L . . . T . . . E
 
 If you now read along the zig-zag shape you can read the original message.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -74,11 +75,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rail_fence_cipher_test.py`
 
-- Python 3.4+: `pytest rail_fence_cipher_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rail_fence_cipher_test.py`
 
 ### Common `pytest` options

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test raindrops_test.py`
 - Python 3.4+: `pytest raindrops_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -17,6 +17,7 @@ Convert a number to a string, the contents of which depend on the number's facto
 - 34 has four factors: 1, 2, 17, and 34.
   - In raindrop-speak, this would be "34".
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -33,11 +34,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest raindrops_test.py`
 
-- Python 3.4+: `pytest raindrops_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest raindrops_test.py`
 
 ### Common `pytest` options

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rational_numbers_test.py`
 - Python 3.4+: `pytest rational_numbers_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -28,6 +28,7 @@ Your implementation of rational numbers should always be reduced to lowest terms
 
 Assume that the programming language you are using does not have an implementation of rational numbers.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rational_numbers_test.py`
 
-- Python 3.4+: `pytest rational_numbers_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rational_numbers_test.py`
 
 ### Common `pytest` options

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -15,6 +15,7 @@ In addition, compute cells should allow for registering change notification
 callbacks.  Call a cell’s callbacks when the cell’s value in a new stable
 state has changed from the previous stable state.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -31,11 +32,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest react_test.py`
 
-- Python 3.4+: `pytest react_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest react_test.py`
 
 ### Common `pytest` options

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test react_test.py`
 - Python 3.4+: `pytest react_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -63,6 +63,7 @@ The above diagram contains 6 rectangles:
 You may assume that the input is always a proper rectangle (i.e. the length of
 every line equals the length of the first line).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -79,11 +80,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rectangles_test.py`
 
-- Python 3.4+: `pytest rectangles_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rectangles_test.py`
 
 ### Common `pytest` options

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -81,7 +81,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rectangles_test.py`
 - Python 3.4+: `pytest rectangles_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -38,7 +38,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test resistor_color_test.py`
 - Python 3.4+: `pytest resistor_color_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -36,11 +36,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest resistor_color_test.py`
 
-- Python 3.4+: `pytest resistor_color_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest resistor_color_test.py`
 
 ### Common `pytest` options

--- a/exercises/rest-api/README.md
+++ b/exercises/rest-api/README.md
@@ -38,6 +38,7 @@ Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/R
 - Example RESTful APIs
   - [GitHub](https://developer.github.com/v3/)
   - [Reddit](https://www.reddit.com/dev/api/)
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -54,11 +55,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rest_api_test.py`
 
-- Python 3.4+: `pytest rest_api_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rest_api_test.py`
 
 ### Common `pytest` options

--- a/exercises/rest-api/README.md
+++ b/exercises/rest-api/README.md
@@ -56,7 +56,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rest_api_test.py`
 - Python 3.4+: `pytest rest_api_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/retree/README.md
+++ b/exercises/retree/README.md
@@ -28,6 +28,7 @@ Note: the first item in the pre-order traversal is always the root.
 
 [wiki]: https://en.wikipedia.org/wiki/Tree_traversal
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422$
+To run the tests, run `pytest retree_test.py`
 
-- Python 3.4+: `pytest retree_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest retree_test.py`
 
 ### Common `pytest` options

--- a/exercises/retree/README.md
+++ b/exercises/retree/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422$
 
-- Python 2.7: `py.test retree_test.py`
 - Python 3.4+: `pytest retree_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -24,7 +24,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test reverse_string_test.py`
 - Python 3.4+: `pytest reverse_string_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -6,6 +6,7 @@ For example:
 input: "cool"
 output: "looc"
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -22,11 +23,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest reverse_string_test.py`
 
-- Python 3.4+: `pytest reverse_string_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest reverse_string_test.py`
 
 ### Common `pytest` options

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -36,7 +36,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rna_transcription_test.py`
 - Python 3.4+: `pytest rna_transcription_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -18,6 +18,7 @@ each nucleotide with its complement:
 * `T` -> `A`
 * `A` -> `U`
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -34,11 +35,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rna_transcription_test.py`
 
-- Python 3.4+: `pytest rna_transcription_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rna_transcription_test.py`
 
 ### Common `pytest` options

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -15,6 +15,7 @@ The names must be random: they should not follow a predictable sequence.
 Random names means a risk of collisions. Your solution must ensure that
 every existing robot has a unique name.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -31,11 +32,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest robot_name_test.py`
 
-- Python 3.4+: `pytest robot_name_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest robot_name_test.py`
 
 ### Common `pytest` options

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -33,7 +33,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test robot_name_test.py`
 - Python 3.4+: `pytest robot_name_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test robot_simulator_test.py`
 - Python 3.4+: `pytest robot_simulator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -27,6 +27,7 @@ direction it is pointing.
 - Say a robot starts at {7, 3} facing north. Then running this stream
   of instructions should leave it at {9, 4} facing west.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -43,11 +44,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest robot_simulator_test.py`
 
-- Python 3.4+: `pytest robot_simulator_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest robot_simulator_test.py`
 
 ### Common `pytest` options

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -60,7 +60,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test roman_numerals_test.py`
 - Python 3.4+: `pytest roman_numerals_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -42,6 +42,7 @@ In Roman numerals 1990 is MCMXC:
 
 See also: http://www.novaroma.org/via_romana/numbers.html
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -58,11 +59,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest roman_numerals_test.py`
 
-- Python 3.4+: `pytest roman_numerals_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest roman_numerals_test.py`
 
 ### Common `pytest` options

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -30,6 +30,7 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -46,11 +47,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest rotational_cipher_test.py`
 
-- Python 3.4+: `pytest rotational_cipher_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest rotational_cipher_test.py`
 
 ### Common `pytest` options

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -48,7 +48,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test rotational_cipher_test.py`
 - Python 3.4+: `pytest rotational_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -41,7 +41,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test run_length_encoding_test.py`
 - Python 3.4+: `pytest run_length_encoding_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -23,6 +23,7 @@ the letters A through Z (either lower or upper case) and whitespace. This way
 data to be encoded will never contain any numbers and numbers inside data to
 be decoded always represent the count for the following character.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -39,11 +40,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest run_length_encoding_test.py`
 
-- Python 3.4+: `pytest run_length_encoding_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest run_length_encoding_test.py`
 
 ### Common `pytest` options

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test saddle_points_test.py`
 - Python 3.4+: `pytest saddle_points_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -8,11 +8,11 @@ So say you have a matrix like so:
     1  2  3
   |---------
 1 | 9  8  7
-2 | 5  3  2     <--- saddle point at (2,1)
+2 | 5  3  2     <--- saddle point at column 1, row 2, with value 5
 3 | 6  6  7
 ```
 
-It has a saddle point at (2, 1).
+It has a saddle point at column 1, row 2.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in
@@ -23,8 +23,11 @@ A matrix may have zero or more saddle points.
 Your code should be able to provide the (possibly empty) list of all the
 saddle points for any given matrix.
 
+The matrix can have a different number of rows and columns (Non square).
+
 Note that you may find other definitions of matrix saddle points online,
 but the tests for this exercise follow the above unambiguous definition.
+
 
 ## Exception messages
 
@@ -42,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest saddle_points_test.py`
 
-- Python 3.4+: `pytest saddle_points_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest saddle_points_test.py`
 
 ### Common `pytest` options

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -80,7 +80,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test say_test.py`
 - Python 3.4+: `pytest say_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -62,6 +62,7 @@ Use _and_ (correctly) when spelling out the number in English:
 - 1002 becomes "one thousand and two".
 - 1323 becomes "one thousand three hundred and twenty-three".
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -78,11 +79,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest say_test.py`
 
-- Python 3.4+: `pytest say_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest say_test.py`
 
 ### Common `pytest` options

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -48,6 +48,7 @@ interval, written "A", has two interceding notes (e.g., from A to C or
 Db to E). There are also smaller and larger intervals, but they will not
 figure into this exercise.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -64,11 +65,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest scale_generator_test.py`
 
-- Python 3.4+: `pytest scale_generator_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest scale_generator_test.py`
 
 ### Common `pytest` options

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -66,7 +66,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test scale_generator_test.py`
 - Python 3.4+: `pytest scale_generator_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -57,7 +57,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test scrabble_score_test.py`
 - Python 3.4+: `pytest scrabble_score_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -39,6 +39,7 @@ And to total:
 - You can play a double or a triple letter.
 - You can play a double or a triple word.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -55,11 +56,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest scrabble_score_test.py`
 
-- Python 3.4+: `pytest scrabble_score_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest scrabble_score_test.py`
 
 ### Common `pytest` options

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test secret_handshake_test.py`
 - Python 3.4+: `pytest secret_handshake_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -28,6 +28,7 @@ Given the input 19, the function would return the array
 Notice that the addition of 16 (10000 in binary)
 has caused the array to be reversed.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest secret_handshake_test.py`
 
-- Python 3.4+: `pytest secret_handshake_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest secret_handshake_test.py`
 
 ### Common `pytest` options

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -20,6 +20,7 @@ whatever you get.
 Note that these series are only required to occupy *adjacent positions*
 in the input; the digits need not be *numerically consecutive*.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -36,11 +37,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest series_test.py`
 
-- Python 3.4+: `pytest series_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest series_test.py`
 
 ### Common `pytest` options

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -38,7 +38,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test series_test.py`
 - Python 3.4+: `pytest series_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -18,9 +18,10 @@ An SGF file may look like this:
 
 This is a tree with three nodes:
 
-- The top level node has two properties: FF\[4\] (key = "FF", value =
-  "4") and C\[root\](key = "C", value = "root"). (FF indicates the
-  version of SGF and C is a comment.)
+- The top level node has three properties: FF\[4\] (key = "FF", value
+  = "4"), C\[root\](key = "C", value = "root") and SZ\[19\] (key =
+  "SZ", value = "19"). (FF indicates the version of SGF, C is a
+  comment and SZ is the size of the board.)
   - The top level node has a single child which has a single property:
     B\[aa\].  (Black plays on the point encoded as "aa", which is the
     1-1 point (which is a stupid place to play)).
@@ -64,6 +65,7 @@ structure of properties. You do not need to encode knowledge about the
 data types of properties, just use the rules for the
 [text](http://www.red-bean.com/sgf/sgf4.html#text) type everywhere.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -80,11 +82,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest sgf_parsing_test.py`
 
-- Python 3.4+: `pytest sgf_parsing_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest sgf_parsing_test.py`
 
 ### Common `pytest` options

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sgf_parsing_test.py`
 - Python 3.4+: `pytest sgf_parsing_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -29,6 +29,7 @@ correct list of primes. A good first test is to check that you do not use
 division or remainder operations (div, /, mod or % depending on the
 language).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -45,11 +46,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest sieve_test.py`
 
-- Python 3.4+: `pytest sieve_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest sieve_test.py`
 
 ### Common `pytest` options

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sieve_test.py`
 - Python 3.4+: `pytest sieve_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -114,7 +114,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test simple_cipher_test.py`
 - Python 3.4+: `pytest simple_cipher_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -13,8 +13,8 @@ for A, and so with the others."
 
 Ciphers are very straight-forward algorithms that allow us to render
 text less readable while still allowing easy deciphering. They are
-vulnerable to many forms of cryptoanalysis, but we are lucky that
-generally our little sisters are not cryptoanalysts.
+vulnerable to many forms of cryptanalysis, but we are lucky that
+generally our little sisters are not cryptanalysts.
 
 The Caesar Cipher was used for some messages from Julius Caesar that
 were sent afield. Now Caesar knew that the cipher wasn't very good, but
@@ -61,7 +61,7 @@ substitution cipher a little more fault tolerant by providing a source
 of randomness and ensuring that the key contains only lowercase letters.
 
 If someone doesn't submit a key at all, generate a truly random key of
-at least 100 characters in length.
+at least 100 alphanumeric characters in length.
 
 ## Extensions
 
@@ -96,6 +96,7 @@ Since this is only an exercise, `random` is fine to use, but note that **it woul
 very insecure if actually used for cryptography.**
 
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -112,11 +113,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest simple_cipher_test.py`
 
-- Python 3.4+: `pytest simple_cipher_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest simple_cipher_test.py`
 
 ### Common `pytest` options

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -33,6 +33,7 @@ def next(self):
 ```
 
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -49,11 +50,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest simple_linked_list_test.py`
 
-- Python 3.4+: `pytest simple_linked_list_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest simple_linked_list_test.py`
 
 ### Common `pytest` options

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -51,7 +51,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test simple_linked_list_test.py`
 - Python 3.4+: `pytest simple_linked_list_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -17,6 +17,7 @@ be able to say that they're 31.69 Earth-years old.
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -33,11 +34,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest space_age_test.py`
 
-- Python 3.4+: `pytest space_age_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest space_age_test.py`
 
 ### Common `pytest` options

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test space_age_test.py`
 - Python 3.4+: `pytest space_age_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -23,6 +23,7 @@ like these examples:
 10  9  8 7
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -39,11 +40,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest spiral_matrix_test.py`
 
-- Python 3.4+: `pytest spiral_matrix_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest spiral_matrix_test.py`
 
 ### Common `pytest` options

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -41,7 +41,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test spiral_matrix_test.py`
 - Python 3.4+: `pytest spiral_matrix_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -51,7 +51,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test strain_test.py`
 - Python 3.4+: `pytest strain_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -33,6 +33,7 @@ Keep your hands off that filter/reject/whatchamacallit functionality
 provided by your standard library!  Solve this one yourself using other
 basic tools instead.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -49,11 +50,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest strain_test.py`
 
-- Python 3.4+: `pytest strain_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest strain_test.py`
 
 ### Common `pytest` options

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -17,6 +17,7 @@ Examples:
  * A = [1, 2, 3, 4, 5], B = [2, 3, 4], A is a superlist of B
  * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or equal to B
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -33,11 +34,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest sublist_test.py`
 
-- Python 3.4+: `pytest sublist_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest sublist_test.py`
 
 ### Common `pytest` options

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -35,7 +35,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sublist_test.py`
 - Python 3.4+: `pytest sublist_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -8,6 +8,7 @@ we get 3, 5, 6, 9, 10, 12, 15, and 18.
 
 The sum of these multiples is 78.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -24,11 +25,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest sum_of_multiples_test.py`
 
-- Python 3.4+: `pytest sum_of_multiples_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest sum_of_multiples_test.py`
 
 ### Common `pytest` options

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -26,7 +26,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test sum_of_multiples_test.py`
 - Python 3.4+: `pytest sum_of_multiples_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -64,6 +64,7 @@ Devastating Donkeys;Courageous Californians;draw
 
 Means that the Devastating Donkeys and Courageous Californians tied.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -80,11 +81,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest tournament_test.py`
 
-- Python 3.4+: `pytest tournament_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest tournament_test.py`
 
 ### Common `pytest` options

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -82,7 +82,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test tournament_test.py`
 - Python 3.4+: `pytest tournament_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -58,6 +58,7 @@ In general, all characters from the input should also be present in the transpos
 That means that if a column in the input text contains only spaces on its bottom-most row(s),
 the corresponding output row should contain the spaces in its right-most column(s).
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -74,11 +75,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest transpose_test.py`
 
-- Python 3.4+: `pytest transpose_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest transpose_test.py`
 
 ### Common `pytest` options

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -76,7 +76,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test transpose_test.py`
 - Python 3.4+: `pytest transpose_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -26,6 +26,7 @@ root (ID: 0, parent ID: 0)
 +-- child3 (ID: 5, parent ID: 0)
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest tree_building_test.py`
 
-- Python 3.4+: `pytest tree_building_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest tree_building_test.py`
 
 ### Common `pytest` options

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test tree_building_test.py`
 - Python 3.4+: `pytest tree_building_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -22,6 +22,7 @@ The case where the sum of the lengths of two sides _equals_ that of the
 third is known as a _degenerate_ triangle - it has zero area and looks like
 a single line. Feel free to add your own code/tests to check for degenerate triangles.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -38,11 +39,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest triangle_test.py`
 
-- Python 3.4+: `pytest triangle_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest triangle_test.py`
 
 ### Common `pytest` options

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -40,7 +40,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test triangle_test.py`
 - Python 3.4+: `pytest triangle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -39,7 +39,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test trinary_test.py`
 - Python 3.4+: `pytest trinary_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -21,6 +21,7 @@ is the 3's place, the third to last is the 9's place, etc.
 If your language provides a method in the standard library to perform the
 conversion, pretend it doesn't exist and implement it yourself.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -37,11 +38,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest trinary_test.py`
 
-- Python 3.4+: `pytest trinary_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest trinary_test.py`
 
 ### Common `pytest` options

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -28,6 +28,7 @@ On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, 
 On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -44,11 +45,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest twelve_days_test.py`
 
-- Python 3.4+: `pytest twelve_days_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest twelve_days_test.py`
 
 ### Common `pytest` options

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -46,7 +46,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test twelve_days_test.py`
 - Python 3.4+: `pytest twelve_days_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -47,7 +47,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test two_bucket_test.py`
 - Python 3.4+: `pytest two_bucket_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -29,6 +29,7 @@ To conclude, the only valid moves are:
 
 Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -45,11 +46,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest two_bucket_test.py`
 
-- Python 3.4+: `pytest two_bucket_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest two_bucket_test.py`
 
 ### Common `pytest` options

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -2,14 +2,28 @@
 
 `Two-fer` or `2-fer` is short for two for one. One for you and one for me.
 
+Given a name, return a string with the message:
+
 ```text
-"One for X, one for me."
+One for X, one for me.
 ```
 
-When X is a name or "you".
+Where X is the given name.
 
-If the given name is "Alice", the result should be "One for Alice, one for me."
-If no name is given, the result should be "One for you, one for me."
+However, if the name is missing, return the string:
+
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+|Name    |String to return 
+|:-------|:------------------
+|Alice   |One for Alice, one for me. 
+|Bob     |One for Bob, one for me.
+|        |One for you, one for me.
+|Zaphod  |One for Zaphod, one for me.
 
 
 ## Exception messages
@@ -28,11 +42,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest two_fer_test.py`
 
-- Python 3.4+: `pytest two_fer_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest two_fer_test.py`
 
 ### Common `pytest` options
@@ -54,7 +66,7 @@ please see [Running the Tests](http://exercism.io/tracks/python/tests).
 
 ## Source
 
-[https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+[https://github.com/exercism/problem-specifications/issues/757](https://github.com/exercism/problem-specifications/issues/757)
 
 ## Submitting Incomplete Solutions
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -30,7 +30,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test two_fer_test.py`
 - Python 3.4+: `pytest two_fer_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -31,6 +31,7 @@ Here are examples of integers as 32-bit values, and the variable length quantiti
 0FFFFFFF          FF FF FF 7F
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -47,11 +48,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest variable_length_quantity_test.py`
 
-- Python 3.4+: `pytest variable_length_quantity_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest variable_length_quantity_test.py`
 
 ### Common `pytest` options

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -49,7 +49,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test variable_length_quantity_test.py`
 - Python 3.4+: `pytest variable_length_quantity_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -11,6 +11,7 @@ come: 1
 free: 1
 ```
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -27,11 +28,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest word_count_test.py`
 
-- Python 3.4+: `pytest word_count_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest word_count_test.py`
 
 ### Common `pytest` options

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -29,7 +29,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test word_count_test.py`
 - Python 3.4+: `pytest word_count_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -44,7 +44,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test word_search_test.py`
 - Python 3.4+: `pytest word_search_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -26,6 +26,7 @@ vertical and diagonal.
 Given a puzzle and a list of words return the location of the first and last
 letter of each word.
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -42,11 +43,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest word_search_test.py`
 
-- Python 3.4+: `pytest word_search_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest word_search_test.py`
 
 ### Common `pytest` options

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -2,6 +2,14 @@
 
 Parse and evaluate simple math word problems returning the answer as an integer.
 
+## Iteration 0 — Numbers
+
+Problems with no operations simply evaluate to the number given.
+
+> What is 5?
+
+Evaluates to 5.
+
 ## Iteration 1 — Addition
 
 Add two numbers together.
@@ -43,6 +51,14 @@ left-to-right, _ignoring the typical order of operations._
 
 15  (i.e. not 9)
 
+## Iteration 4 — Errors
+
+The parser should reject:
+
+* Unsupported operations ("What is 52 cubed?")
+* Non-math questions ("Who is the President of the United States")
+* Word problems with invalid syntax ("What is 1 plus plus 2?")
+
 ## Bonus — Exponentials
 
 If you'd like, handle exponentials.
@@ -50,6 +66,7 @@ If you'd like, handle exponentials.
 > What is 2 raised to the 5th power?
 
 32
+
 
 ## Exception messages
 
@@ -67,11 +84,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest wordy_test.py`
 
-- Python 3.4+: `pytest wordy_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest wordy_test.py`
 
 ### Common `pytest` options

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -69,7 +69,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test wordy_test.py`
 - Python 3.4+: `pytest wordy_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/yacht/README.md
+++ b/exercises/yacht/README.md
@@ -10,19 +10,20 @@ category chosen.
 
 ## Scores in Yacht
 
-    Category    Score                   Example
-    Ones            1 × number of ones      1 1 1 4 5 scores 3
-    Twos            2 × number of twos      2 2 3 4 5 scores 4
-    Threes          3 × number of threes    3 3 3 3 3 scores 15
-    Fours           4 × number of fours     1 2 3 3 5 scores 0
-    Fives           5 × number of fives     5 1 5 2 5 scores 15
-    Sixes           6 × number of sixes     2 3 4 5 6 scores 6
-    Full House      Total of the dice       3 3 3 5 5 scores 19
-    Four of a Kind  Total of the four dice  4 4 4 4 6 scores 16
-    Little Straight 30 points               1 2 3 4 5 scores 30
-    Big Straight    30 points               2 3 4 5 6 scores 30
-    Choice          Sum of the dice         2 3 3 4 6 scores 18
-    Yacht           50 points               4 4 4 4 4 scores 50
+| Category | Score | Description | Example |
+| -------- | ----- | ----------- | ------- |
+| Ones | 1 × number of ones | Any combination	| 1 1 1 4 5 scores 3 |
+| Twos | 2 × number of twos | Any combination | 2 2 3 4 5 scores 4 |
+| Threes | 3 × number of threes | Any combination | 3 3 3 3 3 scores 15 |
+| Fours | 4 × number of fours | Any combination | 1 2 3 3 5 scores 0 |
+| Fives | 5 × number of fives| Any combination | 5 1 5 2 5 scores 15 |
+| Sixes | 6 × number of sixes | Any combination | 2 3 4 5 6 scores 6 |
+| Full House | Total of the dice | Three of one number and two of another | 3 3 3 5 5 scores 19 |
+| Four of a Kind | Total of the four dice | At least four dice showing the same face | 4 4 4 4 6 scores 16 |
+| Little Straight |  30 points | 1-2-3-4-5 | 1 2 3 4 5 scores 30 |
+| Big Straight | 30 points | 2-3-4-5-6 | 2 3 4 5 6 scores 30 |
+| Choice | Sum of the dice | Any combination | 2 3 3 4 6 scores 18 |
+| Yacht | 50 points | All five dice showing the same face | 4 4 4 4 4 scores 50 |
 
 If the dice do not satisfy the requirements of a category, the score is zero.
 If, for example, *Four Of A Kind* is entered in the *Yacht* category, zero
@@ -34,6 +35,7 @@ the score of the dice for that category. If the dice do not satisfy the requirem
 of the category your solution should return 0. You can assume that five values
 will always be presented, and the value of each will be between one and six
 inclusively. You should not assume that the dice are ordered.
+
 
 ## Exception messages
 
@@ -51,11 +53,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest yacht_test.py`
 
-- Python 3.4+: `pytest yacht_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest yacht_test.py`
 
 ### Common `pytest` options

--- a/exercises/yacht/README.md
+++ b/exercises/yacht/README.md
@@ -53,7 +53,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test yacht_test.py`
 - Python 3.4+: `pytest yacht_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -43,7 +43,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test zebra_puzzle_test.py`
 - Python 3.4+: `pytest zebra_puzzle_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -25,6 +25,7 @@ drink different beverages and smoke different brands of cigarettes.
 Which of the residents drinks water?
 Who owns the zebra?
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -41,11 +42,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest zebra_puzzle_test.py`
 
-- Python 3.4+: `pytest zebra_puzzle_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest zebra_puzzle_test.py`
 
 ### Common `pytest` options

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -27,6 +27,7 @@ list of child nodes) a zipper might support these operations:
   `next` node if possible otherwise to the `prev` node if possible,
   otherwise to the parent node, returns a new zipper)
 
+
 ## Exception messages
 
 Sometimes it is necessary to raise an exception. When you do this, you should include a meaningful error message to
@@ -43,11 +44,9 @@ raise Exception("Meaningful message indicating the source of the error")
 
 ## Running the tests
 
-To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
+To run the tests, run `pytest zipper_test.py`
 
-- Python 3.4+: `pytest zipper_test.py`
-
-Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
+Alternatively, you can tell Python to run the pytest module:
 `python -m pytest zipper_test.py`
 
 ### Common `pytest` options

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -45,7 +45,6 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test zipper_test.py`
 - Python 3.4+: `pytest zipper_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):


### PR DESCRIPTION
@cmccandless I deleted all Python 2.7 references in README. Does this look good for you? I can do that for other files too if this works.