### PR TITLE
high-scores: Added new testcase for data corruption

### DIFF
--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -46,6 +46,13 @@ class HighScoreTest(unittest.TestCase):
         scores = [40]
         expected = [40]
         self.assertEqual(HighScores(scores).personal_top_three(), expected)
+    
+    def test_latest_score_after_personal_top_three(self):
+        scores = [20, 10, 30]
+        expected = 30
+        highScores = HighScores(scores)
+        highScores.personal_top_three()
+        self.assertEqual(highScores.latest(), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current test does not check if scores is corrupted by the use of `sort` in the personal_top_three method. From checking multiple solutions and spotting this many times, and BeneKenobi wanting a test case (uuid=bf0004960b7b4ed094743ab835f1a5f4), I wrote this.