### PR TITLE
Test all two digit armstrong numbers, as test description suggests

### DIFF
--- a/exercises/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.py
@@ -5,13 +5,14 @@ from armstrong_numbers import is_armstrong
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
-class ArmstrongNumbersTest(unittest.TestCase):
 
+class ArmstrongNumbersTest(unittest.TestCase):
     def test_single_digit_numbers_are_armstrong_numbers(self):
         self.assertIs(is_armstrong(5), True)
 
     def test_there_are_no_two_digit_armstrong_numbers(self):
-        self.assertIs(is_armstrong(10), False)
+        for num in range(10, 99):
+            self.assertIs(is_armstrong(num), False)
 
     def test_three_digit_number_that_is_an_armstrong_number(self):
         self.assertIs(is_armstrong(153), True)


### PR DESCRIPTION
One of the tests describes itself as: `test_there_are_no_two_digit_armstrong_numbers` but then only runs the test against `10`. This PR tests all 2 digits numbers to assert that there are no two digit armstrong numbers as described.