### PR TITLE
resistor-color-duo: regenerate README to apply rename

### DIFF
--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -1,4 +1,4 @@
-# Resistor Colors
+# Resistor Color Duo
 
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know two things about them:
 
@@ -40,11 +40,11 @@ raise Exception("Meaningful message indicating the source of the error")
 
 To run the tests, run the appropriate command below ([why they are different](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224)):
 
-- Python 2.7: `py.test resistor_colors_test.py`
-- Python 3.4+: `pytest resistor_colors_test.py`
+- Python 2.7: `py.test resistor_color_duo_test.py`
+- Python 3.4+: `pytest resistor_color_duo_test.py`
 
 Alternatively, you can tell Python to run the pytest module (allowing the same command to be used regardless of Python version):
-`python -m pytest resistor_colors_test.py`
+`python -m pytest resistor_color_duo_test.py`
 
 ### Common `pytest` options
 
@@ -56,7 +56,7 @@ For other options, see `python -m pytest -h`
 
 ## Submitting Exercises
 
-Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/python/resistor-colors` directory.
+Note that, when trying to submit an exercise, make sure the solution is in the `$EXERCISM_WORKSPACE/python/resistor-color-duo` directory.
 
 You can find your Exercism workspace by running `exercism debug` and looking for the line that starts with `Workspace`.
 


### PR DESCRIPTION
Exercise was renamed in #1741, but I forgot to regenerate the README.