### PR TITLE
Fix mismatch between description and reality in SGF-parsing readme. Issue #1748

### DIFF
--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -18,9 +18,8 @@ An SGF file may look like this:
 
 This is a tree with three nodes:
 
-- The top level node has two properties: FF\[4\] (key = "FF", value =
-  "4") and C\[root\](key = "C", value = "root"). (FF indicates the
-  version of SGF and C is a comment.)
+- The top level node has three properties: FF\[4\] (key = "FF", value =
+  "4"), C\[root\](key = "C", value = "root") SZ\[19\](key = "SZ", value = "19"). (FF indicates the version of SGF, C is a comment, and SZ indicates the size of the board.)
   - The top level node has a single child which has a single property:
     B\[aa\].  (Black plays on the point encoded as "aa", which is the
     1-1 point (which is a stupid place to play)).


### PR DESCRIPTION
Adds a description of the SZ property to bring the description in line with the example code it describes. Issue #1748 