### PR TITLE
armstrong-numbers: sync with problem-specifications

### DIFF
--- a/exercises/armstrong-numbers/armstrong_numbers.py
+++ b/exercises/armstrong-numbers/armstrong_numbers.py
@@ -1,2 +1,2 @@
-def is_armstrong(number):
+def is_armstrong_number(number):
     pass

--- a/exercises/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.py
@@ -1,35 +1,38 @@
 import unittest
 
-from armstrong_numbers import is_armstrong
+from armstrong_numbers import is_armstrong_number
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class ArmstrongNumbersTest(unittest.TestCase):
 
+    def test_zero_is_an_armstrong_number(self):
+        self.assertIs(is_armstrong_number(0), True)
+
     def test_single_digit_numbers_are_armstrong_numbers(self):
-        self.assertIs(is_armstrong(5), True)
+        self.assertIs(is_armstrong_number(5), True)
 
     def test_there_are_no_two_digit_armstrong_numbers(self):
-        self.assertIs(is_armstrong(10), False)
+        self.assertIs(is_armstrong_number(10), False)
 
     def test_three_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong(153), True)
+        self.assertIs(is_armstrong_number(153), True)
 
     def test_three_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong(100), False)
+        self.assertIs(is_armstrong_number(100), False)
 
     def test_four_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong(9474), True)
+        self.assertIs(is_armstrong_number(9474), True)
 
     def test_four_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong(9475), False)
+        self.assertIs(is_armstrong_number(9475), False)
 
     def test_seven_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong(9926315), True)
+        self.assertIs(is_armstrong_number(9926315), True)
 
     def test_seven_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong(9926314), False)
+        self.assertIs(is_armstrong_number(9926314), False)
 
 
 if __name__ == '__main__':

--- a/exercises/armstrong-numbers/example.py
+++ b/exercises/armstrong-numbers/example.py
@@ -1,2 +1,2 @@
-def is_armstrong(number):
+def is_armstrong_number(number):
     return sum(pow(int(d), len(str(number))) for d in str(number)) == number


### PR DESCRIPTION
Issue: https://github.com/exercism/python/issues/1762

Update `armstrong-numbers` exercise so it matches [canonical-data.json](https://github.com/exercism/problem-specifications/blob/51418ec78bcca075b586d4c38d66d2c322b488fe/exercises/alphametics/canonical-data.json)

*Also Resolves #1751*