### PR TITLE
add parentheses to method area_code

### DIFF
--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -81,7 +81,7 @@ class PhoneNumberTest(unittest.TestCase):
     # Track specific tests
     def test_area_code(self):
         number = Phone("2234567890")
-        self.assertEqual(number.area_code, "223")
+        self.assertEqual(number.area_code(), "223")
 
     def test_pretty_print(self):
         number = Phone("2234567890")


### PR DESCRIPTION
Without parentheses the test_area_code is trying compare this:` <bound method Phone.area_code of <phone_number.Phone object at 0x7f0426e266d8>> != '223'` instead of this: `'223' == '223'` so the test cannot be passed.