### PR TITLE
Difference of squares:   sync expected test results and input data with problem-specifications

### DIFF
--- a/exercises/difference-of-squares/difference_of_squares.py
+++ b/exercises/difference-of-squares/difference_of_squares.py
@@ -6,5 +6,5 @@ def sum_of_squares(number):
     pass
 
 
-def difference(number):
+def difference_of_squares(number):
     pass

--- a/exercises/difference-of-squares/difference_of_squares.py
+++ b/exercises/difference-of-squares/difference_of_squares.py
@@ -1,10 +1,10 @@
-def square_of_sum(count):
+def square_of_sum(number):
     pass
 
 
-def sum_of_squares(count):
+def sum_of_squares(number):
     pass
 
 
-def difference(count):
+def difference(number):
     pass

--- a/exercises/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/difference-of-squares/difference_of_squares_test.py
@@ -1,6 +1,7 @@
 import unittest
 
-from difference_of_squares import difference, square_of_sum, sum_of_squares
+from difference_of_squares import difference_of_squares, \
+     square_of_sum, sum_of_squares
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
@@ -25,13 +26,13 @@ class DifferenceOfSquaresTest(unittest.TestCase):
         self.assertEqual(sum_of_squares(100), 338350)
 
     def test_difference_of_squares_1(self):
-        self.assertEqual(difference(1), 0)
+        self.assertEqual(difference_of_squares(1), 0)
 
     def test_difference_of_squares_5(self):
-        self.assertEqual(difference(5), 170)
+        self.assertEqual(difference_of_squares(5), 170)
 
     def test_difference_of_squares_100(self):
-        self.assertEqual(difference(100), 25164150)
+        self.assertEqual(difference_of_squares(100), 25164150)
 
 
 if __name__ == '__main__':

--- a/exercises/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/difference-of-squares/difference_of_squares_test.py
@@ -1,7 +1,10 @@
 import unittest
 
-from difference_of_squares import difference_of_squares, \
-     square_of_sum, sum_of_squares
+from difference_of_squares import (
+    difference_of_squares,
+    square_of_sum,
+    sum_of_squares
+)
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0

--- a/exercises/difference-of-squares/example.py
+++ b/exercises/difference-of-squares/example.py
@@ -5,7 +5,7 @@ def square_of_sum(number):
 
 def sum_of_squares(number):
     numerator = number * (number + 1) * (2 * number + 1)
-    return numerator/6
+    return numerator / 6
 
 
 def difference_of_squares(number):

--- a/exercises/difference-of-squares/example.py
+++ b/exercises/difference-of-squares/example.py
@@ -1,11 +1,12 @@
-def square_of_sum(count):
-    sum_ = count * (count + 1) / 2
+def square_of_sum(number):
+    sum_ = number * (number + 1) / 2
     return sum_ * sum_
 
 
-def sum_of_squares(count):
-    return sum(m * m for m in range(count + 1))
+def sum_of_squares(number):
+    numerator = number * (number + 1) * (2 * number + 1)
+    return numerator/6
 
 
-def difference(count):
-    return square_of_sum(count) - sum_of_squares(count)
+def difference_of_squares(number):
+    return square_of_sum(number) - sum_of_squares(number)


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to  **difference_of_squares** in test cases, exercise stub, and `example.py` to conform with `canonical-data.json`.
- Changed `example.py` to use the formulas from https://brilliant.org/wiki/sum-of-n-n2-or-n3/, rather than loops.
- Changed argument name in `example.py` and exercise stub to **number** from _count_.
