### PR TITLE
Dominoes: sync expected test results and input data with problem-specifications

### DIFF
--- a/exercises/dominoes/dominoes.py
+++ b/exercises/dominoes/dominoes.py
@@ -1,2 +1,2 @@
-def chain(dominoes):
+def can_chain(dominoes):
     pass

--- a/exercises/dominoes/dominoes_test.py
+++ b/exercises/dominoes/dominoes_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dominoes import chain
+from dominoes import can_chain
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
@@ -8,63 +8,63 @@ from dominoes import chain
 class DominoesTest(unittest.TestCase):
     def test_empty_input_empty_output(self):
         input_dominoes = []
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_singleton_input_singleton_output(self):
         input_dominoes = [(1, 1)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_singleton_cant_be_chained(self):
         input_dominoes = [(1, 2)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.refute_correct_chain(input_dominoes, output_chain)
 
     def test_three_elements(self):
         input_dominoes = [(1, 2), (3, 1), (2, 3)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_can_reverse_dominoes(self):
         input_dominoes = [(1, 2), (1, 3), (2, 3)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_cant_be_chained(self):
         input_dominoes = [(1, 2), (4, 1), (2, 3)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.refute_correct_chain(input_dominoes, output_chain)
 
     def test_disconnected_simple(self):
         input_dominoes = [(1, 1), (2, 2)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.refute_correct_chain(input_dominoes, output_chain)
 
     def test_disconnected_double_loop(self):
         input_dominoes = [(1, 2), (2, 1), (3, 4), (4, 3)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.refute_correct_chain(input_dominoes, output_chain)
 
     def test_disconnected_single_isolated(self):
         input_dominoes = [(1, 2), (2, 3), (3, 1), (4, 4)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.refute_correct_chain(input_dominoes, output_chain)
 
     def test_need_backtrack(self):
         input_dominoes = [(1, 2), (2, 3), (3, 1), (2, 4), (2, 4)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_separate_loops(self):
         input_dominoes = [(1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     def test_nine_elements(self):
         input_dominoes = [(1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6),
                           (2, 3), (3, 4), (5, 6)]
-        output_chain = chain(input_dominoes)
+        output_chain = can_chain(input_dominoes)
         self.assert_correct_chain(input_dominoes, output_chain)
 
     # Utility methods

--- a/exercises/dominoes/example.py
+++ b/exercises/dominoes/example.py
@@ -20,7 +20,7 @@ def build_chain(chain, domino):
     return None
 
 
-def chain(dominoes):
+def can_chain(dominoes):
     if not any(dominoes):
         return []
     for perm in permutations(dominoes):


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name in tests, exercise stub, and `example.py` to **can_chain** to conform to `canonical-data.json`.
