### PR TITLE
Leap : sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/leap/example.py
+++ b/exercises/leap/example.py
@@ -1,2 +1,2 @@
-def is_leap_year(year):
+def leap_year(year):
     return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/exercises/leap/leap.py
+++ b/exercises/leap/leap.py
@@ -1,2 +1,2 @@
-def is_leap_year(year):
+def leap_year(year):
     pass

--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from leap import is_leap_year
+from leap import leap_year
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.1
@@ -8,22 +8,22 @@ from leap import is_leap_year
 
 class LeapTest(unittest.TestCase):
     def test_year_not_divisible_by_4(self):
-        self.assertIs(is_leap_year(2015), False)
+        self.assertIs(leap_year(2015), False)
 
     def test_year_divisible_by_2_not_divisible_by_4(self):
-        self.assertIs(is_leap_year(1970), False)
+        self.assertIs(leap_year(1970), False)
 
     def test_year_divisible_by_4_not_divisible_by_100(self):
-        self.assertIs(is_leap_year(1996), True)
+        self.assertIs(leap_year(1996), True)
 
     def test_year_divisible_by_100_not_divisible_by_400(self):
-        self.assertIs(is_leap_year(2100), False)
+        self.assertIs(leap_year(2100), False)
 
     def test_year_divisible_by_400(self):
-        self.assertIs(is_leap_year(2000), True)
+        self.assertIs(leap_year(2000), True)
 
     def test_year_divisible_by_200_not_divisible_by_400(self):
-        self.assertIs(is_leap_year(1800), False)
+        self.assertIs(leap_year(1800), False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to **leap_year** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`.

