### PR TITLE
List ops: sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/list-ops/example.py
+++ b/exercises/list-ops/example.py
@@ -1,36 +1,36 @@
-def append(xs, ys):
-    return concat([xs, ys])
+def append(list1, list2):
+    return concat([list1, list2])
 
 
 def concat(lists):
-    return [elem for lst in lists for elem in lst]
+    return [element for list in lists for element in list]
 
 
-def filter_clone(function, xs):
-    return [x for x in xs if function(x)]
+def filter(function, list):
+    return [item for item in list if function(item)]
 
 
-def length(xs):
-    return sum(1 for _ in xs)
+def length(list):
+    return sum(1 for _ in list)
 
 
-def map_clone(function, xs):
-    return [function(elem) for elem in xs]
+def map(function, list):
+    return [function(element) for element in list]
 
 
-def foldl(function, xs, acc):
-    if len(xs) == 0:
-        return acc
+def foldl(function, list, initial):
+    if len(list) == 0:
+        return initial
     else:
-        return foldl(function, xs[1:], function(acc, xs[0]))
+        return foldl(function, list[1:], function(initial, list[0]))
 
 
-def foldr(function, xs, acc):
-    if len(xs) == 0:
-        return acc
+def foldr(function, list, initial):
+    if len(list) == 0:
+        return initial
     else:
-        return function(xs[0], foldr(function, xs[1:], acc))
+        return function(list[0], foldr(function, list[1:], initial))
 
 
-def reverse(xs):
-    return xs[::-1]
+def reverse(list):
+    return list[::-1]

--- a/exercises/list-ops/list_ops.py
+++ b/exercises/list-ops/list_ops.py
@@ -1,4 +1,4 @@
-def append(xs, ys):
+def append(list1, list2):
     pass
 
 
@@ -6,25 +6,25 @@ def concat(lists):
     pass
 
 
-def filter_clone(function, xs):
+def filter(function, list):
     pass
 
 
-def length(xs):
+def length(list):
     pass
 
 
-def map_clone(function, xs):
+def map(function, list):
     pass
 
 
-def foldl(function, xs, acc):
+def foldl(function, list, initial):
     pass
 
 
-def foldr(function, xs, acc):
+def foldr(function, list, initial):
     pass
 
 
-def reverse(xs):
+def reverse(list):
     pass

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -48,7 +48,7 @@ class ListOpsTest(unittest.TestCase):
     def test_length_nonempty_list(self):
         self.assertEqual(list_ops.length([1, 2, 3, 4]), 4)
 
-    # tests for map_clone
+    # tests for map
     def test_map_empty_list(self):
         self.assertEqual(list_ops.map(lambda x: x + 1, []), [])
 

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -34,11 +34,11 @@ class ListOpsTest(unittest.TestCase):
 
     # tests for filter_clone
     def test_filter_empty_list(self):
-        self.assertEqual(list_ops.filter_clone(lambda x: x % 2 == 1, []), [])
+        self.assertEqual(list_ops.filter(lambda x: x % 2 == 1, []), [])
 
     def test_filter_nonempty_list(self):
         self.assertEqual(
-            list_ops.filter_clone(lambda x: x % 2 == 1, [1, 2, 3, 4, 5]),
+            list_ops.filter(lambda x: x % 2 == 1, [1, 2, 3, 4, 5]),
             [1, 3, 5])
 
     # tests for length
@@ -50,10 +50,10 @@ class ListOpsTest(unittest.TestCase):
 
     # tests for map_clone
     def test_map_empty_list(self):
-        self.assertEqual(list_ops.map_clone(lambda x: x + 1, []), [])
+        self.assertEqual(list_ops.map(lambda x: x + 1, []), [])
 
     def test_map_nonempty_list(self):
-        self.assertEqual(list_ops.map_clone(lambda x: x + 1, [1, 3, 5, 7]),
+        self.assertEqual(list_ops.map(lambda x: x + 1, [1, 3, 5, 7]),
                          [2, 4, 6, 8])
 
     # tests for foldl

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -32,7 +32,7 @@ class ListOpsTest(unittest.TestCase):
             list_ops.concat([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]),
             [[1], [2], [3], [], [4, 5, 6]])
 
-    # tests for filter_clone
+    # tests for filter
     def test_filter_empty_list(self):
         self.assertEqual(list_ops.filter(lambda x: x % 2 == 1, []), [])
 


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function names to  **map** and **filter** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`.
- Changed changed function argument names to **list**, **inital**, and **function** in `example.py` and exercise stub to better conform to `canonical-data.json`.
- Changed references to single, two-letter, and abbreviated variable names in `example.py` to whole words for clarity.
