### PR TITLE
Markdown: sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/markdown/example.py
+++ b/exercises/markdown/example.py
@@ -1,16 +1,16 @@
 import re
 
 
-def parse_markdown(markdown):
+def parse(markdown):
     lines = markdown.split('\n')
     html = ''
     in_list = False
     in_list_append = False
     for line in lines:
-        res = parse_line(line, in_list, in_list_append)
-        html += res['line']
-        in_list = res['in_list']
-        in_list_append = res['in_list_append']
+        result = parse_line(line, in_list, in_list_append)
+        html += result['line']
+        in_list = result['in_list']
+        in_list_append = result['in_list_append']
     if in_list:
         html += '</ul>'
     return html
@@ -22,9 +22,9 @@ def wrap(line, tag):
 
 def check_headers(line):
     pattern = '# (.*)'
-    for i in range(6):
+    for index in range(6):
         if re.match(pattern, line):
-            return wrap(line[(i + 2):], 'h' + str(i + 1))
+            return wrap(line[(index + 2):], 'h' + str(index + 1))
         pattern = '#' + pattern
     return line
 
@@ -50,38 +50,39 @@ def check_italic(line):
 
 
 def parse_line(line, in_list, in_list_append):
-    res = check_headers(line)
+    result = check_headers(line)
 
-    list_match = re.match(r'\* (.*)', res)
+    list_match = re.match(r'\* (.*)', result)
 
     if (list_match):
         if not in_list:
-            res = '<ul>' + wrap(list_match.group(1), 'li')
+            result = '<ul>' + wrap(list_match.group(1), 'li')
             in_list = True
         else:
-            res = wrap(list_match.group(1), 'li')
+            result = wrap(list_match.group(1), 'li')
     else:
         if in_list:
             in_list_append = True
             in_list = False
 
-    if not re.match('<h|<ul|<li', res):
-        res = wrap(res, 'p')
+    if not re.match('<h|<ul|<li', result):
+        result = wrap(result, 'p')
 
     if list_match is None:
-        res = re.sub('(.*)(<li>)(.*)(</li>)(.*)', r'\1\2<p>\3</p>\4\5', res)
+        result = re.sub('(.*)(<li>)(.*)(</li>)(.*)',
+                        r'\1\2<p>\3</p>\4\5', result)
 
-    while check_bold(res):
-        res = check_bold(res)
-    while check_italic(res):
-        res = check_italic(res)
+    while check_bold(result):
+        result = check_bold(result)
+    while check_italic(result):
+        result = check_italic(result)
 
     if in_list_append:
-        res = '</ul>' + res
+        result = '</ul>' + result
         in_list_append = False
 
     return {
-        'line': res,
+        'line': result,
         'in_list': in_list,
         'in_list_append': in_list_append
     }

--- a/exercises/markdown/markdown.py
+++ b/exercises/markdown/markdown.py
@@ -1,7 +1,7 @@
 import re
 
 
-def parse_markdown(markdown):
+def parse(markdown):
     lines = markdown.split('\n')
     res = ''
     in_list = False

--- a/exercises/markdown/markdown_test.py
+++ b/exercises/markdown/markdown_test.py
@@ -1,5 +1,5 @@
 import unittest
-from markdown import parse_markdown
+from markdown import parse
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
@@ -7,53 +7,53 @@ from markdown import parse_markdown
 class MarkdownTest(unittest.TestCase):
 
     def test_paragraph(self):
-        self.assertEqual(parse_markdown('This will be a paragraph'),
+        self.assertEqual(parse('This will be a paragraph'),
                          '<p>This will be a paragraph</p>')
 
     def test_italics(self):
-        self.assertEqual(parse_markdown('_This will be italic_'),
+        self.assertEqual(parse('_This will be italic_'),
                          '<p><em>This will be italic</em></p>')
 
     def test_bold(self):
-        self.assertEqual(parse_markdown('__This will be bold__'),
+        self.assertEqual(parse('__This will be bold__'),
                          '<p><strong>This will be bold</strong></p>')
 
     def test_mixed_normal_italics_and_bold(self):
-        self.assertEqual(parse_markdown('This will _be_ __mixed__'),
+        self.assertEqual(parse('This will _be_ __mixed__'),
                          '<p>This will <em>be</em> <strong>mixed</strong></p>')
 
     def test_h1(self):
-        self.assertEqual(parse_markdown('# This will be an h1'),
+        self.assertEqual(parse('# This will be an h1'),
                          '<h1>This will be an h1</h1>')
 
     def test_h2(self):
-        self.assertEqual(parse_markdown('## This will be an h2'),
+        self.assertEqual(parse('## This will be an h2'),
                          '<h2>This will be an h2</h2>')
 
     def test_h6(self):
-        self.assertEqual(parse_markdown(
+        self.assertEqual(parse(
             '###### This will be an h6'), '<h6>This will be an h6</h6>')
 
     def test_unordered_lists(self):
-        self.assertEqual(parse_markdown('* Item 1\n* Item 2'),
+        self.assertEqual(parse('* Item 1\n* Item 2'),
                          '<ul><li>Item 1</li>'
                          '<li>Item 2</li></ul>')
 
     def test_little_bit_of_everything(self):
-        self.assertEqual(parse_markdown(
+        self.assertEqual(parse(
             '# Header!\n* __Bold Item__\n* _Italic Item_'),
             '<h1>Header!</h1><ul><li><strong>Bold Item</strong></li>'
             '<li><em>Italic Item</em></li></ul>')
 
     def test_symbols_in_the_header_text_that_should_not_be_interpreted(self):
         self.assertEqual(
-            parse_markdown('# This is a header with # and * in the text'),
+            parse('# This is a header with # and * in the text'),
             '<h1>This is a header with # and * in the text</h1>')
 
     def test_symbols_in_the_list_item_text_that_should_not_be_interpreted(
             self):
         self.assertEqual(
-            parse_markdown(
+            parse(
                 '* Item 1 with a # in the text\n* Item 2 with * in the text'),
             '<ul><li>Item 1 with a # in the text</li>'
             '<li>Item 2 with * in the text</li></ul>')
@@ -61,13 +61,13 @@ class MarkdownTest(unittest.TestCase):
     def test_symbols_in_the_paragraph_text_that_should_not_be_interpreted(
             self):
         self.assertEqual(
-            parse_markdown('This is a paragraph with # and * in the text'),
+            parse('This is a paragraph with # and * in the text'),
             '<p>This is a paragraph with # and * in the text</p>')
 
     def test_unordered_lists_close_properly_with_preceding_and_following_lines(
             self):
         self.assertEqual(
-            parse_markdown('# Start a list\n* Item 1\n* Item 2\nEnd a list'),
+            parse('# Start a list\n* Item 1\n* Item 2\nEnd a list'),
             '<h1>Start a list</h1><ul><li>Item 1</li>'
             '<li>Item 2</li></ul><p>End a list</p>')
 


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

**NOTE:**  `flake8` will report the following for the exercise stub (in this case it isn't really a *stub*, but more a file to refactor):  _**"C901 'parse' is too complex (19)**_".  Which is the point : the file needs to be refactored to reduce complexity.

- Changed  function name to **parse** in tests, `example.py`, and exercise input to conform with `canonical-data.json`.
- Changed abbreviated variable name **res** to **result** in `example.py`, for clarity.
- Changed other single-letter variable names to words in `example.py`, for clarity.
