### PR TITLE
Meetup : sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/meetup/example.py
+++ b/exercises/meetup/example.py
@@ -1,23 +1,24 @@
 from calendar import Calendar
 
 
-def meetup_day(year, month, day_of_the_week, which):
+def meetup(year, month, week, day_of_week):
     candidates = [date
                   for date in Calendar().itermonthdates(year, month)
                   if date.month == month
-                  if date.strftime('%A') == day_of_the_week]
-    return _choice(which)(candidates)
+                  if date.strftime('%A') == day_of_week]
+    return _choice(week)(candidates)
 
 
-def _choice(which):
-    if which == 'teenth':
-        return lambda dates: next(d for d in dates if 13 <= d.day <= 19)
+def _choice(week):
+    if week == 'teenth':
+        return lambda dates: next(date for date in dates if
+                                  13 <= date.day <= 19)
 
-    ix = -1 if (which == 'last') else (int(which[0]) - 1)
+    day = -1 if (week == 'last') else (int(week[0]) - 1)
 
     def _func(dates):
-        if ix < len(dates):
-            return dates[ix]
+        if day < len(dates):
+            return dates[day]
         raise MeetupDayException('day does not exist')
     return _func
 

--- a/exercises/meetup/meetup.py
+++ b/exercises/meetup/meetup.py
@@ -1,2 +1,2 @@
-def meetup_day(year, month, day_of_the_week, which):
+def meetup(year, month, week, day_of_week):
     pass

--- a/exercises/meetup/meetup_test.py
+++ b/exercises/meetup/meetup_test.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import date
 
-from meetup import meetup_day, MeetupDayException
+from meetup import meetup, MeetupDayException
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
@@ -9,392 +9,392 @@ from meetup import meetup_day, MeetupDayException
 class MeetupTest(unittest.TestCase):
     def test_monteenth_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Monday', 'teenth'), date(2013, 5, 13))
+            meetup(2013, 5, 'teenth', 'Monday'), date(2013, 5, 13))
 
     def test_monteenth_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Monday', 'teenth'), date(2013, 8, 19))
+            meetup(2013, 8, 'teenth', 'Monday'), date(2013, 8, 19))
 
     def test_monteenth_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Monday', 'teenth'), date(2013, 9, 16))
+            meetup(2013, 9, 'teenth', 'Monday'), date(2013, 9, 16))
 
     def test_tuesteenth_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Tuesday', 'teenth'), date(2013, 3, 19))
+            meetup(2013, 3, 'teenth', 'Tuesday'), date(2013, 3, 19))
 
     def test_tuesteenth_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Tuesday', 'teenth'), date(2013, 4, 16))
+            meetup(2013, 4, 'teenth', 'Tuesday'), date(2013, 4, 16))
 
     def test_tuesteenth_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Tuesday', 'teenth'), date(2013, 8, 13))
+            meetup(2013, 8, 'teenth', 'Tuesday'), date(2013, 8, 13))
 
     def test_wednesteenth_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Wednesday', 'teenth'), date(2013, 1, 16))
+            meetup(2013, 1, 'teenth', 'Wednesday'), date(2013, 1, 16))
 
     def test_wednesteenth_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Wednesday', 'teenth'), date(2013, 2, 13))
+            meetup(2013, 2, 'teenth', 'Wednesday'), date(2013, 2, 13))
 
     def test_wednesteenth_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Wednesday', 'teenth'), date(2013, 6, 19))
+            meetup(2013, 6, 'teenth', 'Wednesday'), date(2013, 6, 19))
 
     def test_thursteenth_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Thursday', 'teenth'), date(2013, 5, 16))
+            meetup(2013, 5, 'teenth', 'Thursday'), date(2013, 5, 16))
 
     def test_thursteenth_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Thursday', 'teenth'), date(2013, 6, 13))
+            meetup(2013, 6, 'teenth', 'Thursday'), date(2013, 6, 13))
 
     def test_thursteenth_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', 'teenth'), date(2013, 9, 19))
+            meetup(2013, 9, 'teenth', 'Thursday'), date(2013, 9, 19))
 
     def test_friteenth_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Friday', 'teenth'), date(2013, 4, 19))
+            meetup(2013, 4, 'teenth', 'Friday'), date(2013, 4, 19))
 
     def test_friteenth_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Friday', 'teenth'), date(2013, 8, 16))
+            meetup(2013, 8, 'teenth', 'Friday'), date(2013, 8, 16))
 
     def test_friteenth_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Friday', 'teenth'), date(2013, 9, 13))
+            meetup(2013, 9, 'teenth', 'Friday'), date(2013, 9, 13))
 
     def test_saturteenth_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', 'teenth'), date(2013, 2, 16))
+            meetup(2013, 2, 'teenth', 'Saturday'), date(2013, 2, 16))
 
     def test_saturteenth_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Saturday', 'teenth'), date(2013, 4, 13))
+            meetup(2013, 4, 'teenth', 'Saturday'), date(2013, 4, 13))
 
     def test_saturteenth_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Saturday', 'teenth'), date(2013, 10, 19))
+            meetup(2013, 10, 'teenth', 'Saturday'), date(2013, 10, 19))
 
     def test_sunteenth_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Sunday', 'teenth'), date(2013, 5, 19))
+            meetup(2013, 5, 'teenth', 'Sunday'), date(2013, 5, 19))
 
     def test_sunteenth_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Sunday', 'teenth'), date(2013, 6, 16))
+            meetup(2013, 6, 'teenth', 'Sunday'), date(2013, 6, 16))
 
     def test_sunteenth_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Sunday', 'teenth'), date(2013, 10, 13))
+            meetup(2013, 10, 'teenth', 'Sunday'), date(2013, 10, 13))
 
     def test_first_monday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Monday', '1st'), date(2013, 3, 4))
+            meetup(2013, 3, '1st', 'Monday'), date(2013, 3, 4))
 
     def test_first_monday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Monday', '1st'), date(2013, 4, 1))
+            meetup(2013, 4, '1st', 'Monday'), date(2013, 4, 1))
 
     def test_first_tuesday_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Tuesday', '1st'), date(2013, 5, 7))
+            meetup(2013, 5, '1st', 'Tuesday'), date(2013, 5, 7))
 
     def test_first_tuesday_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Tuesday', '1st'), date(2013, 6, 4))
+            meetup(2013, 6, '1st', 'Tuesday'), date(2013, 6, 4))
 
     def test_first_wednesday_of_july_2013(self):
         self.assertEqual(
-            meetup_day(2013, 7, 'Wednesday', '1st'), date(2013, 7, 3))
+            meetup(2013, 7, '1st', 'Wednesday'), date(2013, 7, 3))
 
     def test_first_wednesday_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Wednesday', '1st'), date(2013, 8, 7))
+            meetup(2013, 8, '1st', 'Wednesday'), date(2013, 8, 7))
 
     def test_first_thursday_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', '1st'), date(2013, 9, 5))
+            meetup(2013, 9, '1st', 'Thursday'), date(2013, 9, 5))
 
     def test_first_thursday_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Thursday', '1st'), date(2013, 10, 3))
+            meetup(2013, 10, '1st', 'Thursday'), date(2013, 10, 3))
 
     def test_first_friday_of_november_2013(self):
         self.assertEqual(
-            meetup_day(2013, 11, 'Friday', '1st'), date(2013, 11, 1))
+            meetup(2013, 11, '1st', 'Friday'), date(2013, 11, 1))
 
     def test_first_friday_of_december_2013(self):
         self.assertEqual(
-            meetup_day(2013, 12, 'Friday', '1st'), date(2013, 12, 6))
+            meetup(2013, 12, '1st', 'Friday'), date(2013, 12, 6))
 
     def test_first_saturday_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Saturday', '1st'), date(2013, 1, 5))
+            meetup(2013, 1, '1st', 'Saturday'), date(2013, 1, 5))
 
     def test_first_saturday_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', '1st'), date(2013, 2, 2))
+            meetup(2013, 2, '1st', 'Saturday'), date(2013, 2, 2))
 
     def test_first_sunday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Sunday', '1st'), date(2013, 3, 3))
+            meetup(2013, 3, '1st', 'Sunday'), date(2013, 3, 3))
 
     def test_first_sunday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Sunday', '1st'), date(2013, 4, 7))
+            meetup(2013, 4, '1st', 'Sunday'), date(2013, 4, 7))
 
     def test_second_monday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Monday', '2nd'), date(2013, 3, 11))
+            meetup(2013, 3, '2nd', 'Monday'), date(2013, 3, 11))
 
     def test_second_monday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Monday', '2nd'), date(2013, 4, 8))
+            meetup(2013, 4, '2nd', 'Monday'), date(2013, 4, 8))
 
     def test_second_tuesday_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Tuesday', '2nd'), date(2013, 5, 14))
+            meetup(2013, 5, '2nd', 'Tuesday'), date(2013, 5, 14))
 
     def test_second_tuesday_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Tuesday', '2nd'), date(2013, 6, 11))
+            meetup(2013, 6, '2nd', 'Tuesday'), date(2013, 6, 11))
 
     def test_second_wednesday_of_july_2013(self):
         self.assertEqual(
-            meetup_day(2013, 7, 'Wednesday', '2nd'), date(2013, 7, 10))
+            meetup(2013, 7, '2nd', 'Wednesday'), date(2013, 7, 10))
 
     def test_second_wednesday_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Wednesday', '2nd'), date(2013, 8, 14))
+            meetup(2013, 8, '2nd', 'Wednesday'), date(2013, 8, 14))
 
     def test_second_thursday_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', '2nd'), date(2013, 9, 12))
+            meetup(2013, 9, '2nd', 'Thursday'), date(2013, 9, 12))
 
     def test_second_thursday_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Thursday', '2nd'), date(2013, 10, 10))
+            meetup(2013, 10, '2nd', 'Thursday'), date(2013, 10, 10))
 
     def test_second_friday_of_november_2013(self):
         self.assertEqual(
-            meetup_day(2013, 11, 'Friday', '2nd'), date(2013, 11, 8))
+            meetup(2013, 11, '2nd', 'Friday'), date(2013, 11, 8))
 
     def test_second_friday_of_december_2013(self):
         self.assertEqual(
-            meetup_day(2013, 12, 'Friday', '2nd'), date(2013, 12, 13))
+            meetup(2013, 12, '2nd', 'Friday'), date(2013, 12, 13))
 
     def test_second_saturday_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Saturday', '2nd'), date(2013, 1, 12))
+            meetup(2013, 1, '2nd', 'Saturday'), date(2013, 1, 12))
 
     def test_second_saturday_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', '2nd'), date(2013, 2, 9))
+            meetup(2013, 2, '2nd', 'Saturday'), date(2013, 2, 9))
 
     def test_second_sunday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Sunday', '2nd'), date(2013, 3, 10))
+            meetup(2013, 3, '2nd', 'Sunday'), date(2013, 3, 10))
 
     def test_second_sunday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Sunday', '2nd'), date(2013, 4, 14))
+            meetup(2013, 4, '2nd', 'Sunday'), date(2013, 4, 14))
 
     def test_third_monday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Monday', '3rd'), date(2013, 3, 18))
+            meetup(2013, 3, '3rd', 'Monday'), date(2013, 3, 18))
 
     def test_third_monday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Monday', '3rd'), date(2013, 4, 15))
+            meetup(2013, 4, '3rd', 'Monday'), date(2013, 4, 15))
 
     def test_third_tuesday_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Tuesday', '3rd'), date(2013, 5, 21))
+            meetup(2013, 5, '3rd', 'Tuesday'), date(2013, 5, 21))
 
     def test_third_tuesday_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Tuesday', '3rd'), date(2013, 6, 18))
+            meetup(2013, 6, '3rd', 'Tuesday'), date(2013, 6, 18))
 
     def test_third_wednesday_of_july_2013(self):
         self.assertEqual(
-            meetup_day(2013, 7, 'Wednesday', '3rd'), date(2013, 7, 17))
+            meetup(2013, 7, '3rd', 'Wednesday'), date(2013, 7, 17))
 
     def test_third_wednesday_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Wednesday', '3rd'), date(2013, 8, 21))
+            meetup(2013, 8, '3rd', 'Wednesday'), date(2013, 8, 21))
 
     def test_third_thursday_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', '3rd'), date(2013, 9, 19))
+            meetup(2013, 9, '3rd', 'Thursday'), date(2013, 9, 19))
 
     def test_third_thursday_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Thursday', '3rd'), date(2013, 10, 17))
+            meetup(2013, 10, '3rd', 'Thursday'), date(2013, 10, 17))
 
     def test_third_friday_of_november_2013(self):
         self.assertEqual(
-            meetup_day(2013, 11, 'Friday', '3rd'), date(2013, 11, 15))
+            meetup(2013, 11, '3rd', 'Friday'), date(2013, 11, 15))
 
     def test_third_friday_of_december_2013(self):
         self.assertEqual(
-            meetup_day(2013, 12, 'Friday', '3rd'), date(2013, 12, 20))
+            meetup(2013, 12, '3rd', 'Friday'), date(2013, 12, 20))
 
     def test_third_saturday_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Saturday', '3rd'), date(2013, 1, 19))
+            meetup(2013, 1, '3rd', 'Saturday'), date(2013, 1, 19))
 
     def test_third_saturday_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', '3rd'), date(2013, 2, 16))
+            meetup(2013, 2, '3rd', 'Saturday'), date(2013, 2, 16))
 
     def test_third_sunday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Sunday', '3rd'), date(2013, 3, 17))
+            meetup(2013, 3, '3rd', 'Sunday'), date(2013, 3, 17))
 
     def test_third_sunday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Sunday', '3rd'), date(2013, 4, 21))
+            meetup(2013, 4, '3rd', 'Sunday'), date(2013, 4, 21))
 
     def test_fourth_monday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Monday', '4th'), date(2013, 3, 25))
+            meetup(2013, 3, '4th', 'Monday'), date(2013, 3, 25))
 
     def test_fourth_monday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Monday', '4th'), date(2013, 4, 22))
+            meetup(2013, 4, '4th', 'Monday'), date(2013, 4, 22))
 
     def test_fourth_tuesday_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Tuesday', '4th'), date(2013, 5, 28))
+            meetup(2013, 5, '4th', 'Tuesday'), date(2013, 5, 28))
 
     def test_fourth_tuesday_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Tuesday', '4th'), date(2013, 6, 25))
+            meetup(2013, 6, '4th', 'Tuesday'), date(2013, 6, 25))
 
     def test_fourth_wednesday_of_july_2013(self):
         self.assertEqual(
-            meetup_day(2013, 7, 'Wednesday', '4th'), date(2013, 7, 24))
+            meetup(2013, 7, '4th', 'Wednesday'), date(2013, 7, 24))
 
     def test_fourth_wednesday_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Wednesday', '4th'), date(2013, 8, 28))
+            meetup(2013, 8, '4th', 'Wednesday'), date(2013, 8, 28))
 
     def test_fourth_thursday_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', '4th'), date(2013, 9, 26))
+            meetup(2013, 9, '4th', 'Thursday'), date(2013, 9, 26))
 
     def test_fourth_thursday_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Thursday', '4th'), date(2013, 10, 24))
+            meetup(2013, 10, '4th', 'Thursday'), date(2013, 10, 24))
 
     def test_fourth_friday_of_november_2013(self):
         self.assertEqual(
-            meetup_day(2013, 11, 'Friday', '4th'), date(2013, 11, 22))
+            meetup(2013, 11, '4th', 'Friday'), date(2013, 11, 22))
 
     def test_fourth_friday_of_december_2013(self):
         self.assertEqual(
-            meetup_day(2013, 12, 'Friday', '4th'), date(2013, 12, 27))
+            meetup(2013, 12, '4th', 'Friday'), date(2013, 12, 27))
 
     def test_fourth_saturday_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Saturday', '4th'), date(2013, 1, 26))
+            meetup(2013, 1, '4th', 'Saturday'), date(2013, 1, 26))
 
     def test_fourth_saturday_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', '4th'), date(2013, 2, 23))
+            meetup(2013, 2, '4th', 'Saturday'), date(2013, 2, 23))
 
     def test_fourth_sunday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Sunday', '4th'), date(2013, 3, 24))
+            meetup(2013, 3, '4th', 'Sunday'), date(2013, 3, 24))
 
     def test_fourth_sunday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Sunday', '4th'), date(2013, 4, 28))
+            meetup(2013, 4, '4th', 'Sunday'), date(2013, 4, 28))
 
     def test_last_monday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Monday', 'last'), date(2013, 3, 25))
+            meetup(2013, 3, 'last', 'Monday'), date(2013, 3, 25))
 
     def test_last_monday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Monday', 'last'), date(2013, 4, 29))
+            meetup(2013, 4, 'last', 'Monday'), date(2013, 4, 29))
 
     def test_last_tuesday_of_may_2013(self):
         self.assertEqual(
-            meetup_day(2013, 5, 'Tuesday', 'last'), date(2013, 5, 28))
+            meetup(2013, 5, 'last', 'Tuesday'), date(2013, 5, 28))
 
     def test_last_tuesday_of_june_2013(self):
         self.assertEqual(
-            meetup_day(2013, 6, 'Tuesday', 'last'), date(2013, 6, 25))
+            meetup(2013, 6, 'last', 'Tuesday'), date(2013, 6, 25))
 
     def test_last_wednesday_of_july_2013(self):
         self.assertEqual(
-            meetup_day(2013, 7, 'Wednesday', 'last'), date(2013, 7, 31))
+            meetup(2013, 7, 'last', 'Wednesday'), date(2013, 7, 31))
 
     def test_last_wednesday_of_august_2013(self):
         self.assertEqual(
-            meetup_day(2013, 8, 'Wednesday', 'last'), date(2013, 8, 28))
+            meetup(2013, 8, 'last', 'Wednesday'), date(2013, 8, 28))
 
     def test_last_thursday_of_september_2013(self):
         self.assertEqual(
-            meetup_day(2013, 9, 'Thursday', 'last'), date(2013, 9, 26))
+            meetup(2013, 9, 'last', 'Thursday'), date(2013, 9, 26))
 
     def test_last_thursday_of_october_2013(self):
         self.assertEqual(
-            meetup_day(2013, 10, 'Thursday', 'last'), date(2013, 10, 31))
+            meetup(2013, 10, 'last', 'Thursday'), date(2013, 10, 31))
 
     def test_last_friday_of_november_2013(self):
         self.assertEqual(
-            meetup_day(2013, 11, 'Friday', 'last'), date(2013, 11, 29))
+            meetup(2013, 11, 'last', 'Friday'), date(2013, 11, 29))
 
     def test_last_friday_of_december_2013(self):
         self.assertEqual(
-            meetup_day(2013, 12, 'Friday', 'last'), date(2013, 12, 27))
+            meetup(2013, 12, 'last', 'Friday'), date(2013, 12, 27))
 
     def test_last_saturday_of_january_2013(self):
         self.assertEqual(
-            meetup_day(2013, 1, 'Saturday', 'last'), date(2013, 1, 26))
+            meetup(2013, 1, 'last', 'Saturday'), date(2013, 1, 26))
 
     def test_last_saturday_of_february_2013(self):
         self.assertEqual(
-            meetup_day(2013, 2, 'Saturday', 'last'), date(2013, 2, 23))
+            meetup(2013, 2, 'last', 'Saturday'), date(2013, 2, 23))
 
     def test_last_sunday_of_march_2013(self):
         self.assertEqual(
-            meetup_day(2013, 3, 'Sunday', 'last'), date(2013, 3, 31))
+            meetup(2013, 3, 'last', 'Sunday'), date(2013, 3, 31))
 
     def test_last_sunday_of_april_2013(self):
         self.assertEqual(
-            meetup_day(2013, 4, 'Sunday', 'last'), date(2013, 4, 28))
+            meetup(2013, 4, 'last', 'Sunday'), date(2013, 4, 28))
 
     def test_last_wednesday_of_february_2012(self):
         self.assertEqual(
-            meetup_day(2012, 2, 'Wednesday', 'last'), date(2012, 2, 29))
+            meetup(2012, 2, 'last', 'Wednesday'), date(2012, 2, 29))
 
     def test_last_wednesday_of_december_2014(self):
         self.assertEqual(
-            meetup_day(2014, 12, 'Wednesday', 'last'), date(2014, 12, 31))
+            meetup(2014, 12, 'last', 'Wednesday'), date(2014, 12, 31))
 
     def test_last_sunday_of_february_2015(self):
         self.assertEqual(
-            meetup_day(2015, 2, 'Sunday', 'last'), date(2015, 2, 22))
+            meetup(2015, 2, 'last', 'Sunday'), date(2015, 2, 22))
 
     def test_first_friday_of_december_2012(self):
         self.assertEqual(
-            meetup_day(2012, 12, 'Friday', '1st'), date(2012, 12, 7))
+            meetup(2012, 12, '1st', 'Friday'), date(2012, 12, 7))
 
     # additional track specific tests
     def test_fifth_monday_of_march_2015(self):
         self.assertEqual(
-            meetup_day(2015, 3, 'Monday', '5th'), date(2015, 3, 30))
+            meetup(2015, 3, '5th', 'Monday'), date(2015, 3, 30))
 
     def test_nonexistent_fifth_monday_of_february_2015(self):
         with self.assertRaisesWithMessage(MeetupDayException):
-            meetup_day(2015, 2, 'Monday', '5th')
+            meetup(2015, 2, '5th', 'Monday')
 
     # Utility functions
     def setUp(self):


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to **meetup** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`.
- Changed argument names to **day_of_week** and **week** in `example.py` and exercise stub to conform with `canonical-data.json`.
- Re-ordered function arguments in tests, `example.py`, and exercise stub to _year, month, **week**, **day_of_week**_ to conform with the order of inputs in `canonical-data.json`.
- Changed two-letter variable name to **day** in `example.py`, for clarity 
