### PR TITLE
Minesweeper: sync expected test results and input data with problem-specifications

### DIFF
--- a/exercises/minesweeper/example.py
+++ b/exercises/minesweeper/example.py
@@ -4,7 +4,7 @@ def annotate(minefield):
     verify_board(minefield)
     row_len = len(minefield[0])
     col_len = len(minefield)
-    board = [list(r) for r in minefield]
+    board = [list(row) for row in minefield]
 
     for index1 in range(col_len):
         for index2 in range(row_len):
@@ -23,7 +23,7 @@ def annotate(minefield):
                 continue
 
             board[index1][index2] = str(counts)
-    return ["".join(r) for r in board]
+    return ["".join(row) for row in board]
 
 
 def verify_board(minefield):

--- a/exercises/minesweeper/example.py
+++ b/exercises/minesweeper/example.py
@@ -1,35 +1,40 @@
-def board(inp):
-    if(inp == []):
+def annotate(minefield):
+    if(minefield == []):
         return []
-    verify_board(inp)
-    rowlen = len(inp[0])
-    collen = len(inp)
-    b = [list(r) for r in inp]
-    for i1 in range(collen):
-        for i2 in range(rowlen):
-            if b[i1][i2] != ' ':
+    verify_board(minefield)
+    row_len = len(minefield[0])
+    col_len = len(minefield)
+    board = [list(r) for r in minefield]
+
+    for index1 in range(col_len):
+        for index2 in range(row_len):
+            if board[index1][index2] != ' ':
                 continue
-            low = max(i2 - 1, 0)
-            high = min(i2 + 2, rowlen + 2)
-            cnt = inp[i1][low:high].count('*')
-            if(i1 > 0):
-                cnt += inp[i1 - 1][low:high].count('*')
-            if(i1 < collen - 1):
-                cnt += inp[i1 + 1][low:high].count('*')
-            if cnt == 0:
+
+            low = max(index2 - 1, 0)
+            high = min(index2 + 2, row_len + 2)
+            counts = minefield[index1][low:high].count('*')
+
+            if(index1 > 0):
+                counts += minefield[index1 - 1][low:high].count('*')
+            if(index1 < col_len - 1):
+                counts += minefield[index1 + 1][low:high].count('*')
+            if counts == 0:
                 continue
-            b[i1][i2] = str(cnt)
-    return ["".join(r) for r in b]
+
+            board[index1][index2] = str(counts)
+    return ["".join(r) for r in board]
 
 
-def verify_board(inp):
+def verify_board(minefield):
     # Rows with different lengths
-    rowlen = len(inp[0])
-    if not all(len(r) == rowlen for r in inp):
+    row_len = len(minefield[0])
+    if not all(len(row) == row_len for row in minefield):
         raise ValueError("Invalid board")
+
     # Unknown character in board
-    cset = set()
-    for r in inp:
-        cset.update(r)
-    if cset - set(' *'):
+    character_set = set()
+    for row in minefield:
+        character_set.update(row)
+    if character_set - set(' *'):
         raise ValueError("Invalid board")

--- a/exercises/minesweeper/minesweeper.py
+++ b/exercises/minesweeper/minesweeper.py
@@ -1,3 +1,3 @@
-def board(input_board_array):
+def annotate(minefield):
     # Function body starts here
     pass

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -22,23 +22,39 @@ class MinesweeperTest(unittest.TestCase):
         self.assertEqual(annotate([""]), [""])
 
     def test_no_mines(self):
-        minefield = ["   ", "   ", "   "]
-        out = ["   ", "   ", "   "]
+        minefield = ["   ",
+                     "   ",
+                     "   "]
+        out = ["   ",
+               "   ",
+               "   "]
         self.assertEqual(annotate(minefield), out)
 
     def test_annotate_with_only_mines(self):
-        minefield = ["***", "***", "***"]
-        out = ["***", "***", "***"]
+        minefield = ["***",
+                     "***",
+                     "***"]
+        out = ["***",
+               "***",
+               "***"]
         self.assertEqual(annotate(minefield), out)
 
     def test_mine_surrounded_by_spaces(self):
-        minefield = ["   ", " * ", "   "]
-        out = ["111", "1*1", "111"]
+        minefield = ["   ",
+                     " * ",
+                     "   "]
+        out = ["111",
+               "1*1",
+               "111"]
         self.assertEqual(annotate(minefield), out)
 
     def test_space_surrounded_by_mines(self):
-        minefield = ["***", "* *", "***"]
-        out = ["***", "*8*", "***"]
+        minefield = ["***",
+                     "* *",
+                     "***"]
+        out = ["***",
+               "*8*",
+               "***"]
         self.assertEqual(annotate(minefield), out)
 
     def test_horizontal_line(self):
@@ -52,34 +68,77 @@ class MinesweeperTest(unittest.TestCase):
         self.assertEqual(annotate(minefield), out)
 
     def test_vertical_line(self):
-        minefield = [" ", "*", " ", "*", " "]
-        out = ["1", "*", "2", "*", "1"]
+        minefield = [" ",
+                     "*",
+                     " ",
+                     "*",
+                     " "]
+        out = ["1",
+               "*",
+               "2",
+               "*",
+               "1"]
         self.assertEqual(annotate(minefield), out)
 
     def test_vertical_line_mines_at_edges(self):
-        minefield = ["*", " ", " ", " ", "*"]
-        out = ["*", "1", " ", "1", "*"]
+        minefield = ["*",
+                     " ",
+                     " ",
+                     " ",
+                     "*"]
+        out = ["*",
+               "1",
+               " ",
+               "1",
+               "*"]
         self.assertEqual(annotate(minefield), out)
 
     def test_cross(self):
-        minefield = ["  *  ", "  *  ", "*****", "  *  ", "  *  "]
-        out = [" 2*2 ", "25*52", "*****", "25*52", " 2*2 "]
+        minefield = ["  *  ",
+                     "  *  ",
+                     "*****",
+                     "  *  ",
+                     "  *  "]
+        out = [" 2*2 ",
+               "25*52",
+               "*****",
+               "25*52",
+               " 2*2 "]
         self.assertEqual(annotate(minefield), out)
 
     def test_large_annotate(self):
-        minefield = [" *  * ", "  *   ", "    * ",
-                     "   * *", " *  * ", "      "]
-        out = ["1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"]
+        minefield = [" *  * ",
+                     "  *   ",
+                     "    * ",
+                     "   * *",
+                     " *  * ",
+                     "      "]
+        out = ["1*22*1",
+               "12*322",
+               " 123*2",
+               "112*4*",
+               "1*22*2",
+               "111111"]
         self.assertEqual(annotate(minefield), out)
 
     # Additional test for this track
     def test_annotate9(self):
-        minefield = ["     ", "   * ", "     ", "     ", " *   "]
-        out = ["  111", "  1*1", "  111", "111  ", "1*1  "]
+        minefield = ["     ",
+                     "   * ",
+                     "     ",
+                     "     ",
+                     " *   "]
+        out = ["  111",
+               "  1*1",
+               "  111",
+               "111  ",
+               "1*1  "]
         self.assertEqual(annotate(minefield), out)
 
     def test_different_len(self):
-        minefield = [" ", "*  ", "  "]
+        minefield = [" ",
+                     "*  ",
+                     "  "]
         with self.assertRaisesWithMessage(ValueError):
             annotate(minefield)
 

--- a/exercises/minesweeper/minesweeper_test.py
+++ b/exercises/minesweeper/minesweeper_test.py
@@ -2,13 +2,13 @@
 
 Implementation note:
 The board function must validate its input and raise a
-ValueError with a meaningfull error message if the
+ValueError with a *meaningful* error message if the
 input turns out to be malformed.
 """
 
 import unittest
 
-from minesweeper import board
+from minesweeper import annotate
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
@@ -16,136 +16,77 @@ from minesweeper import board
 class MinesweeperTest(unittest.TestCase):
 
     def test_no_rows(self):
-        self.assertEqual(board([]), [])
+        self.assertEqual(annotate([]), [])
 
     def test_no_columns(self):
-        self.assertEqual(board([""]), [""])
+        self.assertEqual(annotate([""]), [""])
 
     def test_no_mines(self):
-        inp = ["   ",
-               "   ",
-               "   "]
-        out = ["   ",
-               "   ",
-               "   "]
-        self.assertEqual(board(inp), out)
+        minefield = ["   ", "   ", "   "]
+        out = ["   ", "   ", "   "]
+        self.assertEqual(annotate(minefield), out)
 
-    def test_board_with_only_mines(self):
-        inp = ["***",
-               "***",
-               "***"]
-        out = ["***",
-               "***",
-               "***"]
-        self.assertEqual(board(inp), out)
+    def test_annotate_with_only_mines(self):
+        minefield = ["***", "***", "***"]
+        out = ["***", "***", "***"]
+        self.assertEqual(annotate(minefield), out)
 
     def test_mine_surrounded_by_spaces(self):
-        inp = ["   ",
-               " * ",
-               "   "]
-        out = ["111",
-               "1*1",
-               "111"]
-        self.assertEqual(board(inp), out)
+        minefield = ["   ", " * ", "   "]
+        out = ["111", "1*1", "111"]
+        self.assertEqual(annotate(minefield), out)
 
     def test_space_surrounded_by_mines(self):
-        inp = ["***",
-               "* *",
-               "***"]
-        out = ["***",
-               "*8*",
-               "***"]
-        self.assertEqual(board(inp), out)
+        minefield = ["***", "* *", "***"]
+        out = ["***", "*8*", "***"]
+        self.assertEqual(annotate(minefield), out)
 
     def test_horizontal_line(self):
-        inp = [" * * "]
+        minefield = [" * * "]
         out = ["1*2*1"]
-        self.assertEqual(board(inp), out)
+        self.assertEqual(annotate(minefield), out)
 
     def test_horizontal_line_mines_at_edges(self):
-        inp = ["*   *"]
+        minefield = ["*   *"]
         out = ["*1 1*"]
-        self.assertEqual(board(inp), out)
+        self.assertEqual(annotate(minefield), out)
 
     def test_vertical_line(self):
-        inp = [" ",
-               "*",
-               " ",
-               "*",
-               " "]
-        out = ["1",
-               "*",
-               "2",
-               "*",
-               "1"]
-        self.assertEqual(board(inp), out)
+        minefield = [" ", "*", " ", "*", " "]
+        out = ["1", "*", "2", "*", "1"]
+        self.assertEqual(annotate(minefield), out)
 
     def test_vertical_line_mines_at_edges(self):
-        inp = ["*",
-               " ",
-               " ",
-               " ",
-               "*"]
-        out = ["*",
-               "1",
-               " ",
-               "1",
-               "*"]
-        self.assertEqual(board(inp), out)
+        minefield = ["*", " ", " ", " ", "*"]
+        out = ["*", "1", " ", "1", "*"]
+        self.assertEqual(annotate(minefield), out)
 
     def test_cross(self):
-        inp = ["  *  ",
-               "  *  ",
-               "*****",
-               "  *  ",
-               "  *  "]
-        out = [" 2*2 ",
-               "25*52",
-               "*****",
-               "25*52",
-               " 2*2 "]
-        self.assertEqual(board(inp), out)
+        minefield = ["  *  ", "  *  ", "*****", "  *  ", "  *  "]
+        out = [" 2*2 ", "25*52", "*****", "25*52", " 2*2 "]
+        self.assertEqual(annotate(minefield), out)
 
-    def test_large_board(self):
-        inp = [" *  * ",
-               "  *   ",
-               "    * ",
-               "   * *",
-               " *  * ",
-               "      "]
-        out = ["1*22*1",
-               "12*322",
-               " 123*2",
-               "112*4*",
-               "1*22*2",
-               "111111"]
-        self.assertEqual(board(inp), out)
+    def test_large_annotate(self):
+        minefield = [" *  * ", "  *   ", "    * ",
+                     "   * *", " *  * ", "      "]
+        out = ["1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"]
+        self.assertEqual(annotate(minefield), out)
 
     # Additional test for this track
-    def test_board9(self):
-        inp = ["     ",
-               "   * ",
-               "     ",
-               "     ",
-               " *   "]
-        out = ["  111",
-               "  1*1",
-               "  111",
-               "111  ",
-               "1*1  "]
-        self.assertEqual(board(inp), out)
+    def test_annotate9(self):
+        minefield = ["     ", "   * ", "     ", "     ", " *   "]
+        out = ["  111", "  1*1", "  111", "111  ", "1*1  "]
+        self.assertEqual(annotate(minefield), out)
 
     def test_different_len(self):
-        inp = [" ",
-               "*  ",
-               "  "]
+        minefield = [" ", "*  ", "  "]
         with self.assertRaisesWithMessage(ValueError):
-            board(inp)
+            annotate(minefield)
 
     def test_invalid_char(self):
-        inp = ["X  * "]
+        minefield = ["X  * "]
         with self.assertRaisesWithMessage(ValueError):
-            board(inp)
+            annotate(minefield)
 
     # Utility functions
     def setUp(self):


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed name of function to **annotate** in tests, `example.py`, and  exercise stub to conform with `canonical-data.json`.
- Changed function argument name to **minefield** in tests, `example.py` and exercise stub to conform with `canonical-data.json`.
- Changed the following in `example.py` for clarity:
   - single-letter **r** variables to **row**  
   - single-letter **b** variables to **board**.
   -  **i1 / i2** variable references to **index1 / index2**
   - **rowlen / collen** variable references to **row_len / col_len** 
   - **cset** to **character_set**
- Changed the layout of tests list input/output to contain less vertical space to conform with `flake8` tests.
