### PR TITLE
sum_of_multiples: sync with canonical data

### DIFF
--- a/exercises/sum-of-multiples/example.py
+++ b/exercises/sum-of-multiples/example.py
@@ -1,5 +1,8 @@
-def sum_of_multiples(limit, multiples):
-    return sum(value for value in range(limit)
-               if any(value % multiple == 0
-                      for multiple in multiples
-                      if multiple > 0))
+old_sum = sum
+
+
+def sum(factors, limit):
+    return old_sum(value for value in range(limit)
+                   if any(value % multiple == 0
+                          for multiple in factors
+                          if multiple > 0))

--- a/exercises/sum-of-multiples/sum_of_multiples.py
+++ b/exercises/sum-of-multiples/sum_of_multiples.py
@@ -1,2 +1,2 @@
-def sum_of_multiples(limit, multiples):
+def sum(factors, limit):
     pass

--- a/exercises/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.py
@@ -1,6 +1,6 @@
 """
 You can make the following assumptions about the inputs to the
-'sum_of_multiples' function:
+'sum' function:
     * All input numbers are non-negative 'int's, i.e. natural numbers
       including zero.
     * A list of factors must be given, and its elements are unique
@@ -9,60 +9,59 @@ You can make the following assumptions about the inputs to the
 
 import unittest
 
-from sum_of_multiples import sum_of_multiples
+from sum_of_multiples import sum
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.0
 
 class SumOfMultiplesTest(unittest.TestCase):
-    def test_multiples_with_no_factors_in_limit(self):
-        self.assertEqual(sum_of_multiples(1, [3, 5]), 0)
+    def test_no_multiples_within_limit(self):
+        self.assertEqual(sum([3, 5], 1), 0)
 
-    def test_multiples_of_one_factor_within_limit(self):
-        self.assertEqual(sum_of_multiples(4, [3, 5]), 3)
+    def test_one_factor_has_multiples_within_limit(self):
+        self.assertEqual(sum([3, 5], 4), 3)
 
-    def test_various_multiples_in_limit(self):
-        self.assertEqual(sum_of_multiples(7, [3]), 9)
+    def test_more_than_one_multiple_within_limit(self):
+        self.assertEqual(sum([3], 7), 9)
 
     def test_various_factors_with_multiples_in_limit(self):
-        self.assertEqual(sum_of_multiples(10, [3, 5]), 23)
+        self.assertEqual(sum([3, 5], 10), 23)
 
-    def test_multiples_counted_only_once(self):
-        self.assertEqual(sum_of_multiples(100, [3, 5]), 2318)
+    def test_each_multiple_is_only_counted_once(self):
+        self.assertEqual(sum([3, 5], 100), 2318)
 
-    def test_multiples_with_large_limit(self):
-        self.assertEqual(sum_of_multiples(1000, [3, 5]), 233168)
+    def test_a_much_larger_limit(self):
+        self.assertEqual(sum([3, 5], 1000), 233168)
 
-    def test_multiples_with_three_factors(self):
-        self.assertEqual(sum_of_multiples(20, [7, 13, 17]), 51)
+    def test_three_factors(self):
+        self.assertEqual(sum([7, 13, 17], 20), 51)
 
-    def test_multiples_with_factors_not_prime(self):
-        self.assertEqual(sum_of_multiples(15, [4, 6]), 30)
+    def test_factors_not_relatively_prime(self):
+        self.assertEqual(sum([4, 6], 15), 30)
 
-    def test_multiples_with_factors_prime_and_not(self):
-        self.assertEqual(sum_of_multiples(150, [5, 6, 8]), 4419)
+    def test_some_pairs_of_factors_relatively_prime_and_some_not(self):
+        self.assertEqual(sum([5, 6, 8], 150), 4419)
 
-    def test_multiples_with_similar_factors(self):
-        self.assertEqual(sum_of_multiples(51, [5, 25]), 275)
+    def test_one_factor_is_a_multiple_of_another(self):
+        self.assertEqual(sum([5, 25], 51), 275)
 
-    def test_multiples_with_large_factors(self):
-        self.assertEqual(sum_of_multiples(10000, [43, 47]), 2203160)
+    def test_much_larger_factors(self):
+        self.assertEqual(sum([43, 47], 10000), 2203160)
 
-    def test_multiples_of_one_will_be_all(self):
-        self.assertEqual(sum_of_multiples(100, [1]), 4950)
+    def test_all_numbers_are_multiples_of_1(self):
+        self.assertEqual(sum([1], 100), 4950)
 
-    def test_multiples_of_an_empty_list(self):
-        self.assertEqual(sum_of_multiples(10000, []), 0)
+    def test_no_factors_means_an_empty_sum(self):
+        self.assertEqual(sum([], 10000), 0)
 
-    def test_multiples_of_zero_will_be_none(self):
-        self.assertEqual(sum_of_multiples(1, [0]), 0)
+    def test_the_only_multiple_of_0_is_0(self):
+        self.assertEqual(sum([0], 1), 0)
 
-    def test_multiples_with_a_zero_factor(self):
-        self.assertEqual(sum_of_multiples(4, [0, 3]), 3)
+    def test_the_factor_0_does_not_affect_the_sum_of_other_factors(self):
+        self.assertEqual(sum([3, 0], 4), 3)
 
-    def test_multiples_of_several_factors(self):
-        self.assertEqual(sum_of_multiples(10000,
-                         [2, 3, 5, 7, 11]), 39614537)
+    def test_solutions_must_extend_to_cardinality_greater_than_3(self):
+        self.assertEqual(sum([2, 3, 5, 7, 11], 10000), 39614537)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
part of #1762 

- changed the stub, tests, and example to fit with the [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/sum-of-multiples/canonical-data.json)
- order of arguments changed
- test function names changed to canon
- the function name is supposed to be `sum()` which is a name of a built-in function. This was addressed in the `example.py` by `old_sum = sum`
- one of the test function names would be too long if used exactly as in canon. Used a truncated name for now. Discuss inline.
