### PR TITLE
spiral-matrix: sync with canonical data

### DIFF
--- a/exercises/spiral-matrix/example.py
+++ b/exercises/spiral-matrix/example.py
@@ -1,11 +1,11 @@
-def spiral(size):
-    sm = [[0]*size for k in range(size)]
-    i, j, el = 0, -1, 1
+def spiral_matrix(size):
+    matrix = [[0]*size for row in range(size)]
+    i, j, element = 0, -1, 1
     di, dj = [0, 1, 0, -1], [1, 0, -1, 0]
     for x in range(2*size - 1):
         for y in range((2*size - x) // 2):
             i += di[x % 4]
             j += dj[x % 4]
-            sm[i][j] = el
-            el += 1
-    return sm
+            matrix[i][j] = element
+            element += 1
+    return matrix

--- a/exercises/spiral-matrix/spiral_matrix.py
+++ b/exercises/spiral-matrix/spiral_matrix.py
@@ -1,2 +1,2 @@
-def spiral(size):
+def spiral_matrix(size):
     pass

--- a/exercises/spiral-matrix/spiral_matrix_test.py
+++ b/exercises/spiral-matrix/spiral_matrix_test.py
@@ -1,39 +1,50 @@
 import unittest
 
-from spiral_matrix import spiral
+from spiral_matrix import spiral_matrix
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 
-class SpiralMatrixTest(unittest.TestCase):
-    def test_spiral_matrix_with_size_0(self):
-        self.assertEqual(spiral(0), [])
+class Spiral_matrixMatrixTest(unittest.TestCase):
+    def test_empty_spiral(self):
+        self.assertEqual(spiral_matrix(0), [
+        ])
 
-    def test_spiral_matrix_with_size_1(self):
-        self.assertEqual(spiral(1), [[1]])
+    def test_trivial_spiral(self):
+        self.assertEqual(spiral_matrix(1), [
+            [1]
+        ])
 
-    def test_spiral_matrix_with_size_2(self):
-        self.assertEqual(spiral(2), [[1, 2],
-                                     [4, 3]])
+    def test_spiral_of_size_2(self):
+        self.assertEqual(spiral_matrix(2), [
+            [1, 2],
+            [4, 3]
+        ])
 
-    def test_spiral_matrix_with_size_3(self):
-        self.assertEqual(spiral(3), [[1, 2, 3],
-                                     [8, 9, 4],
-                                     [7, 6, 5]])
+    def test_spiral_of_size_3(self):
+        self.assertEqual(spiral_matrix(3), [
+            [1, 2, 3],
+            [8, 9, 4],
+            [7, 6, 5]
+        ])
 
-    def test_spiral_matrix_with_size_4(self):
-        self.assertEqual(spiral(4), [[1,  2,  3,  4],
-                                     [12, 13, 14, 5],
-                                     [11, 16, 15, 6],
-                                     [10, 9,  8,  7]])
+    def test_spiral_of_size_4(self):
+        self.assertEqual(spiral_matrix(4), [
+            [1,  2,  3,  4],
+            [12, 13, 14, 5],
+            [11, 16, 15, 6],
+            [10, 9,  8,  7]
+        ])
 
-    def test_spiral_matrix_with_size_5(self):
-        self.assertEqual(spiral(5), [[1,  2,  3,  4,  5],
-                                     [16, 17, 18, 19, 6],
-                                     [15, 24, 25, 20, 7],
-                                     [14, 23, 22, 21, 8],
-                                     [13, 12, 11, 10, 9]])
+    def test_spiral_of_size_5(self):
+        self.assertEqual(spiral_matrix(5), [
+            [1,  2,  3,  4,  5],
+            [16, 17, 18, 19, 6],
+            [15, 24, 25, 20, 7],
+            [14, 23, 22, 21, 8],
+            [13, 12, 11, 10, 9]
+        ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of #1762 

- changed the name of the main function with accordance with [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/spiral-matrix/canonical-data.json)
- changed the test function names to fit canon.
- applied consistent indentation in test cases for clarity.
- some `example.py` variable name cleanup.