### PR TITLE
sieve: sync with canonical data

### DIFF
--- a/exercises/sieve/example.py
+++ b/exercises/sieve/example.py
@@ -1,4 +1,4 @@
-def sieve(limit):
+def primes(limit):
     prime = [True] * (limit + 1)
     prime[0] = prime[1] = False
     for i in range(2, int(limit ** 0.5) + 1):

--- a/exercises/sieve/sieve.py
+++ b/exercises/sieve/sieve.py
@@ -1,2 +1,2 @@
-def sieve(limit):
+def primes(limit):
     pass

--- a/exercises/sieve/sieve_test.py
+++ b/exercises/sieve/sieve_test.py
@@ -1,26 +1,26 @@
 import unittest
 
-from sieve import sieve
+from sieve import primes
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class SieveTest(unittest.TestCase):
     def test_no_primes_under_two(self):
-        self.assertEqual(sieve(1), [])
+        self.assertEqual(primes(1), [])
 
     def test_find_first_prime(self):
-        self.assertEqual(sieve(2), [2])
+        self.assertEqual(primes(2), [2])
 
     def test_find_primes_up_to_10(self):
-        self.assertEqual(sieve(10), [2, 3, 5, 7])
+        self.assertEqual(primes(10), [2, 3, 5, 7])
 
     def test_limit_is_prime(self):
-        self.assertEqual(sieve(13), [2, 3, 5, 7, 11, 13])
+        self.assertEqual(primes(13), [2, 3, 5, 7, 11, 13])
 
     def test_find_primes_up_to_1000(self):
         self.assertEqual(
-            sieve(1000), [
+            primes(1000), [
                 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
                 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127,
                 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191,


### PR DESCRIPTION
part of #1762 

- renamed the function in sieve, test and example to primes in accordance with [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/sieve/canonical-data.json)
