### PR TITLE
Prime factors: sync expected test results and input data with problem-specifications

### DIFF
--- a/exercises/prime-factors/example.py
+++ b/exercises/prime-factors/example.py
@@ -1,10 +1,10 @@
-def prime_factors(number):
+def factors(value):
     factors = []
     divisor = 2
-    while number > 1:
-        while number % divisor == 0:
+    while value > 1:
+        while value % divisor == 0:
             factors.append(divisor)
-            number /= divisor
+            value /= divisor
 
         divisor += 1
 

--- a/exercises/prime-factors/prime_factors.py
+++ b/exercises/prime-factors/prime_factors.py
@@ -1,2 +1,2 @@
-def prime_factors(natural_number):
+def factors(value):
     pass

--- a/exercises/prime-factors/prime_factors_test.py
+++ b/exercises/prime-factors/prime_factors_test.py
@@ -1,31 +1,31 @@
 import unittest
 
-from prime_factors import prime_factors
+from prime_factors import factors
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class PrimeFactorsTest(unittest.TestCase):
     def test_no_factors(self):
-        self.assertEqual(prime_factors(1), [])
+        self.assertEqual(factors(1), [])
 
     def test_prime_number(self):
-        self.assertEqual(prime_factors(2), [2])
+        self.assertEqual(factors(2), [2])
 
     def test_square_of_a_prime(self):
-        self.assertEqual(prime_factors(9), [3, 3])
+        self.assertEqual(factors(9), [3, 3])
 
     def test_cube_of_a_prime(self):
-        self.assertEqual(prime_factors(8), [2, 2, 2])
+        self.assertEqual(factors(8), [2, 2, 2])
 
     def test_product_of_primes_and_non_primes(self):
-        self.assertEqual(prime_factors(12), [2, 2, 3])
+        self.assertEqual(factors(12), [2, 2, 3])
 
     def test_product_of_primes(self):
-        self.assertEqual(prime_factors(901255), [5, 17, 23, 461])
+        self.assertEqual(factors(901255), [5, 17, 23, 461])
 
     def test_factors_include_a_large_prime(self):
-        self.assertEqual(prime_factors(93819012551), [11, 9539, 894119])
+        self.assertEqual(factors(93819012551), [11, 9539, 894119])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to **factors** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`.
- Changed function argument name to **value** in `example.py` and exercise stub to conform with `canonical-data.json`
