### PR TITLE
Raindrops: sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/raindrops/example.py
+++ b/exercises/raindrops/example.py
@@ -1,31 +1,10 @@
-
-def _is_pling(number):
-    return number % 3 == 0
+DROPS = ((3, 'Pling'), (5, 'Plang'), (7, 'Plong'))
 
 
-def _is_plang(number):
-    return number % 5 == 0
+def convert(number):
+    """
+    Converts a number to a string according to the raindrop sounds.
+    """
 
-
-def _is_plong(number):
-    return number % 7 == 0
-
-
-def _drops_for(number):
-    drops = []
-    if _is_pling(number):
-        drops.append('Pling')
-
-    if _is_plang(number):
-        drops.append('Plang')
-
-    if _is_plong(number):
-        drops.append('Plong')
-
-    return drops
-
-
-def raindrops(number):
-    drops = _drops_for(number)
-
-    return ''.join(drops) or str(number)
+    return "".join(sound for factor, sound
+                   in DROPS if number % factor == 0) or str(number)

--- a/exercises/raindrops/raindrops.py
+++ b/exercises/raindrops/raindrops.py
@@ -1,2 +1,2 @@
-def raindrops(number):
+def convert(number):
     pass

--- a/exercises/raindrops/raindrops_test.py
+++ b/exercises/raindrops/raindrops_test.py
@@ -1,64 +1,64 @@
 import unittest
 
-from raindrops import raindrops
+from raindrops import convert
 
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 class RaindropsTest(unittest.TestCase):
     def test_the_sound_for_1_is_1(self):
-        self.assertEqual(raindrops(1), "1")
+        self.assertEqual(convert(1), "1")
 
     def test_the_sound_for_3_is_pling(self):
-        self.assertEqual(raindrops(3), "Pling")
+        self.assertEqual(convert(3), "Pling")
 
     def test_the_sound_for_5_is_plang(self):
-        self.assertEqual(raindrops(5), "Plang")
+        self.assertEqual(convert(5), "Plang")
 
     def test_the_sound_for_7_is_plong(self):
-        self.assertEqual(raindrops(7), "Plong")
+        self.assertEqual(convert(7), "Plong")
 
     def test_the_sound_for_6_is_pling(self):
-        self.assertEqual(raindrops(6), "Pling")
+        self.assertEqual(convert(6), "Pling")
 
     def test_2_to_the_power_3_does_not_make_sound(self):
-        self.assertEqual(raindrops(8), "8")
+        self.assertEqual(convert(8), "8")
 
     def test_the_sound_for_9_is_pling(self):
-        self.assertEqual(raindrops(9), "Pling")
+        self.assertEqual(convert(9), "Pling")
 
     def test_the_sound_for_10_is_plang(self):
-        self.assertEqual(raindrops(10), "Plang")
+        self.assertEqual(convert(10), "Plang")
 
     def test_the_sound_for_14_is_plong(self):
-        self.assertEqual(raindrops(14), "Plong")
+        self.assertEqual(convert(14), "Plong")
 
     def test_the_sound_for_15_is_plingplang(self):
-        self.assertEqual(raindrops(15), "PlingPlang")
+        self.assertEqual(convert(15), "PlingPlang")
 
     def test_the_sound_for_21_is_plingplong(self):
-        self.assertEqual(raindrops(21), "PlingPlong")
+        self.assertEqual(convert(21), "PlingPlong")
 
     def test_the_sound_for_25_is_plang(self):
-        self.assertEqual(raindrops(25), "Plang")
+        self.assertEqual(convert(25), "Plang")
 
     def test_the_sound_for_27_is_pling(self):
-        self.assertEqual(raindrops(27), "Pling")
+        self.assertEqual(convert(27), "Pling")
 
     def test_the_sound_for_35_is_plangplong(self):
-        self.assertEqual(raindrops(35), "PlangPlong")
+        self.assertEqual(convert(35), "PlangPlong")
 
     def test_the_sound_for_49_is_plong(self):
-        self.assertEqual(raindrops(49), "Plong")
+        self.assertEqual(convert(49), "Plong")
 
     def test_the_sound_for_52_is_52(self):
-        self.assertEqual(raindrops(52), "52")
+        self.assertEqual(convert(52), "52")
 
     def test_the_sound_for_105_is_plingplangplong(self):
-        self.assertEqual(raindrops(105), "PlingPlangPlong")
+        self.assertEqual(convert(105), "PlingPlangPlong")
 
     def test_the_sound_for_12121_is_12121(self):
-        self.assertEqual(raindrops(12121), "12121")
+        self.assertEqual(convert(12121), "12121")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to **convert** in tests, `example.py`, and exercise stub to conform with `canoncial-data.json`
- Changed function argument name to **number** in `example.py` and exercise stub to conform with `canonical-data.json`
- Changed `example.py` solution to a shorter one using a nested tuple.
