### PR TITLE
README.md: Remove references to Python 2.7 from README.md (#1704)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ A list of missing exercise can be found here: https://github.com/exercism/python
 
 ### Testing
 
-All exercises must be compatible with Python versions 2.7 and 3.4 upwards.
+All exercises must be compatible with Python version 3.6 upwards.
 
-To test a single exercise (e.g., with Python 2.7):
+To test a single exercise:
 ```
-python2.7 test/check-exercises.py [exercise-name]
+python3 test/check-exercises.py [exercise-name]
 ```
 
-To test all exercises (e.g., with Python 3):
+To test all exercises:
 ```
 python3 test/check-exercises.py
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A list of missing exercise can be found here: https://github.com/exercism/python
 
 ### Testing
 
-All exercises must be compatible with Python version 3.6 upwards.
+All exercises must be compatible with Python version 3.4 upwards.
 
 To test a single exercise:
 ```


### PR DESCRIPTION
Following the patterns from previous commits over branch _**drop-python2**_: 
- Removed the references for Python 2.7 from **README.md**
- Updated the Python _3_ version to _3.6_ following the **ABOUT.md** guidelines on #1760.