### PR TITLE
roman-numerals: sync expected test results and input data with problem-specifications.

### DIFF
--- a/exercises/roman-numerals/example.py
+++ b/exercises/roman-numerals/example.py
@@ -15,10 +15,10 @@ NUMERAL_MAPPINGS = (
 )
 
 
-def numeral(number):
-    s = ''
+def roman(number):
+    result = ''
     for arabic, roman in NUMERAL_MAPPINGS:
         while number >= arabic:
-            s += roman
+            result += roman
             number -= arabic
-    return s
+    return result

--- a/exercises/roman-numerals/roman_numerals.py
+++ b/exercises/roman-numerals/roman_numerals.py
@@ -1,2 +1,2 @@
-def numeral(number):
+def roman(number):
     pass

--- a/exercises/roman-numerals/roman_numerals_test.py
+++ b/exercises/roman-numerals/roman_numerals_test.py
@@ -2,8 +2,8 @@ import unittest
 
 import roman_numerals
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
+
 
 class RomanNumeralsTest(unittest.TestCase):
     numerals = {
@@ -30,7 +30,7 @@ class RomanNumeralsTest(unittest.TestCase):
 
     def test_numerals(self):
         for arabic, numeral in self.numerals.items():
-            self.assertEqual(roman_numerals.numeral(arabic), numeral)
+            self.assertEqual(roman_numerals.roman(arabic), numeral)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of https://github.com/exercism/python/issues/1762

- Changed function name to **roman** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`
- Changed function argument name to **number** in tests, `example.py`, and exercise stub to conform with `canonical-data.json`
