### PR TITLE
two-fer: revert change to explicit None argument

### DIFF
--- a/exercises/two-fer/example.py
+++ b/exercises/two-fer/example.py
@@ -1,5 +1,2 @@
 def two_fer(name=None):
-    if not name:
-        return "One for you, one for me."
-    else:
-        return "One for {}, one for me.".format(name)
+        return "One for {}, one for me.".format(name or 'you')

--- a/exercises/two-fer/example.py
+++ b/exercises/two-fer/example.py
@@ -1,2 +1,2 @@
 def two_fer(name=None):
-        return "One for {}, one for me.".format(name or 'you')
+    return "One for {}, one for me.".format(name or 'you')

--- a/exercises/two-fer/two_fer_test.py
+++ b/exercises/two-fer/two_fer_test.py
@@ -7,7 +7,7 @@ from two_fer import two_fer
 
 class TwoFerTest(unittest.TestCase):
     def test_no_name_given(self):
-        self.assertEqual(two_fer(None), 'One for you, one for me.')
+        self.assertEqual(two_fer(), 'One for you, one for me.')
 
     def test_a_name_given(self):
         self.assertEqual(two_fer("Alice"), "One for Alice, one for me.")


### PR DESCRIPTION
The changes being reverted by this PR were made to blindly conform to a 1-to-1 interpretation of the canonical data. I have been convinced that these changes are not idiomatic, and should not have been included.

Ref: [community response](https://github.com/exercism/python/pull/1806#issuecomment-497971969)

Maintainer's Note: when test generators are deployed, custom handling may be required for this exercise.