### PR TITLE
reverse-string: update tests to v1.2.0

### DIFF
--- a/exercises/reverse-string/reverse_string_test.py
+++ b/exercises/reverse-string/reverse_string_test.py
@@ -20,9 +20,10 @@ class ReverseStringTest(unittest.TestCase):
 
     def test_a_palindrome(self):
         self.assertEqual(reverse('racecar'), 'racecar')
-    
+
     def test_an_even_sized_word(self):
         self.assertEqual(reverse('drawer'), 'reward')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/exercises/reverse-string/reverse_string_test.py
+++ b/exercises/reverse-string/reverse_string_test.py
@@ -3,7 +3,7 @@ import unittest
 from reverse_string import reverse
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class ReverseStringTest(unittest.TestCase):
     def test_empty_string(self):
@@ -20,7 +20,9 @@ class ReverseStringTest(unittest.TestCase):
 
     def test_a_palindrome(self):
         self.assertEqual(reverse('racecar'), 'racecar')
-
+    
+    def test_an_even_sized_word(self):
+        self.assertEqual(reverse('drawer'), 'reward')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Based off [this](https://github.com/exercism/problem-specifications/commit/6c95c2e50fb4cda7dfcc83de220dd3467d788007):

- added an additional test to conform with the 1.2.0 version of [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/reverse-string/canonical-data.json)