### PR TITLE
Anagram: relax test requirement for ordered elements

### DIFF
--- a/exercises/anagram/anagram_test.py
+++ b/exercises/anagram/anagram_test.py
@@ -6,6 +6,7 @@ from anagram import find_anagrams
 if not hasattr(unittest.TestCase, 'assertCountEqual'):
     unittest.TestCase.assertCountEqual = unittest.TestCase.assertItemsEqual
 
+
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.1
 
 class AnagramTest(unittest.TestCase):

--- a/exercises/anagram/anagram_test.py
+++ b/exercises/anagram/anagram_test.py
@@ -12,7 +12,7 @@ class AnagramTest(unittest.TestCase):
 
     def test_detects_two_anagrams(self):
         candidates = ["stream", "pigeon", "maters"]
-        self.assertEqual(
+        self.assertCountEqual(
             find_anagrams("master", candidates), ["stream", "maters"])
 
     def test_does_not_detect_anagram_subsets(self):
@@ -26,7 +26,7 @@ class AnagramTest(unittest.TestCase):
         candidates = [
             "gallery", "ballerina", "regally", "clergy", "largely", "leading"
         ]
-        self.assertEqual(
+        self.assertCountEqual(
             find_anagrams("allergy", candidates),
             ["gallery", "regally", "largely"])
 

--- a/exercises/anagram/anagram_test.py
+++ b/exercises/anagram/anagram_test.py
@@ -2,6 +2,9 @@ import unittest
 
 from anagram import find_anagrams
 
+# Python 2/3 compatibility
+if not hasattr(unittest.TestCase, 'assertCountEqual'):
+    unittest.TestCase.assertCountEqual = unittest.TestCase.assertItemsEqual
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.1
 

--- a/exercises/anagram/anagram_test.py
+++ b/exercises/anagram/anagram_test.py
@@ -3,7 +3,7 @@ import unittest
 from anagram import find_anagrams
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.1
 
 class AnagramTest(unittest.TestCase):
     def test_no_matches(self):
@@ -48,7 +48,7 @@ class AnagramTest(unittest.TestCase):
         self.assertEqual(
             find_anagrams("orchestra", candidates), ["Carthorse"])
 
-    def test_does_not_detect_a_anagram_if_the_original_word_is_repeated(self):
+    def test_does_not_detect_an_anagram_if_the_original_word_is_repeated(self):
         self.assertEqual(find_anagrams("go", ["go Go GO"]), [])
 
     def test_anagrams_must_use_all_letters_exactly_once(self):


### PR DESCRIPTION
See issue #1826.  
- [x] Tested against reference solution and own solution. 
- [x] Tested full track-level test suite.

Note: this implementation uses `assertCountEqual()`, first available in Python 3.2.

"Update tests to v1.4.1" references: https://github.com/exercism/problem-specifications/pull/1534