### PR TITLE
yacht: sync with canonical data

### DIFF
--- a/exercises/yacht/example.py
+++ b/exercises/yacht/example.py
@@ -15,7 +15,7 @@ BIG_STRAIGHT = 10
 CHOICE = 11
 
 
-def ns(number, dice):
+def sum_of_ns(number, dice):
     return sum(n for n in dice if n == number)
 
 
@@ -44,12 +44,12 @@ def yacht(dice):
 
 functions = [
     yacht,
-    partial(ns, 1),
-    partial(ns, 2),
-    partial(ns, 3),
-    partial(ns, 4),
-    partial(ns, 5),
-    partial(ns, 6),
+    partial(sum_of_ns, 1),
+    partial(sum_of_ns, 2),
+    partial(sum_of_ns, 3),
+    partial(sum_of_ns, 4),
+    partial(sum_of_ns, 5),
+    partial(sum_of_ns, 6),
     full_house,
     four_of_a_kind,
     little_straight,
@@ -62,4 +62,4 @@ def score(dice, category):
     try:
         return functions[category](dice)
     except IndexError:
-        raise ValueError("no such category")
+        raise ValueError("No such category.")

--- a/exercises/yacht/yacht.py
+++ b/exercises/yacht/yacht.py
@@ -1,5 +1,19 @@
-# Score categories
-# Change the values as you see fit
+"""
+This exercise stub and the test suite contain several enumerated constants.
+
+Since Python 2 does not have the enum module, the idiomatic way to write
+enumerated constants has traditionally been a NAME assigned to an arbitrary,
+but unique value. An integer is traditionally used because it’s memory
+efficient.
+It is a common practice to export both constants and functions that work with
+those constants (ex. the constants in the os, subprocess and re modules).
+
+You can learn more here: https://en.wikipedia.org/wiki/Enumerated_type
+"""
+
+
+# Score categories.
+# Change the values as you see fit.
 YACHT = None
 ONES = None
 TWOS = None

--- a/exercises/yacht/yacht_test.py
+++ b/exercises/yacht/yacht_test.py
@@ -4,7 +4,7 @@ import yacht
 from yacht import score
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 class YachtTest(unittest.TestCase):
     def test_yacht(self):
@@ -31,7 +31,7 @@ class YachtTest(unittest.TestCase):
     def test_yacht_counted_as_threes(self):
         self.assertEqual(score([3, 3, 3, 3, 3], yacht.THREES), 15)
 
-    def test_yacht_of_threes_counted_as_fives(self):
+    def test_yacht_of_3s_counted_as_fives(self):
         self.assertEqual(score([3, 3, 3, 3, 3], yacht.FIVES), 0)
 
     def test_sixes(self):
@@ -59,7 +59,7 @@ class YachtTest(unittest.TestCase):
         self.assertEqual(score([3, 3, 3, 3, 3], yacht.FOUR_OF_A_KIND), 12)
 
     def test_full_house_is_not_four_of_a_kind(self):
-        self.assertEqual(score([3, 5, 4, 1, 2], yacht.FOUR_OF_A_KIND), 0)
+        self.assertEqual(score([3, 3, 3, 5, 5], yacht.FOUR_OF_A_KIND), 0)
 
     def test_little_straight(self):
         self.assertEqual(score([3, 5, 4, 1, 2], yacht.LITTLE_STRAIGHT), 30)
@@ -73,7 +73,7 @@ class YachtTest(unittest.TestCase):
     def test_no_pairs_but_not_a_little_straight(self):
         self.assertEqual(score([1, 2, 3, 4, 6], yacht.LITTLE_STRAIGHT), 0)
 
-    def test_min_1_max_5_but_not_a_little_straight(self):
+    def test_minimum_is_1_maximum_is_5_but_not_a_little_straight(self):
         self.assertEqual(score([1, 1, 3, 4, 5], yacht.LITTLE_STRAIGHT), 0)
 
     def test_big_straight(self):
@@ -81,6 +81,9 @@ class YachtTest(unittest.TestCase):
 
     def test_big_straight_as_little_straight(self):
         self.assertEqual(score([6, 5, 4, 3, 2], yacht.LITTLE_STRAIGHT), 0)
+
+    def test_no_pairs_but_not_a_big_straight(self):
+        self.assertEqual(score([6, 5, 4, 3, 1], yacht.BIG_STRAIGHT), 0)
 
     def test_choice(self):
         self.assertEqual(score([3, 3, 5, 6, 6], yacht.CHOICE), 23)


### PR DESCRIPTION
Part of #1762 
Based upon #1809 

- Updated test suite to v1.2.0 of [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/yacht/canonical-data.json).
- Fixed an error in one of the test cases, and renamed functions to match canon.
- Added the same comment concerning enumerated constants as in the sublists exercise.
- Minor variable and message changes to `example.py`