### PR TITLE
complex-numbers: add __eq__ skeleton

### DIFF
--- a/exercises/complex-numbers/complex_numbers.py
+++ b/exercises/complex-numbers/complex_numbers.py
@@ -2,6 +2,9 @@ class ComplexNumber(object):
     def __init__(self, real, imaginary):
         pass
 
+    def __eq__(self, other):
+        pass
+
     def __add__(self, other):
         pass
 

--- a/exercises/complex-numbers/complex_numbers_test.py
+++ b/exercises/complex-numbers/complex_numbers_test.py
@@ -35,6 +35,13 @@ class ComplexNumbersTest(unittest.TestCase):
         input_number = ComplexNumber(1, 2)
         self.assertEqual(input_number.imaginary, 2)
 
+    def test_complex_number_equality_and_inequality(self):
+        input_number = ComplexNumber(1, 2)
+        other_number = ComplexNumber(2, 1)
+        expected = ComplexNumber(1, 2)
+        self.assertEqual(input_number, expected)
+        self.assertNotEqual(other_number, expected)
+
     def test_imaginary_unit(self):
         first_input = ComplexNumber(0, 1)
         second_input = ComplexNumber(0, 1)

--- a/exercises/complex-numbers/complex_numbers_test.py
+++ b/exercises/complex-numbers/complex_numbers_test.py
@@ -35,12 +35,11 @@ class ComplexNumbersTest(unittest.TestCase):
         input_number = ComplexNumber(1, 2)
         self.assertEqual(input_number.imaginary, 2)
 
-    def test_complex_number_equality_and_inequality(self):
-        input_number = ComplexNumber(1, 2)
-        other_number = ComplexNumber(2, 1)
-        expected = ComplexNumber(1, 2)
-        self.assertEqual(input_number, expected)
-        self.assertNotEqual(other_number, expected)
+    def test_equality_of_complex_numbers(self):
+        self.assertEqual(ComplexNumber(1, 2), ComplexNumber(1, 2))
+
+    def test_inequality_of_complex_numbers(self):
+        self.assertNotEqual(ComplexNumber(1, 2), ComplexNumber(2, 1))
 
     def test_imaginary_unit(self):
         first_input = ComplexNumber(0, 1)


### PR DESCRIPTION
All of the needed method skeletons (`__add__`, `__mul__`, etc.) are provided in the initial solution file except for `__eq__`.

Proposing to add it as well for the sake of consistency.