### PR TITLE
dot-dsl: remove mutable default arguments

### DIFF
--- a/exercises/dot-dsl/dot_dsl.py
+++ b/exercises/dot-dsl/dot_dsl.py
@@ -2,7 +2,7 @@ NODE, EDGE, ATTR = range(3)
 
 
 class Node(object):
-    def __init__(self, name, attrs={}):
+    def __init__(self, name, attrs):
         self.name = name
         self.attrs = attrs
 
@@ -11,7 +11,7 @@ class Node(object):
 
 
 class Edge(object):
-    def __init__(self, src, dst, attrs={}):
+    def __init__(self, src, dst, attrs):
         self.src = src
         self.dst = dst
         self.attrs = attrs
@@ -23,5 +23,5 @@ class Edge(object):
 
 
 class Graph(object):
-    def __init__(self, data=[]):
+    def __init__(self, data=None):
         pass

--- a/exercises/dot-dsl/dot_dsl_test.py
+++ b/exercises/dot-dsl/dot_dsl_test.py
@@ -16,7 +16,7 @@ class DotDslTest(unittest.TestCase):
             (NODE, "a", {})
         ])
 
-        self.assertEqual(g.nodes, [Node("a")])
+        self.assertEqual(g.nodes, [Node("a", {})])
         self.assertEqual(g.edges, [])
         self.assertEqual(g.attrs, {})
 

--- a/exercises/dot-dsl/example.py
+++ b/exercises/dot-dsl/example.py
@@ -2,7 +2,7 @@ NODE, EDGE, ATTR = range(3)
 
 
 class Node(object):
-    def __init__(self, name, attrs={}):
+    def __init__(self, name, attrs):
         self.name = name
         self.attrs = attrs
 
@@ -11,7 +11,7 @@ class Node(object):
 
 
 class Edge(object):
-    def __init__(self, src, dst, attrs={}):
+    def __init__(self, src, dst, attrs):
         self.src = src
         self.dst = dst
         self.attrs = attrs
@@ -23,10 +23,13 @@ class Edge(object):
 
 
 class Graph(object):
-    def __init__(self, data=[]):
+    def __init__(self, data=None):
         self.nodes = []
         self.edges = []
         self.attrs = {}
+
+        if data is None:
+            data = []
 
         if not isinstance(data, list):
             raise TypeError("Graph data malformed")


### PR DESCRIPTION
Unintentional mutable default arguments lead to surprising results and are confusing to newcomers to say the least ( https://docs.python-guide.org/writing/gotchas ).

A mutable default argument
```python
def __init__(self, attrs={}):
    self.attrs = attrs
```
can be replaced with 
```python
def __init__(self, attrs=None):
    self.attrs = {} if attrs is None else attrs
```
or possibly even more compact
```python
def __init__(self, attrs=None):
    self.attrs = attrs or {}
```

However, this particular exercise forces all of the arguments to be passed through the test suite (specifically, `test_malformed_EDGE`). In that case, I think it makes sense not to provide any defaults for the constructors of `Node` and `Edge` at all, and an immutable default (or, again, no default at all) for the constructor of `Graph`.