### PR TITLE
luhn: improve example.py

### DIFF
--- a/exercises/luhn/example.py
+++ b/exercises/luhn/example.py
@@ -1,18 +1,19 @@
 class Luhn(object):
     def __init__(self, card_num):
-        self.card_num = card_num.replace(" ", "")
-
-    def addends(self):
-        def luhn_transform(n):
-            return (2 * n - 9) if (n > 4) else (2 * n)
-        old_digits = [int(d) for d in str(self.card_num)]
-        return [(luhn_transform(n) if (i % 2 == 0) else n)
-                for i, n in enumerate(old_digits, start=len(old_digits) % 2)]
-
-    def checksum(self):
-        return sum(self.addends())
+        self.card_num = card_num
+        self.checksum = -1
+        digits = card_num.replace(" ", "")
+        length = len(digits)
+        if digits.isdigit() and length > 1:
+            self.checksum = 0
+            cadence = length % 2
+            for idx, digit in enumerate(digits):
+                num = int(digit)
+                if idx % 2 == cadence:
+                    num *= 2
+                    if num > 9:
+                        num -= 9
+                self.checksum += num
 
     def valid(self):
-        if len(self.card_num) <= 1 or not self.card_num.isdigit():
-            return False
-        return self.checksum() % 10 == 0
+        return self.checksum % 10 == 0


### PR DESCRIPTION
The existing example is convoluted: the multiple methods are unnecessary (and inefficient considering the checksum for a given string need only be calculated once), and the use of a closure in **Luhn.addends** adds complexity without enhancing readability.

Instead here's a straightforward method that should be easier to understand. The only "trick" is the **cadence**, which just reflects the fact that you want to double every even-indexed digit on an even-length card number and every odd-indexed digit on an odd-length card number.