### PR TITLE
pangram: update tests to canonical data 2.0.0.

### DIFF
--- a/exercises/pangram/pangram_test.py
+++ b/exercises/pangram/pangram_test.py
@@ -3,37 +3,37 @@ import unittest
 from pangram import is_pangram
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.1
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
 
 class PangramTest(unittest.TestCase):
 
-    def test_sentence_empty(self):
+    def test_empty_sentence_(self):
         self.assertIs(is_pangram(''), False)
 
-    def test_recognizes_a_perfect_lower_case_pangram(self):
+    def test_perfect_lower_case(self):
         self.assertIs(is_pangram('abcdefghijklmnopqrstuvwxyz'), True)
 
-    def test_pangram_with_only_lower_case(self):
+    def test_only_lower_case(self):
         self.assertIs(
             is_pangram('the quick brown fox jumps over the lazy dog'),
             True)
 
-    def test_missing_character_x(self):
+    def test_missing_the_letter_x(self):
         self.assertIs(
             is_pangram('a quick movement of the enemy will '
                        'jeopardize five gunboats'),
             False)
 
-    def test_another_missing_character(self):
+    def test_missing_letter_h(self):
         self.assertIs(is_pangram('five boxing wizards jump quickly at it'),
                       False)
 
-    def test_pangram_with_underscores(self):
+    def test_with_underscores(self):
         self.assertIs(
             is_pangram('the_quick_brown_fox_jumps_over_the_lazy_dog'),
             True)
 
-    def test_pangram_with_numbers(self):
+    def test_with_numbers(self):
         self.assertIs(
             is_pangram('the 1 quick brown fox jumps over the 2 lazy dogs'),
             True)
@@ -43,12 +43,12 @@ class PangramTest(unittest.TestCase):
             is_pangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog'),
             False)
 
-    def test_pangram_with_mixedcase_and_punctuation(self):
+    def test_mixed_case_and_punctuation(self):
         self.assertIs(
             is_pangram('"Five quacking Zephyrs jolt my wax bed."'),
             True)
 
-    def test_upper_and_lower_case_versions_of_the_same_character(self):
+    def test_case_insensitive(self):
         self.assertIs(
             is_pangram('the quick brown fox jumped over the lazy FX'),
             False)


### PR DESCRIPTION
Fixes #1841 

- This was just a cosmetic change, renamed the test functions to the [canon](https://github.com/exercism/problem-specifications/blob/master/exercises/pangram/canonical-data.json)equivalents.