### PR TITLE
robot-simulator: update tests to canonical data 3.2.0

### DIFF
--- a/exercises/robot-simulator/robot_simulator_test.py
+++ b/exercises/robot-simulator/robot_simulator_test.py
@@ -3,29 +3,29 @@ import unittest
 from robot_simulator import Robot, NORTH, EAST, SOUTH, WEST
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v3.1.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v3.2.0
 
 class RobotSimulatorTest(unittest.TestCase):
 
-    def test_robot_created_with_position_and_direction(self):
+    def test_create_robot_at_origin_facing_north(self):
         robot = Robot(NORTH, 0, 0)
         self.assertEqual(robot.coordinates, (0, 0))
         self.assertEqual(robot.bearing, NORTH)
 
-    def test_robot_created_with_negative_position_values(self):
-        robot = Robot(SOUTH, -1, 1)
-        self.assertEqual(robot.coordinates, (-1, 1))
+    def test_create_robot_at_negative_position_facing_south(self):
+        robot = Robot(SOUTH, -1, -1)
+        self.assertEqual(robot.coordinates, (-1, -1))
         self.assertEqual(robot.bearing, SOUTH)
 
-    def test_rotate_turn_right(self):
-        dirA = [EAST, SOUTH, WEST, NORTH]
-        dirB = [SOUTH, WEST, NORTH, EAST]
+    def test_rotating_clockwise(self):
+        dirA = [NORTH, EAST, SOUTH, WEST]
+        dirB = [EAST, SOUTH, WEST, NORTH]
         for x in range(len(dirA)):
             robot = Robot(dirA[x], 0, 0)
             robot.turn_right()
             self.assertEqual(robot.bearing, dirB[x])
 
-    def test_rotate_simulate_R(self):
+    def test_rotating_clockwise_by_simulate_R(self):
         A = [NORTH, EAST, SOUTH, WEST]
         B = [EAST, SOUTH, WEST, NORTH]
         for x in range(len(A)):
@@ -33,7 +33,15 @@ class RobotSimulatorTest(unittest.TestCase):
             robot.simulate("R")
             self.assertEqual(robot.bearing, B[x])
 
-    def test_rotate_simulate_L(self):
+    def test_rotating_counter_clockwise(self):
+        dirA = [NORTH, EAST, SOUTH, WEST]
+        dirB = [WEST, NORTH, EAST, SOUTH]
+        for x in range(len(dirA)):
+            robot = Robot(dirA[x], 0, 0)
+            robot.turn_left()
+            self.assertEqual(robot.bearing, dirB[x])
+
+    def test_rotating_counter_clockwise_by_simulate_L(self):
         A = [NORTH, WEST, SOUTH, EAST]
         B = [WEST, SOUTH, EAST, NORTH]
         for x in range(len(A)):
@@ -41,57 +49,49 @@ class RobotSimulatorTest(unittest.TestCase):
             robot.simulate("L")
             self.assertEqual(robot.bearing, B[x])
 
-    def test_rotate_turn_left(self):
-        dirA = [EAST, SOUTH, WEST, NORTH]
-        dirB = [NORTH, EAST, SOUTH, WEST]
-        for x in range(len(dirA)):
-            robot = Robot(dirA[x], 0, 0)
-            robot.turn_left()
-            self.assertEqual(robot.bearing, dirB[x])
-
-    def test_advance_positive_north(self):
+    def test_moving_forward_one_facing_north_increments_Y(self):
         robot = Robot(NORTH, 0, 0)
         robot.advance()
         self.assertEqual(robot.coordinates, (0, 1))
         self.assertEqual(robot.bearing, NORTH)
 
-    def test_advance_negative_south(self):
+    def test_moving_forward_one_facing_south_decrements_Y(self):
         robot = Robot(SOUTH, 0, 0)
         robot.advance()
         self.assertEqual(robot.coordinates, (0, -1))
         self.assertEqual(robot.bearing, SOUTH)
 
-    def test_advance_positive_east(self):
+    def test_moving_forward_one_facing_east_increments_X(self):
         robot = Robot(EAST, 0, 0)
         robot.advance()
         self.assertEqual(robot.coordinates, (1, 0))
         self.assertEqual(robot.bearing, EAST)
 
-    def test_advance_negative_west(self):
+    def test_moving_forward_one_facing_west_decrements_X(self):
         robot = Robot(WEST, 0, 0)
         robot.advance()
         self.assertEqual(robot.coordinates, (-1, 0))
         self.assertEqual(robot.bearing, WEST)
 
-    def test_move_east_north_from_README(self):
+    def test_series_of_instructions_moving_east_and_north_from_README(self):
         robot = Robot(NORTH, 7, 3)
         robot.simulate("RAALAL")
         self.assertEqual(robot.coordinates, (9, 4))
         self.assertEqual(robot.bearing, WEST)
 
-    def test_move_west_north(self):
+    def test_series_of_instructions_moving_west_and_north(self):
         robot = Robot(NORTH, 0, 0)
         robot.simulate("LAAARALA")
         self.assertEqual(robot.coordinates, (-4, 1))
         self.assertEqual(robot.bearing, WEST)
 
-    def test_move_west_south(self):
+    def test_series_of_instructions_moving_west_and_south(self):
         robot = Robot(EAST, 2, -7)
         robot.simulate("RRAAAAALA")
         self.assertEqual(robot.coordinates, (-3, -8))
         self.assertEqual(robot.bearing, SOUTH)
 
-    def test_move_east_north(self):
+    def test_series_of_instructions_moving_east_and_north(self):
         robot = Robot(SOUTH, 8, 4)
         robot.simulate("LAAARRRALLLL")
         self.assertEqual(robot.coordinates, (11, 5))


### PR DESCRIPTION
Fixes #1839 

- changed the test names to fit the new [canonical](https://github.com/exercism/problem-specifications/blob/master/exercises/robot-simulator/canonical-data.json) changes.
- changed the argument of one of the functions to fit canon.
- reordered tests so they make more logical sense.
- reordered arguments in .rotate() tests, to better fit the order in canon.