### PR TITLE
forth: update canonical reference version

### DIFF
--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -3,7 +3,7 @@ import unittest
 from forth import evaluate, StackUnderflowError
 
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.1
 
 class ForthUtilities(unittest.TestCase):
     # Utility functions


### PR DESCRIPTION
Changes made in 1.7.1 were superficial, so just updating the reference for consistency's sake.