### PR TITLE
rna-transcription: add invalid strand tests

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -25,6 +25,18 @@ class RnaTranscriptionTest(unittest.TestCase):
     def test_transcribes_all_occurrences(self):
         self.assertEqual(to_rna('ACGTGGTCTTAA'), 'UGCACCAGAAUU')
 
+    def test_invalid_nucleotide(self):
+        with self.assertRaises(ValueError):
+            to_rna('X')
+
+    def test_invalid_strand(self):
+        with self.assertRaises(ValueError):
+            to_rna('XYYP')
+
+    def test_partially_invalid_strand(self):
+        with self.assertRaises(ValueError):
+            to_rna('ACGTGGXYTCTTAAYP')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I wrote those test cases because the exercise description tells you that the code need to be able to handle invalid inputs by raising a **ValueError**.