### PR TITLE
Test that original list is not modified for high scores tests

### DIFF
--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -43,7 +43,7 @@ class HighScoresTest(unittest.TestCase):
         
     def test_all_do_not_modify_original_list(self):
         scores = [40, 20, 50, 30]
-        expected = scores.copy()
+        expected = [40, 20, 50, 30]
 
         personal_top_three(scores)
         self.assertEqual(scores, expected)

--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -40,6 +40,19 @@ class HighScoresTest(unittest.TestCase):
         scores = [40]
         expected = [40]
         self.assertEqual(personal_top_three(scores), expected)
+        
+    def test_all_do_not_modify_original_list(self):
+        scores = [40, 20, 50, 30]
+        expected = scores.copy()
+
+        personal_top_three(scores)
+        self.assertEqual(scores, expected)
+
+        latest(scores)
+        self.assertEqual(scores, expected)
+
+        personal_best(scores)
+        self.assertEqual(scores, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The mentor notes mention the importance of using `sorted()` instead of `sort()` (which mutates the list and makes subsequent calls to `latest` incorrect) but this case is not currently tested for and easy for mentors to miss.