### PR TITLE
rna-transcription: fix example.py

### DIFF
--- a/exercises/rna-transcription/example.py
+++ b/exercises/rna-transcription/example.py
@@ -1,18 +1,4 @@
-import sys
-
-if sys.version_info[0] == 2:
-    from string import maketrans
-else:
-    maketrans = str.maketrans
-
-
-DNA_CHARS = 'AGCT'
-DNA_TO_RNA = maketrans(DNA_CHARS, 'UCGA')
-
+DNA_TO_RNA = {ord(d): r for d, r in zip("AGCT", "UCGA")}
 
 def to_rna(dna_strand):
-    valid_chars = set(DNA_CHARS)
-    if any(char not in valid_chars for char in dna_strand):
-        raise ValueError("Input DNA strand contains invalid bases")
-
     return dna_strand.translate(DNA_TO_RNA)

--- a/exercises/rna-transcription/example.py
+++ b/exercises/rna-transcription/example.py
@@ -1,4 +1,11 @@
-DNA_TO_RNA = {ord(d): r for d, r in zip("AGCT", "UCGA")}
+import sys
+
+if sys.version_info[0] == 2:
+    from string import maketrans
+else:
+    maketrans = str.maketrans
+
+DNA_TO_RNA = maketrans("AGCT", "UCGA")
 
 def to_rna(dna_strand):
     return dna_strand.translate(DNA_TO_RNA)


### PR DESCRIPTION
Remove valid character test, as that's not required by spec any longer.
Also removed some unwieldy Python 2 compatibility code. When we drop support for Python 2 we can just change this to a **str.maketrans** call.