### PR TITLE
high scores: Add testing to make sure methods don't mutate the scores list

### DIFF
--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import unittest
 
 from high_scores import latest, personal_best, personal_top_three
@@ -13,9 +14,10 @@ class HighScoresTest(unittest.TestCase):
 
     def test_latest_score_doesnt_modify(self):
         scores = [100, 0, 90, 30]
-        score_length_before_call = len(scores)
+        scores_before_call = deepcopy(scores)
         latest(scores)
-        self.assertEqual(len(scores), score_length_before_call)
+        # test we didn't sort/reverse
+        self.assertEqual(scores, scores_before_call)
 
     def test_personal_best(self):
         scores = [40, 100, 70]
@@ -24,9 +26,9 @@ class HighScoresTest(unittest.TestCase):
 
     def test_personal_best_doesnt_modify(self):
         scores = [40, 100, 70]
-        score_length_before_call = len(scores)
+        scores_before_call = deepcopy(scores)
         personal_best(scores)
-        self.assertEqual(len(scores), score_length_before_call)
+        self.assertEqual(scores, scores_before_call)
 
     def test_personal_top_three_from_a_list_of_scores(self):
         scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
@@ -55,9 +57,9 @@ class HighScoresTest(unittest.TestCase):
 
     def test_personal_top_doesnt_modify(self):
         scores = [40, 100, 70]
-        score_length_before_call = len(scores)
+        scores_before_call = deepcopy(scores)
         personal_top_three(scores)
-        self.assertEqual(len(scores), score_length_before_call)
+        self.assertEqual(scores, scores_before_call)
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -11,10 +11,22 @@ class HighScoresTest(unittest.TestCase):
         expected = 30
         self.assertEqual(latest(scores), expected)
 
+    def test_latest_score_doesnt_modify(self):
+        scores = [100, 0, 90, 30]
+        score_length_before_call = len(scores)
+        latest(scores)
+        self.assertEqual(len(scores), score_length_before_call)
+
     def test_personal_best(self):
         scores = [40, 100, 70]
         expected = 100
         self.assertEqual(personal_best(scores), expected)
+
+    def test_personal_best_doesnt_modify(self):
+        scores = [40, 100, 70]
+        score_length_before_call = len(scores)
+        personal_best(scores)
+        self.assertEqual(len(scores), score_length_before_call)
 
     def test_personal_top_three_from_a_list_of_scores(self):
         scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
@@ -41,6 +53,11 @@ class HighScoresTest(unittest.TestCase):
         expected = [40]
         self.assertEqual(personal_top_three(scores), expected)
 
+    def test_personal_top_doesnt_modify(self):
+        scores = [40, 100, 70]
+        score_length_before_call = len(scores)
+        personal_top_three(scores)
+        self.assertEqual(len(scores), score_length_before_call)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
from a conversation in slack: https://exercism-team.slack.com/archives/CASLGCCSZ/p1564786254008900

This is a common issue we are seeing as python track mentors. This should catch students using pop to return values and doing sorts or reverse rather than sorted() or reverse()