### PR TITLE
high-scores: add tests to prevent solutions that mutate 'scores'

### DIFF
--- a/exercises/high-scores/high_scores_test.py
+++ b/exercises/high-scores/high_scores_test.py
@@ -41,6 +41,27 @@ class HighScoresTest(unittest.TestCase):
         expected = [40]
         self.assertEqual(personal_top_three(scores), expected)
 
+    def test_latest_doesnt_mutate_scores(self):
+        # make sure latest doesn't affect/damage our original object
+        scores = [20, 10, 30]
+        scores_backup = list(scores)
+        _unused = latest(scores)
+        self.assertEqual(scores, scores_backup)
+
+    def test_personal_best_doesnt_mutate_scores(self):
+        # make sure personal_best doesn't affect/damage our original object
+        scores = [20, 10, 30, 50, 40, 10]
+        scores_backup = list(scores)
+        _unused = personal_best(scores)
+        self.assertEqual(scores, scores_backup)
+
+    def test_personal_top_three_doesnt_mutate_scores(self):
+        # make sure personal_top_three doesn't affect/damage our original object
+        scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
+        scores_backup = list(scores)
+        _unused = personal_top_three(scores)
+        self.assertEqual(scores, scores_backup)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
On the exercise 'high-scores', I'd say 80-90% of the people I've mentored on that one mutate 'scores' in one or more of the functions. It's a subtle but easy thing to miss, and it's compounded by two gotchas that can happen at once: the pass-by-reference thing, and the fact that some methods on lists DON'T return a copy, but operate in place.

As is, the tests can pass if someone damages scores by sorting it in place, or even pop()-ing stuff from the list (both stuff I've seen). But I'd say that would be a bad habit to allow. 

Here is a patch that adds tests to make sure that after running all three functions, scores is still the same. This would save lots of mentor time, and might encourage students to find the facts about list methods on their own. I added three tests rather than just one that tested the same 'bug' on all three methods, because it seems that the small units are the convention.