### PR TITLE
Use import with context for generators

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -9,23 +9,26 @@
 {%- endfor %}
 {% endmacro -%}
 
-{% macro properties(exercise, properties) -%}
-from {{ exercise | to_snake }} import {% for prop in properties -%}
-    {{ prop | to_snake }}
-    {%- if not loop.last %}, {% endif -%}
-{% endfor %}
-{% endmacro -%}
-
-{% macro canonical_ref(version) -%}
+{% macro canonical_ref() -%}
 # Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
 {%- endmacro %}
 
-{% macro header(exercise, props, version) -%}
+{% macro header(imports=[], ignore=[]) -%}
 import unittest
 
-{{ properties(exercise, props) }}
+from {{ exercise | to_snake }} import ({% if imports -%}
+{% for name in imports -%}
+    {{ name }},
+{% endfor %}
+{%- else -%}
+{% for prop in properties -%}
+    {%- if prop not in ignore -%}
+    {{ prop | to_snake }},
+    {%- endif -%}
+{% endfor %}
+{%- endif %})
 
-{{ canonical_ref(version) }}
+{{ canonical_ref() }}
 {%- endmacro %}
 
 {% macro utility() -%}# Utility functions

--- a/exercises/acronym/.meta/template.j2
+++ b/exercises/acronym/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +7,7 @@
             "{{ case["expected"] }}"
         )
 {%- endmacro %}
-{{ macros.header(exercise, properties, version)}}
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}{% for case in supercase["cases"] -%}
@@ -15,4 +15,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endfor %}{% endfor %}
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/acronym/acronym_test.py
+++ b/exercises/acronym/acronym_test.py
@@ -2,7 +2,6 @@ import unittest
 
 from acronym import abbreviate
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.0
 
 

--- a/exercises/clock/.meta/template.j2
+++ b/exercises/clock/.meta/template.j2
@@ -1,12 +1,8 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro clock(obj) -%}
 Clock({{ obj["hour"] }}, {{ obj["minute"] }})
 {%- endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import Clock
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header(["Clock"])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases -%}
@@ -32,4 +28,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endfor %}
     {%- endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/grade-school/.meta/template.j2
+++ b/exercises/grade-school/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_case( case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -13,15 +13,11 @@
         self.assertEqual(school.{{ case["property"] | to_snake }}(), expected)
         {%- endif %}
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import School
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header(["School"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}
     {{ test_case(case) }}
     {% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/hamming/.meta/template.j2
+++ b/exercises/hamming/.meta/template.j2
@@ -1,16 +1,12 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_call(case) %}
-            {{ exercise | to_snake }}.{{ case["property"] }}(
+            {{ case["property"] }}(
                 {% for arg in case["input"].values() -%}
                 "{{ arg }}",
                 {% endfor %}
             )
 {% endmacro -%}
-import unittest
-
-import {{ exercise | to_snake }}
-
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -28,6 +24,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 
     {{ macros.utility() }}
 
-
-if __name__ == '__main__':
-    unittest.main()
+{{ macros.footer() }}

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -1,41 +1,41 @@
 import unittest
 
-import hamming
+from hamming import distance
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v2.3.0
 
 
 class HammingTest(unittest.TestCase):
     def test_empty_strands(self):
-        self.assertEqual(hamming.distance("", ""), 0)
+        self.assertEqual(distance("", ""), 0)
 
     def test_single_letter_identical_strands(self):
-        self.assertEqual(hamming.distance("A", "A"), 0)
+        self.assertEqual(distance("A", "A"), 0)
 
     def test_single_letter_different_strands(self):
-        self.assertEqual(hamming.distance("G", "T"), 1)
+        self.assertEqual(distance("G", "T"), 1)
 
     def test_long_identical_strands(self):
-        self.assertEqual(hamming.distance("GGACTGAAATCTG", "GGACTGAAATCTG"), 0)
+        self.assertEqual(distance("GGACTGAAATCTG", "GGACTGAAATCTG"), 0)
 
     def test_long_different_strands(self):
-        self.assertEqual(hamming.distance("GGACGGATTCTG", "AGGACGGATTCT"), 9)
+        self.assertEqual(distance("GGACGGATTCTG", "AGGACGGATTCT"), 9)
 
     def test_disallow_first_strand_longer(self):
         with self.assertRaisesWithMessage(ValueError):
-            hamming.distance("AATG", "AAA")
+            distance("AATG", "AAA")
 
     def test_disallow_second_strand_longer(self):
         with self.assertRaisesWithMessage(ValueError):
-            hamming.distance("ATA", "AGTG")
+            distance("ATA", "AGTG")
 
     def test_disallow_left_empty_strand(self):
         with self.assertRaisesWithMessage(ValueError):
-            hamming.distance("", "G")
+            distance("", "G")
 
     def test_disallow_right_empty_strand(self):
         with self.assertRaisesWithMessage(ValueError):
-            hamming.distance("G", "")
+            distance("G", "")
 
     # Utility functions
     def setUp(self):

--- a/exercises/hello-world/.meta/template.j2
+++ b/exercises/hello-world/.meta/template.j2
@@ -1,15 +1,10 @@
-import unittest
-
-import {{ exercise | to_snake }}
-
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{ exercise | to_snake }}.{{ case["property"] }}(), "{{ case["expected"] }}")
+        self.assertEqual({{ case["property"] }}(), "{{ case["expected"] }}")
     {% endfor %}
 
-
-if __name__ == '__main__':
-    unittest.main()
+{{ macros.footer() }}

--- a/exercises/hello-world/hello_world_test.py
+++ b/exercises/hello-world/hello_world_test.py
@@ -1,13 +1,13 @@
 import unittest
 
-import hello_world
+from hello_world import hello
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 
 class HelloWorldTest(unittest.TestCase):
     def test_say_hi(self):
-        self.assertEqual(hello_world.hello(), "Hello, World!")
+        self.assertEqual(hello(), "Hello, World!")
 
 
 if __name__ == "__main__":

--- a/exercises/high-scores/.meta/template.j2
+++ b/exercises/high-scores/.meta/template.j2
@@ -1,20 +1,11 @@
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro testcase(case) %}
     def test_{{ case["description"] | to_snake }}(self):
         scores = {{ case["input"]["scores"] }}
         expected = {{ case["expected"] }}
         self.assertEqual({{ case["property"] | to_snake }}(scores), expected)
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import (
-    {%- for prop in properties %}
-    {%- if prop != "scores" %}
-    {{ prop | to_snake }},
-    {% endif -%}
-    {%- endfor %}
-)
-
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+{{ macros.header(ignore=["scores"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- for case in cases -%}

--- a/exercises/isogram/.meta/template.j2
+++ b/exercises/isogram/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_call(case) %}
             {{ case["property"] | to_snake }}(
                 {% for arg in case["input"].values() -%}
@@ -6,13 +6,7 @@
                 {% endfor %}
             )
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import {% for prop in properties -%}
-    {{ prop | to_snake }}{% if not loop.last %}, {% endif -%}
-{% endfor %}
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {# All test cases in this exercise are nested, so use two for loops -#}
@@ -24,6 +18,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         )
     {% endfor %}{% endfor %}
 
-
-if __name__ == '__main__':
-    unittest.main()
+{{ macros.footer() }}

--- a/exercises/kindergarten-garden/.meta/template.j2
+++ b/exercises/kindergarten-garden/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_case(group_name, case) -%}
     {%- set input = case["input"] -%}
     def test_{{ group_name | to_snake }}_
@@ -17,11 +17,7 @@
             {% endfor %}]
         )
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import Garden
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header(["Garden"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases %}
@@ -49,4 +45,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/luhn/.meta/template.j2
+++ b/exercises/luhn/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_case(group_name, case) -%}
     {%- set input = case["input"] -%}
     def test_{{ group_name | to_snake }}_
@@ -17,11 +17,7 @@
             {% endfor %}]
         )
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import Luhn
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header(["Luhn"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}
@@ -46,4 +42,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         self.assertIs(number.valid(), True)
         self.assertIs(number.valid(), True)
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/matrix/.meta/template.j2
+++ b/exercises/matrix/.meta/template.j2
@@ -1,13 +1,10 @@
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro testcase(case) %}
     def test_{{ case["description"] | to_snake }}(self):
-        {{ exercise | to_snake }} = {{ exercise | camel_case }}("{{ case["input"]["string"] | replace('\n', '\\n') }}")
-        self.assertEqual({{ exercise | to_snake }}.{{ case["property"] | to_snake }}({{ case["input"]["index"]}} ), {{ case["expected"] }})
+        matrix = Matrix("{{ case["input"]["string"] | replace('\n', '\\n') }}")
+        self.assertEqual(matrix.{{ case["property"] | to_snake }}({{ case["input"]["index"]}} ), {{ case["expected"] }})
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import {{ exercise | camel_case }}
-
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+{{ macros.header(["Matrix"])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- for case in cases -%}

--- a/exercises/raindrops/.meta/template.j2
+++ b/exercises/raindrops/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {%- macro test_call(case) %}
             {{ case["property"] | to_snake }}(
                 {% for arg in case["input"].values() -%}
@@ -6,13 +6,7 @@
                 {% endfor %}
             )
 {% endmacro -%}
-import unittest
-
-from {{ exercise | to_snake }} import {% for prop in properties -%}
-    {{ prop | to_snake }}{% if not loop.last %}, {% endif -%}
-{% endfor %}
-
-{{ macros.canonical_ref(version) }}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -23,6 +17,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         )
     {% endfor %}
 
-
-if __name__ == '__main__':
-    unittest.main()
+{{ macros.footer() }}

--- a/exercises/scrabble-score/.meta/template.j2
+++ b/exercises/scrabble-score/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +7,7 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header(exercise, properties, version)}}
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -15,4 +15,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endfor %}
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/scrabble-score/scrabble_score_test.py
+++ b/exercises/scrabble-score/scrabble_score_test.py
@@ -2,7 +2,6 @@ import unittest
 
 from scrabble_score import score
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
 

--- a/exercises/twelve-days/.meta/template.j2
+++ b/exercises/twelve-days/.meta/template.j2
@@ -1,5 +1,5 @@
-{%- import "generator_macros.j2" as macros -%}
-{{ macros.header(exercise, properties, version) }}
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {# All test cases in this exercise are nested, so use two for loops -#}
@@ -20,4 +20,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
             {{- input["endVerse"] }}), expected)
     {% endfor %}{% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/twelve-days/twelve_days_test.py
+++ b/exercises/twelve-days/twelve_days_test.py
@@ -2,7 +2,6 @@ import unittest
 
 from twelve_days import recite
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
 

--- a/exercises/two-fer/.meta/template.j2
+++ b/exercises/two-fer/.meta/template.j2
@@ -1,8 +1,5 @@
-import unittest
-
-from {{ exercise | to_snake }} import {{ exercise | to_snake }}
-
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -14,6 +11,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {% endif %}
     {% endfor %}
 
-
-if __name__ == "__main__":
-    unittest.main()
+{{ macros.footer() }}

--- a/exercises/word-count/.meta/template.j2
+++ b/exercises/word-count/.meta/template.j2
@@ -1,4 +1,4 @@
-{%- import "generator_macros.j2" as macros -%}
+{%- import "generator_macros.j2" as macros with context -%}
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +7,7 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header(exercise, properties, version)}}
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -23,4 +23,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- endif %}
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -2,7 +2,6 @@ import unittest
 
 from word_count import count_words
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
 
 


### PR DESCRIPTION
Import macros with context allows standard header/footer macros to access variables from the exercise spec so they do not need to be provided as arguments, simplifying test templates significantly.