### PR TITLE
Add template status script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
       python: 3.7
       install:
         - pip install requests
+        - pip install -r requirements-generator.txt
         - git clone https://github.com/exercism/problem-specifications spec
       before_script: []
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ matrix:
         - git clone https://github.com/exercism/problem-specifications spec
       before_script: []
       script:
-        - ./bin/check-test-version.py -v -p spec
-        - ./bin/template_status.py -v -p spec
+        - echo "Test Version Status" && ./bin/check-test-version.py -p spec
+        - echo "Test Template Status" && ./bin/template_status.py -v -p spec
   allow_failures:
     - python: nightly
     - env: JOB=CANONICAL_SYNC

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ matrix:
         - pip install requests
         - git clone https://github.com/exercism/problem-specifications spec
       before_script: []
-      script: ./bin/check-test-version.py -v -p spec
+      script:
+        - ./bin/check-test-version.py -v -p spec
+        - ./bin/template_status.py -v -p spec
   allow_failures:
     - python: nightly
     - env: JOB=CANONICAL_SYNC

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -44,7 +44,7 @@ def exec_cmd(cmd, verbose=False):
 
 
 def generate_template(exercise, spec_path):
-    return exec_cmd(f'bin/generate_tests.py --verbose -p "{spec_path}" {exercise}')
+    return exec_cmd(f'bin/generate_tests.py --verbose --spec-path "{spec_path}" {exercise}')
 
 
 def run_tests(exercise):
@@ -89,6 +89,7 @@ if __name__ == "__main__":
     if not os.path.isdir(opts.spec_path):
         logger.error(f'{opts.spec_path} is not a directory')
         sys.exit(1)
+    opts.spec_path = os.path.abspath(opts.spec_path)
     logger.debug(f'problem-specifications path is {opts.spec_path}')
 
     result = True

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -52,7 +52,7 @@ def generate_template(exercise, spec_path):
 
 
 def run_tests(exercise):
-    script = os.path.abspath("bin/test/check-exercises.py")
+    script = os.path.abspath("test/check-exercises.py")
     return exec_cmd(f"{script} {exercise}")
 
 

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import shlex
-from subprocess import check_call, DEVNULL, CalledProcessError
+from subprocess import check_output, STDOUT, CalledProcessError
 import sys
 
 DEFAULT_SPEC_LOCATION = os.path.join("..", "problem-specifications")
@@ -33,9 +33,10 @@ def get_template_path(exercise):
     return os.path.join(exercises_dir, exercise, ".meta", "template.j2")
 
 
-def exec_cmd(cmd):
+def exec_cmd(cmd, verbose=False):
     try:
-        check_call(shlex.split(cmd), stdout=DEVNULL, stderr=DEVNULL)
+        out = check_output(shlex.split(cmd), stderr=STDOUT)
+        logger.debug(out.decode())
         return True
     except CalledProcessError:
         return False

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -39,6 +39,7 @@ def exec_cmd(cmd, verbose=False):
         logger.debug(out.decode())
         return True
     except CalledProcessError as e:
+        logger.debug(out.decode())
         logger.debug(str(e))
         return False
 

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import shlex
-from subprocess import check_output, STDOUT, CalledProcessError
+from subprocess import check_call, DEVNULL, CalledProcessError
 import sys
 
 DEFAULT_SPEC_LOCATION = os.path.join("..", "problem-specifications")
@@ -35,11 +35,13 @@ def get_template_path(exercise):
 
 def exec_cmd(cmd, verbose=False):
     try:
-        out = check_output(shlex.split(cmd), stderr=STDOUT)
-        logger.debug(out.decode())
+        args = shlex.split(cmd)
+        if verbose:
+            check_call(args)
+        else:
+            check_call(args, stderr=DEVNULL, stdout=DEVNULL)
         return True
     except CalledProcessError as e:
-        logger.debug(out.decode())
         logger.debug(str(e))
         return False
 

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -38,7 +38,8 @@ def exec_cmd(cmd, verbose=False):
         out = check_output(shlex.split(cmd), stderr=STDOUT)
         logger.debug(out.decode())
         return True
-    except CalledProcessError:
+    except CalledProcessError as e:
+        logger.debug(str(e))
         return False
 
 
@@ -88,6 +89,7 @@ if __name__ == "__main__":
     if not os.path.isdir(opts.spec_path):
         logger.error(f'{opts.spec_path} is not a directory')
         sys.exit(1)
+    logger.debug(f'problem-specifications path is {opts.spec_path}')
 
     result = True
     for exercise in filter(

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -85,6 +85,10 @@ if __name__ == "__main__":
     elif opts.verbose:
         logger.setLevel(logging.DEBUG)
 
+    if not os.path.isdir(opts.spec_path):
+        logger.error(f'{opts.spec_path} is not a directory')
+        sys.exit(1)
+
     result = True
     for exercise in filter(
         lambda e: fnmatch(e["slug"], opts.exercise_pattern), config["exercises"]

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3.7
+import argparse
+from enum import Enum, auto
+from fnmatch import fnmatch
+import json
+import logging
+import os
+import shlex
+from subprocess import check_call, DEVNULL, CalledProcessError
+import sys
+
+logging.basicConfig(format="%(levelname)s:%(message)s")
+logger = logging.getLogger("generator")
+logger.setLevel(logging.WARN)
+
+
+class TemplateStatus(Enum):
+    OK = auto()
+    MISSING = auto()
+    INVALID = auto()
+    TEST_FAILURE = auto()
+
+
+with open("config.json") as f:
+    config = json.load(f)
+
+exercises_dir = os.path.abspath("exercises")
+
+
+def get_template_path(exercise):
+    return os.path.join(exercises_dir, exercise, ".meta", "template.j2")
+
+
+def exec_cmd(cmd):
+    try:
+        check_call(shlex.split(cmd), stdout=DEVNULL, stderr=DEVNULL)
+        return True
+    except CalledProcessError:
+        return False
+
+
+def generate_template(exercise, spec_path="../problem-specifications"):
+    return exec_cmd(f'bin/generate_tests.py -p "{spec_path}" {exercise}')
+
+
+def run_tests(exercise):
+    return exec_cmd(f"test/check-exercises.py {exercise}")
+
+
+def get_status(exercise):
+    template_path = get_template_path(exercise)
+    if os.path.isfile(template_path):
+        if generate_template(exercise):
+            if run_tests(exercise):
+                logging.info(f"{exercise}: OK")
+                return TemplateStatus.OK
+            else:
+                return TemplateStatus.TEST_FAILURE
+        else:
+            return TemplateStatus.INVALID
+    else:
+        return TemplateStatus.MISSING
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("exercise_pattern", nargs="?", default="*", metavar="EXERCISE")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-q", "--quiet", action="store_true")
+    parser.add_argument("--stop-on-failure", action="store_true")
+    opts = parser.parse_args()
+    if opts.quiet:
+        logger.setLevel(logging.FATAL)
+    elif opts.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    result = True
+    for exercise in filter(
+        lambda e: fnmatch(e["slug"], opts.exercise_pattern), config["exercises"]
+    ):
+        slug = exercise["slug"]
+        status = get_status(slug)
+        if status != TemplateStatus.OK:
+            result = False
+            logger.error(f"{slug}: {status.name}")
+            if opts.stop_on_failure:
+                break
+        else:
+            logger.info(f"{slug}: {status.name}")
+
+    if not result:
+        sys.exit(1)

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -44,7 +44,7 @@ def exec_cmd(cmd, verbose=False):
 
 
 def generate_template(exercise, spec_path):
-    return exec_cmd(f'bin/generate_tests.py -p "{spec_path}" {exercise}')
+    return exec_cmd(f'bin/generate_tests.py --verbose -p "{spec_path}" {exercise}')
 
 
 def run_tests(exercise):

--- a/bin/template_status.py
+++ b/bin/template_status.py
@@ -47,11 +47,13 @@ def exec_cmd(cmd, verbose=False):
 
 
 def generate_template(exercise, spec_path):
-    return exec_cmd(f'bin/generate_tests.py --verbose --spec-path "{spec_path}" {exercise}')
+    script = os.path.abspath("bin/generate_tests.py")
+    return exec_cmd(f'{script} --verbose --spec-path "{spec_path}" {exercise}')
 
 
 def run_tests(exercise):
-    return exec_cmd(f"test/check-exercises.py {exercise}")
+    script = os.path.abspath("bin/test/check-exercises.py")
+    return exec_cmd(f"{script} {exercise}")
 
 
 def get_status(exercise, spec_path):
@@ -90,10 +92,10 @@ if __name__ == "__main__":
         logger.setLevel(logging.DEBUG)
 
     if not os.path.isdir(opts.spec_path):
-        logger.error(f'{opts.spec_path} is not a directory')
+        logger.error(f"{opts.spec_path} is not a directory")
         sys.exit(1)
     opts.spec_path = os.path.abspath(opts.spec_path)
-    logger.debug(f'problem-specifications path is {opts.spec_path}')
+    logger.debug(f"problem-specifications path is {opts.spec_path}")
 
     result = True
     for exercise in filter(


### PR DESCRIPTION
`template_status.py` will check each exercise and report the following states:
- Template not found
- Template contains syntax error
- Template creates tests that are either invalid Python code or do not pass with the current example solution

Running this script in the CANONICAL_SYNC job will provide a reference for which exercises are still missing templates.