### PR TITLE
Add test for all numeric name

### DIFF
--- a/exercises/two-fer/two_fer_test.py
+++ b/exercises/two-fer/two_fer_test.py
@@ -15,6 +15,9 @@ class TwoFerTest(unittest.TestCase):
     def test_another_name_given(self):
         self.assertEqual(two_fer("Bob"), "One for Bob, one for me.")
 
+    def test_numeric_name_given(self):
+        self.assertEqual(two_fer(7), "One for 7, one for me.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some student solutions are using string concatenation instead of a string formatting. Their solutions raise a TypeError when an integer is entered.

This test is designed to push students toward a more Pythonic/safer solution.

