### PR TITLE
Resolved Issue #1915

### DIFF
--- a/exercises/etl/.meta/template.j2
+++ b/exercises/etl/.meta/template.j2
@@ -3,7 +3,7 @@
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
         legacy_data =  { {% for key, value in case["input"]["legacy"].items() %}
-                            {{key}}: {{value}}{{ "," if not loop.last else "" }}{% endfor %} }
+                            {{key}}: {{value}},{% endfor %} }
         data = {{case["expected"]}}
         self.assertEqual(
             {{ case["property"] | to_snake }}(legacy_data), data

--- a/exercises/etl/.meta/template.j2
+++ b/exercises/etl/.meta/template.j2
@@ -3,8 +3,7 @@
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
         legacy_data =  { {% for key, value in case["input"]["legacy"].items() %}
-                             {{key}}: {{value}}, 
-                        {% endfor %} }
+                            {{key}}: {{value}}{{ "," if not loop.last else "" }}{% endfor %} }
         data = {{case["expected"]}}
         self.assertEqual(
             {{ case["property"] | to_snake }}(legacy_data), data

--- a/exercises/etl/.meta/template.j2
+++ b/exercises/etl/.meta/template.j2
@@ -1,0 +1,21 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{% macro test_case(case) -%}
+    {%- set input = case["input"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        legacy_data =  { {% for key, value in case["input"]["legacy"].items() %}
+                             {{key}}: {{value}}, 
+                        {% endfor %} }
+        data = {{case["expected"]}}
+        self.assertEqual(
+            {{ case["property"] | to_snake }}(legacy_data), data
+        )
+{%- endmacro %}
+{{ macros.header()}}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for supercase in cases %}{% for case in supercase["cases"] -%}
+    {{ test_case(case) }}
+    {% endfor %}{% endfor %}
+
+
+{{ macros.footer() }}

--- a/exercises/etl/etl_test.py
+++ b/exercises/etl/etl_test.py
@@ -2,12 +2,14 @@ import unittest
 
 from etl import transform
 
+# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.1
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v2.0.0
 
 class EtlTest(unittest.TestCase):
-    def test_a_single_letter(self):
-        self.assertEqual(transform({1: ['A']}), {'a': 1})
+    def test_single_letter(self):
+        legacy_data = {1: ["A"]}
+        data = {"a": 1}
+        self.assertEqual(transform(legacy_data), data)
 
     def test_single_score_with_multiple_letters(self):
         legacy_data = {1: ["A", "E", "I", "O", "U"]}
@@ -27,17 +29,38 @@ class EtlTest(unittest.TestCase):
             4: ["F", "H", "V", "W", "Y"],
             5: ["K"],
             8: ["J", "X"],
-            10: ["Q", "Z"]
+            10: ["Q", "Z"],
         }
         data = {
-            "a": 1, "b": 3, "c": 3, "d": 2, "e": 1, "f": 4,
-            "g": 2, "h": 4, "i": 1, "j": 8, "k": 5, "l": 1,
-            "m": 3, "n": 1, "o": 1, "p": 3, "q": 10, "r": 1,
-            "s": 1, "t": 1, "u": 1, "v": 4, "w": 4, "x": 8,
-            "y": 4, "z": 10
+            "a": 1,
+            "b": 3,
+            "c": 3,
+            "d": 2,
+            "e": 1,
+            "f": 4,
+            "g": 2,
+            "h": 4,
+            "i": 1,
+            "j": 8,
+            "k": 5,
+            "l": 1,
+            "m": 3,
+            "n": 1,
+            "o": 1,
+            "p": 3,
+            "q": 10,
+            "r": 1,
+            "s": 1,
+            "t": 1,
+            "u": 1,
+            "v": 4,
+            "w": 4,
+            "x": 8,
+            "y": 4,
+            "z": 10,
         }
         self.assertEqual(transform(legacy_data), data)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently, there are two minor issues with the generated test file which appear to be with the black auto formatter:
1- Dictionary entries are ALWAYS on separate lines, which makes them less easy to read when dealing with small entries. Like [here](https://github.com/exercism/python/compare/master...alirezaghey:issue-%231915?expand=1#diff-6162c6d7d91d9dc13cbdf39e188b596fR35)
2- These very same entries have a redundant comma after their last entry. Like [here](https://github.com/exercism/python/compare/master...alirezaghey:issue-%231915?expand=1#diff-6162c6d7d91d9dc13cbdf39e188b596fR60)

**edit**:
Resolved #1915 