### PR TITLE
high-scores: Fix invalid topic name

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,7 +51,7 @@
       "difficulty": 1,
       "topics": [
         "classes",
-        "control_flow_if_else_statements",
+        "conditionals",
         "sequences",
         "text_formatting"
       ]


### PR DESCRIPTION
As per [this link](https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt), `control_flow_if_else_statements` is not a valid topic, but `conditionals` is.