### PR TITLE
Armstrong numbers add test template

### DIFF
--- a/exercises/armstrong-numbers/.meta/template.j2
+++ b/exercises/armstrong-numbers/.meta/template.j2
@@ -4,7 +4,7 @@
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual(
+        self.assertIs(
             {{ case["property"] | to_snake }}({{ case["input"]["number"] }}),
             {{ case["expected"] }}
         )

--- a/exercises/armstrong-numbers/.meta/template.j2
+++ b/exercises/armstrong-numbers/.meta/template.j2
@@ -1,0 +1,13 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header()}}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        input = case["input"]["number"]
+        expected = case["expected"]
+        self.assertEqual({{ case["property"] | to_snake }}(input), expected)
+    {% endfor %}
+
+
+{{ macros.footer() }}

--- a/exercises/armstrong-numbers/.meta/template.j2
+++ b/exercises/armstrong-numbers/.meta/template.j2
@@ -4,9 +4,10 @@
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        input = {{ case["input"]["number"] }}
-        expected = {{ case["expected"] }}
-        self.assertEqual({{ case["property"] | to_snake }}(input), expected)
+        self.assertEqual(
+            {{ case["property"] | to_snake }}({{ case["input"]["number"] }}),
+            {{ case["expected"] }}
+        )
 
     {% endfor %}
 

--- a/exercises/armstrong-numbers/.meta/template.j2
+++ b/exercises/armstrong-numbers/.meta/template.j2
@@ -1,11 +1,11 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header()}}
+{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        input = case["input"]["number"]
-        expected = case["expected"]
+        input = {{ case["input"]["number"] }}
+        expected = {{ case["expected"] }}
         self.assertEqual({{ case["property"] | to_snake }}(input), expected)
     {% endfor %}
 

--- a/exercises/armstrong-numbers/.meta/template.j2
+++ b/exercises/armstrong-numbers/.meta/template.j2
@@ -7,7 +7,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         input = {{ case["input"]["number"] }}
         expected = {{ case["expected"] }}
         self.assertEqual({{ case["property"] | to_snake }}(input), expected)
-    {% endfor %}
 
+    {% endfor %}
 
 {{ macros.footer() }}

--- a/exercises/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.py
@@ -7,49 +7,31 @@ from armstrong_numbers import is_armstrong_number
 
 class ArmstrongNumbersTest(unittest.TestCase):
     def test_zero_is_an_armstrong_number(self):
-        input = 0
-        expected = True
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(0), True)
 
     def test_single_digit_numbers_are_armstrong_numbers(self):
-        input = 5
-        expected = True
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(5), True)
 
     def test_there_are_no_2_digit_armstrong_numbers(self):
-        input = 10
-        expected = False
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(10), False)
 
     def test_three_digit_number_that_is_an_armstrong_number(self):
-        input = 153
-        expected = True
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(153), True)
 
     def test_three_digit_number_that_is_not_an_armstrong_number(self):
-        input = 100
-        expected = False
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(100), False)
 
     def test_four_digit_number_that_is_an_armstrong_number(self):
-        input = 9474
-        expected = True
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(9474), True)
 
     def test_four_digit_number_that_is_not_an_armstrong_number(self):
-        input = 9475
-        expected = False
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(9475), False)
 
     def test_seven_digit_number_that_is_an_armstrong_number(self):
-        input = 9926315
-        expected = True
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(9926315), True)
 
     def test_seven_digit_number_that_is_not_an_armstrong_number(self):
-        input = 9926314
-        expected = False
-        self.assertEqual(is_armstrong_number(input), expected)
+        self.assertEqual(is_armstrong_number(9926314), False)
 
 
 if __name__ == "__main__":

--- a/exercises/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.py
@@ -2,38 +2,55 @@ import unittest
 
 from armstrong_numbers import is_armstrong_number
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
-class ArmstrongNumbersTest(unittest.TestCase):
 
+class ArmstrongNumbersTest(unittest.TestCase):
     def test_zero_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(0), True)
+        input = 0
+        expected = True
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_single_digit_numbers_are_armstrong_numbers(self):
-        self.assertIs(is_armstrong_number(5), True)
+        input = 5
+        expected = True
+        self.assertEqual(is_armstrong_number(input), expected)
 
-    def test_there_are_no_two_digit_armstrong_numbers(self):
-        self.assertIs(is_armstrong_number(10), False)
+    def test_there_are_no_2_digit_armstrong_numbers(self):
+        input = 10
+        expected = False
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_three_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(153), True)
+        input = 153
+        expected = True
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_three_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(100), False)
+        input = 100
+        expected = False
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_four_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(9474), True)
+        input = 9474
+        expected = True
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_four_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(9475), False)
+        input = 9475
+        expected = False
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_seven_digit_number_that_is_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(9926315), True)
+        input = 9926315
+        expected = True
+        self.assertEqual(is_armstrong_number(input), expected)
 
     def test_seven_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertIs(is_armstrong_number(9926314), False)
+        input = 9926314
+        expected = False
+        self.assertEqual(is_armstrong_number(input), expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.py
@@ -7,31 +7,31 @@ from armstrong_numbers import is_armstrong_number
 
 class ArmstrongNumbersTest(unittest.TestCase):
     def test_zero_is_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(0), True)
+        self.assertIs(is_armstrong_number(0), True)
 
     def test_single_digit_numbers_are_armstrong_numbers(self):
-        self.assertEqual(is_armstrong_number(5), True)
+        self.assertIs(is_armstrong_number(5), True)
 
     def test_there_are_no_2_digit_armstrong_numbers(self):
-        self.assertEqual(is_armstrong_number(10), False)
+        self.assertIs(is_armstrong_number(10), False)
 
     def test_three_digit_number_that_is_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(153), True)
+        self.assertIs(is_armstrong_number(153), True)
 
     def test_three_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(100), False)
+        self.assertIs(is_armstrong_number(100), False)
 
     def test_four_digit_number_that_is_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(9474), True)
+        self.assertIs(is_armstrong_number(9474), True)
 
     def test_four_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(9475), False)
+        self.assertIs(is_armstrong_number(9475), False)
 
     def test_seven_digit_number_that_is_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(9926315), True)
+        self.assertIs(is_armstrong_number(9926315), True)
 
     def test_seven_digit_number_that_is_not_an_armstrong_number(self):
-        self.assertEqual(is_armstrong_number(9926314), False)
+        self.assertIs(is_armstrong_number(9926314), False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a template for armstrong numbers #1927 

However I'm having an issue generating the tests. The generator script doesn't find the template. 
Running `bin/generate_tests.py -v armstrong-numbers` gives me the following console output
`DEBUG:generator:armstrong-numbers\.meta\template.j2`
`INFO:generator:armstrong-numbers: no template found; skipping`
