### PR TITLE
Update template path formatting

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -17,6 +17,7 @@ import filecmp
 import json
 import logging
 import os
+import posixpath
 import re
 import shutil
 import sys
@@ -149,7 +150,7 @@ def generate_exercise(env, spec_path, exercise, check=False):
         spec = load_canonical(slug, spec_path)
         additional_tests = load_additional_tests(slug)
         spec["additional_cases"] = additional_tests
-        template_path = os.path.join(slug, '.meta', 'template.j2')
+        template_path = posixpath.join(slug, '.meta', 'template.j2')
         template = env.get_template(template_path)
         tests_path = os.path.join(
             exercise, f'{to_snake(slug)}_test.py'


### PR DESCRIPTION
Allows for template creation in a Windows environment.

The Jijna environment/loader expects forward slashes for the path used to find a template. In a Windows environment `os.path.join` produces a string with backslashes. We can use `posixpath.join` instead to make sure that the template path is always created with forward slashes.