### PR TITLE
space-age: add test template

### DIFF
--- a/exercises/space-age/.meta/additional_tests.json
+++ b/exercises/space-age/.meta/additional_tests.json
@@ -1,0 +1,12 @@
+{
+  "cases": [
+    {
+      "description": "age in seconds",
+      "property": "SpaceAge",
+      "input": {
+        "seconds": "1e6"
+      },
+      "expected": "1e6"
+    }
+  ]
+}

--- a/exercises/space-age/.meta/template.j2
+++ b/exercises/space-age/.meta/template.j2
@@ -1,0 +1,23 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header(["SpaceAge"]) }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {%- set seconds = case["input"]["seconds"] %}
+        {%- set planet = case["input"]["planet"] %}
+        self.assertEqual(SpaceAge({{ seconds }}).on_{{ planet | lower }}(), {{ case["expected"] }})
+
+    {% endfor %}
+    {% if additional_cases | length -%}
+
+    # Additional tests for this track
+
+    {% for case in additional_cases -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {%- set seconds = case["input"]["seconds"] %}
+        self.assertEqual(SpaceAge({{ seconds }}).seconds, {{  case["expected"]}})
+    {% endfor %}
+    {%- endif %}
+
+{{ macros.footer() }}

--- a/exercises/space-age/space_age_test.py
+++ b/exercises/space-age/space_age_test.py
@@ -2,19 +2,18 @@ import unittest
 
 from space_age import SpaceAge
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
+
 class SpaceAgeTest(unittest.TestCase):
+    def test_age_on_earth(self):
+        self.assertEqual(SpaceAge(1000000000).on_earth(), 31.69)
 
     def test_age_on_mercury(self):
         self.assertEqual(SpaceAge(2134835688).on_mercury(), 280.88)
 
     def test_age_on_venus(self):
         self.assertEqual(SpaceAge(189839836).on_venus(), 9.78)
-
-    def test_age_on_earth(self):
-        self.assertEqual(SpaceAge(1000000000).on_earth(), 31.69)
 
     def test_age_on_mars(self):
         self.assertEqual(SpaceAge(2129871239).on_mars(), 35.88)
@@ -37,5 +36,5 @@ class SpaceAgeTest(unittest.TestCase):
         self.assertEqual(SpaceAge(1e6).seconds, 1e6)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1993 

A few things I wanted to check on:

- [ ] Is it correct to hard-code 'SpaceAge' since the canonical-data uses 'age' as the property?
- [ ] Is it correct to the method calls that are not listed in the canonical data. i.e. `.on_[planet]` and `.seconds`?
