### PR TITLE
rotational-cipher: Add test template.

### DIFF
--- a/exercises/rotational-cipher/.meta/template.j2
+++ b/exercises/rotational-cipher/.meta/template.j2
@@ -1,0 +1,16 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for supercase in cases %}
+        {% for case in supercase["cases"] -%}
+        def test_{{ case["description"] | to_snake }}(self):
+            {%- set text = case["input"]["text"] %}
+            {%- set shiftKey = case["input"]["shiftKey"] %}
+            {%- set expected = case["expected"] %}
+            self.assertEqual({{ case["property"] }}("{{ text }}", {{ shiftKey }}), "{{ expected }}")
+            
+        {% endfor %}
+    {% endfor %}
+
+{{ macros.footer() }}

--- a/exercises/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/rotational-cipher/rotational_cipher_test.py
@@ -1,48 +1,44 @@
 import unittest
 
-import rotational_cipher
-
+from rotational_cipher import rotate
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
+
 class RotationalCipherTest(unittest.TestCase):
-    def test_rotate_a_by_0(self):
-        self.assertEqual(rotational_cipher.rotate('a', 0), 'a')
+    def test_rotate_a_by_0_same_output_as_input(self):
+        self.assertEqual(rotate("a", 0), "a")
 
     def test_rotate_a_by_1(self):
-        self.assertEqual(rotational_cipher.rotate('a', 1), 'b')
+        self.assertEqual(rotate("a", 1), "b")
 
-    def test_rotate_a_by_26(self):
-        self.assertEqual(rotational_cipher.rotate('a', 26), 'a')
+    def test_rotate_a_by_26_same_output_as_input(self):
+        self.assertEqual(rotate("a", 26), "a")
 
     def test_rotate_m_by_13(self):
-        self.assertEqual(rotational_cipher.rotate('m', 13), 'z')
+        self.assertEqual(rotate("m", 13), "z")
 
     def test_rotate_n_by_13_with_wrap_around_alphabet(self):
-        self.assertEqual(rotational_cipher.rotate('n', 13), 'a')
+        self.assertEqual(rotate("n", 13), "a")
 
     def test_rotate_capital_letters(self):
-        self.assertEqual(rotational_cipher.rotate('OMG', 5), 'TRL')
+        self.assertEqual(rotate("OMG", 5), "TRL")
 
     def test_rotate_spaces(self):
-        self.assertEqual(rotational_cipher.rotate('O M G', 5), 'T R L')
+        self.assertEqual(rotate("O M G", 5), "T R L")
 
     def test_rotate_numbers(self):
-        self.assertEqual(
-            rotational_cipher.rotate('Testing 1 2 3 testing', 4),
-            'Xiwxmrk 1 2 3 xiwxmrk')
+        self.assertEqual(rotate("Testing 1 2 3 testing", 4), "Xiwxmrk 1 2 3 xiwxmrk")
 
     def test_rotate_punctuation(self):
-        self.assertEqual(
-            rotational_cipher.rotate("Let's eat, Grandma!", 21),
-            "Gzo'n zvo, Bmviyhv!")
+        self.assertEqual(rotate("Let's eat, Grandma!", 21), "Gzo'n zvo, Bmviyhv!")
 
     def test_rotate_all_letters(self):
         self.assertEqual(
-            rotational_cipher.rotate("The quick brown fox jumps"
-                                     " over the lazy dog.", 13),
-            "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")
+            rotate("The quick brown fox jumps over the lazy dog.", 13),
+            "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1982.

Sorry about the seemingly large number of changes. I've changed the `'` to `"` everywhere for consistency since otherwise there was a single case which used an apostrophe in the text, so only that had double quotes. 