### PR TITLE
Add exercise name to the header comment

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -10,7 +10,7 @@
 {% endmacro -%}
 
 {% macro canonical_ref() -%}
-# Tests adapted from `problem-specifications//canonical-data.json` @ v{{ version }}
+# Tests adapted from `problem-specifications//{{exercise}}//canonical-data.json` @ v{{ version }}
 {%- endmacro %}
 
 {% macro header(imports=[], ignore=[]) -%}


### PR DESCRIPTION
This small change will add exercise name to the generated comment in header:
Before:
```python
# Tests adapted from `problem-specifications//canonical-data.json` @ v3.2.0
```

After:
```python
# Tests adapted from `problem-specifications//robot-simulator//canonical-data.json` @ v3.2.0
```
