### PR TITLE
run-length-encoding: add test template

### DIFF
--- a/exercises/run-length-encoding/.meta/template.j2
+++ b/exercises/run-length-encoding/.meta/template.j2
@@ -1,0 +1,36 @@
+{%- import "generator_macros.j2" as macros with context -%}
+
+{% macro test_case(case, tmod) -%}
+    {%- set input = case["input"] -%}
+    def test_{{ tmod }}{{ case["description"] | to_snake }}(self):
+        self.assertMultiLineEqual(
+            {% if case["property"] == "consistency" -%}
+            decode(encode("{{ ', '.join(input.values()) }}")),
+            {% else -%}
+            {{ case["property"] | to_snake }}("{{ ', '.join(input.values()) }}"),
+            {% endif -%}
+            "{{ case["expected"] }}"
+        )
+{%- endmacro %}
+
+{{ macros.header(['encode','decode'])}}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for supercase in cases -%}
+    
+    {%- set title_modifier = "" -%}
+    {%- if "encode" in supercase["description"] -%}
+    {%- set title_modifier = "encode_" -%}
+    {%- endif -%}
+    {%- if "decode" in supercase["description"] -%}
+    {% if title_modifier -%}{% set title_modifier = "" -%}{% else -%}
+    {%- set title_modifier = "decode_" -%}{% endif -%}{# if both encode and decode, no modifier #}
+    {%- endif -%}
+
+    {% for case in supercase["cases"] -%}
+    {{ test_case(case, title_modifier) }}
+    {% endfor %}
+    {% endfor %}
+
+
+{{ macros.footer() }}

--- a/exercises/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/run-length-encoding/run_length_encoding_test.py
@@ -2,53 +2,55 @@ import unittest
 
 from run_length_encoding import encode, decode
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
+
 
 class RunLengthEncodingTest(unittest.TestCase):
     def test_encode_empty_string(self):
-        self.assertMultiLineEqual(encode(''), '')
+        self.assertMultiLineEqual(encode(""), "")
 
     def test_encode_single_characters_only_are_encoded_without_count(self):
-        self.assertMultiLineEqual(encode('XYZ'), 'XYZ')
+        self.assertMultiLineEqual(encode("XYZ"), "XYZ")
 
     def test_encode_string_with_no_single_characters(self):
-        self.assertMultiLineEqual(encode('AABBBCCCC'), '2A3B4C')
+        self.assertMultiLineEqual(encode("AABBBCCCC"), "2A3B4C")
 
     def test_encode_single_characters_mixed_with_repeated_characters(self):
         self.assertMultiLineEqual(
-            encode('WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'),
-            '12WB12W3B24WB')
+            encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"),
+            "12WB12W3B24WB",
+        )
 
     def test_encode_multiple_whitespace_mixed_in_string(self):
-        self.assertMultiLineEqual(encode('  hsqq qww  '), '2 hs2q q2w2 ')
+        self.assertMultiLineEqual(encode("  hsqq qww  "), "2 hs2q q2w2 ")
 
     def test_encode_lowercase_characters(self):
-        self.assertMultiLineEqual(encode('aabbbcccc'), '2a3b4c')
+        self.assertMultiLineEqual(encode("aabbbcccc"), "2a3b4c")
 
     def test_decode_empty_string(self):
-        self.assertMultiLineEqual(decode(''), '')
+        self.assertMultiLineEqual(decode(""), "")
 
     def test_decode_single_characters_only(self):
-        self.assertMultiLineEqual(decode('XYZ'), 'XYZ')
+        self.assertMultiLineEqual(decode("XYZ"), "XYZ")
 
     def test_decode_string_with_no_single_characters(self):
-        self.assertMultiLineEqual(decode('2A3B4C'), 'AABBBCCCC')
+        self.assertMultiLineEqual(decode("2A3B4C"), "AABBBCCCC")
 
     def test_decode_single_characters_with_repeated_characters(self):
         self.assertMultiLineEqual(
-            decode('12WB12W3B24WB'),
-            'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB')
+            decode("12WB12W3B24WB"),
+            "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB",
+        )
 
     def test_decode_multiple_whitespace_mixed_in_string(self):
-        self.assertMultiLineEqual(decode('2 hs2q q2w2 '), '  hsqq qww  ')
+        self.assertMultiLineEqual(decode("2 hs2q q2w2 "), "  hsqq qww  ")
 
     def test_decode_lower_case_string(self):
-        self.assertMultiLineEqual(decode('2a3b4c'), 'aabbbcccc')
+        self.assertMultiLineEqual(decode("2a3b4c"), "aabbbcccc")
 
-    def test_combination(self):
-        self.assertMultiLineEqual(decode(encode('zzz ZZ  zZ')), 'zzz ZZ  zZ')
+    def test_encode_followed_by_decode_gives_original_string(self):
+        self.assertMultiLineEqual(decode(encode("zzz ZZ  zZ")), "zzz ZZ  zZ")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1983 

I put in a little logic to modify the names of the test functions with either "encode" or "decode" in order to match the original test file. Would it be better to keep this and better match the original or to keep the template code more simple?