### PR TITLE
nth-prime: add template

### DIFF
--- a/exercises/nth-prime/.meta/additional_tests.json
+++ b/exercises/nth-prime/.meta/additional_tests.json
@@ -1,0 +1,13 @@
+{
+  "cases": [
+    {
+      "description": "first twenty primes",
+      "property": "primeRange",
+      "input": {
+        "number": 20
+      },
+      "expected": [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31,
+                   37, 41, 43, 47, 53, 59, 61, 67, 71]
+    }
+  ]
+}

--- a/exercises/nth-prime/.meta/template.j2
+++ b/exercises/nth-prime/.meta/template.j2
@@ -1,0 +1,35 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{% macro test_case(case) -%}
+    {%- set input = case["input"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {% if case is error_case -%}
+          with self.assertRaisesWithMessage(ValueError):
+                {{ case["property"] | to_snake }}({{ input["number"] }})
+        {% else -%}
+          self.assertEqual(
+                {{ case["property"] | to_snake }}({{ input["number"] }}),
+                {{ case["expected"] }}
+            )
+        {%- endif %}
+{%- endmacro %}
+{{ macros.header()}}
+
+def prime_range(n):
+    """Returns a list of the first n primes"""
+    return [prime(i) for i in range(1, n + 1)]
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}       
+    {{ test_case(case) }}
+    {% endfor %}
+    {% if additional_cases | length -%}
+
+    # Additional tests for this track
+
+    {% for case in additional_cases -%}
+    {{ test_case(case) }}
+    {% endfor %}
+    {%- endif %}
+
+
+{{ macros.footer(has_error_case) }}

--- a/exercises/nth-prime/nth_prime_test.py
+++ b/exercises/nth-prime/nth_prime_test.py
@@ -2,8 +2,13 @@ import unittest
 
 from nth_prime import prime
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v2.1.0
+
+
+def prime_range(n):
+    """Returns a list of the first n primes"""
+    return [prime(i) for i in range(1, n + 1)]
+
 
 class NthPrimeTest(unittest.TestCase):
     def test_first_prime(self):
@@ -22,11 +27,34 @@ class NthPrimeTest(unittest.TestCase):
         with self.assertRaisesWithMessage(ValueError):
             prime(0)
 
-    # additional track specific test
+    # Additional tests for this track
+
     def test_first_twenty_primes(self):
-        self.assertEqual([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31,
-                          37, 41, 43, 47, 53, 59, 61, 67, 71],
-                         [prime(n) for n in range(1, 21)])
+        self.assertEqual(
+            prime_range(20),
+            [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19,
+                23,
+                29,
+                31,
+                37,
+                41,
+                43,
+                47,
+                53,
+                59,
+                61,
+                67,
+                71,
+            ],
+        )
 
     # Utility functions
     def setUp(self):
@@ -39,5 +67,5 @@ class NthPrimeTest(unittest.TestCase):
         return self.assertRaisesRegex(exception, r".+")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add meta template and additional_tests.json to generate nth-prime test file including all tests currently contained in the nth_prime_test.py file. test_case macro is split conditionally to handle error cases, single number cases and ranges of primes. Closes: #1962 