### PR TITLE
grains: add test template

### DIFF
--- a/exercises/grains/.meta/template.j2
+++ b/exercises/grains/.meta/template.j2
@@ -1,0 +1,28 @@
+{%- import "generator_macros.j2" as macros with context -%}
+
+{% macro test_case(case) %}
+    {%- set input = case["input"] %}
+    def test_{{ case["description"] | to_snake }}(self):
+    {%- if case is error_case %}
+          with self.assertRaisesWithMessage(ValueError):
+                {{ case["property"] | to_snake }}({{ input["square"] }})
+    {%- else%}
+          self.assertEqual({{ case["property"] | to_snake }}(
+            {{ input["square"] }}), {{ case["expected"] }})
+    {% endif %}
+{%- endmacro %}
+
+{{ macros.header()}}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+        {%- if "cases" in case -%} 
+        {% for subcase in case['cases'] -%}      
+        {{ test_case(subcase) }}
+        {% endfor %}
+        {%-else%}
+        {{test_case(case)}}
+        {%-endif%}
+    {% endfor %}
+
+{{ macros.footer(has_error_case) }}

--- a/exercises/grains/example.py
+++ b/exercises/grains/example.py
@@ -1,19 +1,13 @@
 def square(number):
-    check_square_input(number)
-
-    return 2 ** (number - 1)
-
-
-def total(number):
-    check_square_input(number)
-
-    return sum(square(n + 1) for n in range(number))
-
-
-def check_square_input(number):
     if number == 0:
         raise ValueError("Square input of zero is invalid.")
     elif number < 0:
         raise ValueError("Negative square input is invalid.")
     elif number > 64:
         raise ValueError("Square input greater than 64 is invalid.")
+
+    return 2 ** (number - 1)
+
+
+def total():
+    return (2 ** 64) - 1

--- a/exercises/grains/grains.py
+++ b/exercises/grains/grains.py
@@ -2,5 +2,5 @@ def square(number):
     pass
 
 
-def total(number):
+def total():
     pass

--- a/exercises/grains/grains_test.py
+++ b/exercises/grains/grains_test.py
@@ -2,51 +2,45 @@ import unittest
 
 from grains import square, total
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 
+
 class GrainsTest(unittest.TestCase):
-    def test_square_1(self):
+    def test_1(self):
         self.assertEqual(square(1), 1)
 
-    def test_square_2(self):
+    def test_2(self):
         self.assertEqual(square(2), 2)
 
-    def test_square_3(self):
+    def test_3(self):
         self.assertEqual(square(3), 4)
 
-    def test_square_4(self):
+    def test_4(self):
         self.assertEqual(square(4), 8)
 
-    def test_square_16(self):
+    def test_16(self):
         self.assertEqual(square(16), 32768)
 
-    def test_square_32(self):
+    def test_32(self):
         self.assertEqual(square(32), 2147483648)
 
-    def test_square_64(self):
+    def test_64(self):
         self.assertEqual(square(64), 9223372036854775808)
 
-    def test_square_0_raises_exception(self):
+    def test_square_0_raises_an_exception(self):
         with self.assertRaisesWithMessage(ValueError):
             square(0)
-        with self.assertRaisesWithMessage(ValueError):
-            total(0)
 
-    def test_square_negative_raises_exception(self):
+    def test_negative_square_raises_an_exception(self):
         with self.assertRaisesWithMessage(ValueError):
             square(-1)
-        with self.assertRaisesWithMessage(ValueError):
-            total(-1)
 
-    def test_square_gt_64_raises_exception(self):
+    def test_square_greater_than_64_raises_an_exception(self):
         with self.assertRaisesWithMessage(ValueError):
             square(65)
-        with self.assertRaisesWithMessage(ValueError):
-            total(65)
 
-    def test_total(self):
-        self.assertEqual(total(64), 18446744073709551615)
+    def test_returns_the_total_number_of_grains_on_the_board(self):
+        self.assertEqual(total(), 18446744073709551615)
 
     # Utility functions
     def setUp(self):
@@ -59,5 +53,5 @@ class GrainsTest(unittest.TestCase):
         return self.assertRaisesRegex(exception, r".+")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add test template for grains which adds all square() tests and the method to generate the only existing total() test. Closes #1952.