### PR TITLE
rational-numbers add template

### DIFF
--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -5,7 +5,8 @@
     "sub": "-",
     "mul": "*",
     "div": "/",
-    "exprational": "**"
+    "exprational": "**",
+    "expreal": "**"
 } -%}
 
 {% macro test_case_arithmetic(case) -%}
@@ -38,6 +39,24 @@
         self.assertEqual({{left}} {{operator}} {{right}}, {{expected}})
 {%- endmacro %}
 
+{% macro test_case_exponentiation_real(case) -%}
+    {%- set x = case["input"]["x"] -%}
+    {%- set r = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set expected = case["expected"] -%}
+    {%- set operator = operators[case["property"]] -%}
+
+    def test_{{ case["description"] | to_snake }}(self):
+        self.assertEqual({{x}} {{operator}} {{r}}, {{expected}})
+{%- endmacro %}
+
+{% macro test_case_reduction(case) -%}
+    {%- set r = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
+
+    def test_{{ case["description"] | to_snake }}(self):
+        self.assertEqual({{r}}, {{expected}})
+{%- endmacro %}
+
 {{ macros.header(imports=["Rational"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
@@ -56,6 +75,10 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case_absolutevalue(case) }}
                 {% elif mathtypescases["description"] == 'Exponentiation of a rational number' %}
     {{ test_case_exponentiation(case) }}
+                {% elif mathtypescases["description"] == 'Exponentiation of a real number to a rational number' %}
+    {{ test_case_exponentiation_real(case) }}
+                {% elif mathtypescases["description"] == 'Reduction to lowest terms' %}
+    {{ test_case_reduction(case) }}
                 {% endif %}
             {% endfor %}
         {% endif %}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -44,7 +44,7 @@
     {%- set operator = operators[case["property"]] -%}
 
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{x}} {{operator}} {{r}}, {{expected}})
+        self.assertAlmostEqual({{x}} {{operator}} {{r}}, {{expected}}, places=8)
 {%- endmacro %}
 
 {% macro test_case_reduction(case) -%}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -82,6 +82,7 @@
 
 {%- endmacro %}
 
+from __future__ import division
 {{ macros.header(imports=["Rational"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -19,7 +19,7 @@
         pass
 {%- endmacro %}
 
-{{ macros.header() }}
+{{ macros.header(imports=["Rational"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for mathtypescases in cases %}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -1,9 +1,22 @@
 {%- import "generator_macros.j2" as macros with context -%}
 
+{%- set operators = {
+    "add": "+",
+    "sub": "-",
+    "mul": "*",
+    "div": "/"
+} -%}
 
 {% macro test_case_arithmetic(case) -%}
+    {%- set input = case["input"] -%}
+    {%- set expected = case["expected"] -%}
+    {%- set left = "Rational({}, {})".format(input["r1"][0], input["r1"][1]) -%}
+    {%- set right = "Rational({}, {})".format(input["r2"][0], input["r2"][1]) -%}
+    {%- set expected = "Rational({}, {})".format(expected[0], expected[1]) -%}
+    {%- set operator = operators[case["property"]] -%}
+
     def test_{{ case["description"] | to_snake }}(self):
-        pass
+        self.assertEqual({{left}} {{operator}} {{right}}, {{expected}})
 {%- endmacro %}
 
 {% macro test_case_absolutevalue(case) -%}
@@ -24,17 +37,21 @@
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for mathtypescases in cases %}
     # Tests of type: {{ mathtypescases["description"] }}
-        {% for mathoperationcases in mathtypescases["cases"] %}
+        {% if mathtypescases["description"] == 'Arithmetic' %}
+            {% for mathoperationcases in mathtypescases["cases"] %}
     # {{ mathoperationcases["description"] }}
-            {% for case in mathoperationcases["cases"] %}
-                {% if mathtypescases["description"] == 'Arithmetic' %}
+                {% for case in mathoperationcases["cases"] %}
     {{ test_case_arithmetic(case) }}
-                {% elif mathtypescases["description"] == 'Absolute value' %}
+                {% endfor %}
+            {% endfor %}
+        {% else %}
+            {% for case in mathtypescases["cases"] %}
+                {% if mathtypescases["description"] == 'Absolute value' %}
     {{ test_case_absolutevalue(case) }}
                 {% elif mathtypescases["description"] == 'Exponentiation of a rational number' %}
     {{ test_case_exponentiation(case) }}
                 {% endif %}
             {% endfor %}
-        {% endfor %}
+        {% endif %}
     {% endfor %}
 {{ macros.footer() }}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -10,33 +10,31 @@
 } -%}
 
 {% macro test_case_arithmetic(case) -%}
-    {%- set input = case["input"] -%}
-    {%- set expected = case["expected"] -%}
-    {%- set left = "Rational({}, {})".format(input["r1"][0], input["r1"][1]) -%}
-    {%- set right = "Rational({}, {})".format(input["r2"][0], input["r2"][1]) -%}
-    {%- set expected = "Rational({}, {})".format(expected[0], expected[1]) -%}
+    {%- set r1 = "Rational({}, {})".format(case["input"]["r1"][0], case["input"]["r1"][1]) -%}
+    {%- set r2 = "Rational({}, {})".format(case["input"]["r2"][0], case["input"]["r2"][1]) -%}
+    {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
     {%- set operator = operators[case["property"]] -%}
 
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{left}} {{operator}} {{right}}, {{expected}})
+        self.assertEqual({{r1}} {{operator}} {{r2}}, {{expected}})
 {%- endmacro %}
 
 {% macro test_case_absolutevalue(case) -%}
-    {%- set left = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set r = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
     {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
     {%- set method = case["property"] -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{method}}({{left}}), {{expected}})
+        self.assertEqual({{method}}({{r}}), {{expected}})
 {%- endmacro %}
 
 {% macro test_case_exponentiation(case) -%}
-    {%- set left = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
-    {%- set right = case["input"]["n"] -%}
+    {%- set r = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set n = case["input"]["n"] -%}
     {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
     {%- set operator = operators[case["property"]] -%}
 
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{left}} {{operator}} {{right}}, {{expected}})
+        self.assertEqual({{r}} {{operator}} {{n}}, {{expected}})
 {%- endmacro %}
 
 {% macro test_case_exponentiation_real(case) -%}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -20,9 +20,11 @@
 {%- endmacro %}
 
 {% macro test_case_absolutevalue(case) -%}
+    {%- set left = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
+    {%- set method = case["property"] -%}
     def test_{{ case["description"] | to_snake }}(self):
-        # yyy
-        pass
+        self.assertEqual({{method}}({{left}}), {{expected}})
 {%- endmacro %}
 
 {% macro test_case_exponentiation(case) -%}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -55,30 +55,42 @@
         self.assertEqual({{r}}, {{expected}})
 {%- endmacro %}
 
+{% macro render_arithmetic_cases(mathtypescases) -%}
+
+    {% for mathoperationcases in mathtypescases["cases"] %}
+    # {{ mathoperationcases["description"] }}
+        {% for case in mathoperationcases["cases"] %}
+    {{ test_case_arithmetic(case) }}
+        {% endfor %}
+    {% endfor %}
+
+{%- endmacro %}
+
+{% macro render_other_cases(mathtypescases) -%}
+
+    {% for case in mathtypescases["cases"] %}
+        {% if mathtypescases["description"] == 'Absolute value' %}
+    {{ test_case_absolutevalue(case) }}
+        {% elif mathtypescases["description"] == 'Exponentiation of a rational number' %}
+    {{ test_case_exponentiation(case) }}
+        {% elif mathtypescases["description"] == 'Exponentiation of a real number to a rational number' %}
+    {{ test_case_exponentiation_real(case) }}
+        {% elif mathtypescases["description"] == 'Reduction to lowest terms' %}
+    {{ test_case_reduction(case) }}
+        {% endif %}
+    {% endfor %}
+
+{%- endmacro %}
+
 {{ macros.header(imports=["Rational"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for mathtypescases in cases %}
     # Tests of type: {{ mathtypescases["description"] }}
         {% if mathtypescases["description"] == 'Arithmetic' %}
-            {% for mathoperationcases in mathtypescases["cases"] %}
-    # {{ mathoperationcases["description"] }}
-                {% for case in mathoperationcases["cases"] %}
-    {{ test_case_arithmetic(case) }}
-                {% endfor %}
-            {% endfor %}
+            {{ render_arithmetic_cases(mathtypescases) }}
         {% else %}
-            {% for case in mathtypescases["cases"] %}
-                {% if mathtypescases["description"] == 'Absolute value' %}
-    {{ test_case_absolutevalue(case) }}
-                {% elif mathtypescases["description"] == 'Exponentiation of a rational number' %}
-    {{ test_case_exponentiation(case) }}
-                {% elif mathtypescases["description"] == 'Exponentiation of a real number to a rational number' %}
-    {{ test_case_exponentiation_real(case) }}
-                {% elif mathtypescases["description"] == 'Reduction to lowest terms' %}
-    {{ test_case_reduction(case) }}
-                {% endif %}
-            {% endfor %}
+            {{ render_other_cases(mathtypescases) }}
         {% endif %}
     {% endfor %}
 {{ macros.footer() }}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -4,7 +4,8 @@
     "add": "+",
     "sub": "-",
     "mul": "*",
-    "div": "/"
+    "div": "/",
+    "exprational": "**"
 } -%}
 
 {% macro test_case_arithmetic(case) -%}
@@ -28,10 +29,13 @@
 {%- endmacro %}
 
 {% macro test_case_exponentiation(case) -%}
-    {%- set input = case["input"] -%}
+    {%- set left = "Rational({}, {})".format(case["input"]["r"][0], case["input"]["r"][1]) -%}
+    {%- set right = case["input"]["n"] -%}
+    {%- set expected = "Rational({}, {})".format(case["expected"][0], case["expected"][1]) -%}
+    {%- set operator = operators[case["property"]] -%}
+
     def test_{{ case["description"] | to_snake }}(self):
-        # xxx
-        pass
+        self.assertEqual({{left}} {{operator}} {{right}}, {{expected}})
 {%- endmacro %}
 
 {{ macros.header(imports=["Rational"]) }}

--- a/exercises/rational-numbers/.meta/template.j2
+++ b/exercises/rational-numbers/.meta/template.j2
@@ -1,0 +1,40 @@
+{%- import "generator_macros.j2" as macros with context -%}
+
+
+{% macro test_case_arithmetic(case) -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        pass
+{%- endmacro %}
+
+{% macro test_case_absolutevalue(case) -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        # yyy
+        pass
+{%- endmacro %}
+
+{% macro test_case_exponentiation(case) -%}
+    {%- set input = case["input"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        # xxx
+        pass
+{%- endmacro %}
+
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for mathtypescases in cases %}
+    # Tests of type: {{ mathtypescases["description"] }}
+        {% for mathoperationcases in mathtypescases["cases"] %}
+    # {{ mathoperationcases["description"] }}
+            {% for case in mathoperationcases["cases"] %}
+                {% if mathtypescases["description"] == 'Arithmetic' %}
+    {{ test_case_arithmetic(case) }}
+                {% elif mathtypescases["description"] == 'Absolute value' %}
+    {{ test_case_absolutevalue(case) }}
+                {% elif mathtypescases["description"] == 'Exponentiation of a rational number' %}
+    {{ test_case_exponentiation(case) }}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endfor %}
+{{ macros.footer() }}

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import unittest
 
 from rational_numbers import Rational

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -74,28 +74,23 @@ class RationalNumbersTest(unittest.TestCase):
     # Tests of type: Absolute value
 
     def test_absolute_value_of_a_positive_rational_number(self):
-        # yyy
-        pass
+        self.assertEqual(abs(Rational(1, 2)), Rational(1, 2))
 
     def test_absolute_value_of_a_positive_rational_number_with_negative_numerator_and_denominator(
         self
     ):
-        # yyy
-        pass
+        self.assertEqual(abs(Rational(-1, -2)), Rational(1, 2))
 
     def test_absolute_value_of_a_negative_rational_number(self):
-        # yyy
-        pass
+        self.assertEqual(abs(Rational(-1, 2)), Rational(1, 2))
 
     def test_absolute_value_of_a_negative_rational_number_with_negative_denominator(
         self
     ):
-        # yyy
-        pass
+        self.assertEqual(abs(Rational(1, -2)), Rational(1, 2))
 
     def test_absolute_value_of_zero(self):
-        # yyy
-        pass
+        self.assertEqual(abs(Rational(0, 1)), Rational(0, 1))
 
     # Tests of type: Exponentiation of a rational number
 

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -1,138 +1,124 @@
-from __future__ import division
-
 import unittest
 
-from rational_numbers import Rational
-
+from rational_numbers import abs, add, div, exprational, expreal, mul, reduce, sub
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
+
 class RationalNumbersTest(unittest.TestCase):
 
-    # Test addition
-    def test_add_two_positive(self):
-        self.assertEqual(Rational(1, 2) + Rational(2, 3), Rational(7, 6))
+    # Tests of type: Arithmetic
 
-    def test_add_positive_and_negative(self):
-        self.assertEqual(Rational(1, 2) + Rational(-2, 3), Rational(-1, 6))
+    # Addition
 
-    def test_add_two_negative(self):
-        self.assertEqual(Rational(-1, 2) + Rational(-2, 3), Rational(-7, 6))
+    def test_add_two_positive_rational_numbers(self):
+        pass
 
-    def test_add_opposite(self):
-        self.assertEqual(Rational(1, 2) + Rational(-1, 2), Rational(0, 1))
+    def test_add_a_positive_rational_number_and_a_negative_rational_number(self):
+        pass
 
-    # Test subtraction
-    def test_subtract_two_positive(self):
-        self.assertEqual(Rational(1, 2) - Rational(2, 3), Rational(-1, 6))
+    def test_add_two_negative_rational_numbers(self):
+        pass
 
-    def test_subtract_positive_and_negative(self):
-        self.assertEqual(Rational(1, 2) - Rational(-2, 3), Rational(7, 6))
+    def test_add_a_rational_number_to_its_additive_inverse(self):
+        pass
 
-    def test_subtract_two_negative(self):
-        self.assertEqual(Rational(-1, 2) - Rational(-2, 3), Rational(1, 6))
+    # Subtraction
 
-    def test_subtract_from_self(self):
-        self.assertEqual(Rational(1, 2) - Rational(1, 2), Rational(0, 1))
+    def test_subtract_two_positive_rational_numbers(self):
+        pass
 
-    # Test multiplication
-    def test_multiply_two_positive(self):
-        self.assertEqual(Rational(1, 2) * Rational(2, 3), Rational(1, 3))
+    def test_subtract_a_positive_rational_number_and_a_negative_rational_number(self):
+        pass
 
-    def test_multiply_negative_by_positive(self):
-        self.assertEqual(Rational(-1, 2) * Rational(2, 3), Rational(-1, 3))
+    def test_subtract_two_negative_rational_numbers(self):
+        pass
 
-    def test_multiply_two_negative(self):
-        self.assertEqual(Rational(-1, 2) * Rational(-2, 3), Rational(1, 3))
+    def test_subtract_a_rational_number_from_itself(self):
+        pass
 
-    def test_multiply_reciprocal(self):
-        self.assertEqual(Rational(1, 2) * Rational(2, 1), Rational(1, 1))
+    # Multiplication
 
-    def test_multiply_by_one(self):
-        self.assertEqual(Rational(1, 2) * Rational(1, 1), Rational(1, 2))
+    def test_multiply_two_positive_rational_numbers(self):
+        pass
 
-    def test_multiply_by_zero(self):
-        self.assertEqual(Rational(1, 2) * Rational(0, 1), Rational(0, 1))
+    def test_multiply_a_negative_rational_number_by_a_positive_rational_number(self):
+        pass
 
-    # Test division
-    def test_divide_two_positive(self):
-        self.assertEqual(Rational(1, 2) / Rational(2, 3), Rational(3, 4))
+    def test_multiply_two_negative_rational_numbers(self):
+        pass
 
-    def test_divide_positive_by_negative(self):
-        self.assertEqual(Rational(1, 2) / Rational(-2, 3), Rational(-3, 4))
+    def test_multiply_a_rational_number_by_its_reciprocal(self):
+        pass
 
-    def test_divide_two_negative(self):
-        self.assertEqual(Rational(-1, 2) / Rational(-2, 3), Rational(3, 4))
+    def test_multiply_a_rational_number_by_1(self):
+        pass
 
-    def test_divide_by_one(self):
-        self.assertEqual(Rational(1, 2) / Rational(1, 1), Rational(1, 2))
+    def test_multiply_a_rational_number_by_0(self):
+        pass
 
-    # Test absolute value
-    def test_absolute_value_of_positive(self):
-        self.assertEqual(abs(Rational(1, 2)), Rational(1, 2))
+    # Division
 
-    def test_absolute_value_of_positive_negative_numerator_denominator(self):
-        self.assertEqual(abs(Rational(-1, -2)), Rational(1, 2))
+    def test_divide_two_positive_rational_numbers(self):
+        pass
 
-    def test_absolute_value_of_negative(self):
-        self.assertEqual(abs(Rational(-1, 2)), Rational(1, 2))
+    def test_divide_a_positive_rational_number_by_a_negative_rational_number(self):
+        pass
 
-    def test_absolute_value_of_negative_with_negative_denominator(self):
-        self.assertEqual(abs(Rational(1, -2)), Rational(1, 2))
+    def test_divide_two_negative_rational_numbers(self):
+        pass
 
-    def test_absolute_value_of_zero(self):
-        self.assertEqual(abs(Rational(0, 1)), Rational(0, 1))
+    def test_divide_a_rational_number_by_1(self):
+        pass
 
-    # Test exponentiation of a rational number
-    def test_raise_a_positive_rational_to_a_positive_integer_power(self):
-        self.assertEqual(Rational(1, 2) ** 3, Rational(1, 8))
+    # Tests of type: Absolute value
 
-    def test_raise_a_negative_rational_to_a_positive_integer_power(self):
-        self.assertEqual(Rational(-1, 2) ** 3, Rational(-1, 8))
+    # Absolute value of a positive rational number
 
-    def test_raise_zero_to_an_integer_power(self):
-        self.assertEqual(Rational(0, 1) ** 5, Rational(0, 1))
+    # Absolute value of a positive rational number with negative numerator and denominator
 
-    def test_raise_one_to_an_integer_power(self):
-        self.assertEqual(Rational(1, 1) ** 4, Rational(1, 1))
+    # Absolute value of a negative rational number
 
-    def test_raise_a_positive_rational_to_the_power_of_zero(self):
-        self.assertEqual(Rational(1, 2) ** 0, Rational(1, 1))
+    # Absolute value of a negative rational number with negative denominator
 
-    def test_raise_a_negative_rational_to_the_power_of_zero(self):
-        self.assertEqual(Rational(-1, 2) ** 0, Rational(1, 1))
+    # Absolute value of zero
 
-    # Test exponentiation of a real number to a rational number
-    def test_raise_a_real_number_to_a_positive_rational(self):
-        self.assertAlmostEqual(8 ** Rational(4, 3), 16.0, places=8)
+    # Tests of type: Exponentiation of a rational number
 
-    def test_raise_a_real_number_to_a_negative_rational(self):
-        self.assertAlmostEqual(
-            9 ** Rational(-1, 2), 0.3333333333333333, places=8
-        )
+    # Raise a positive rational number to a positive integer power
 
-    def test_raise_a_real_number_to_a_zero_rational(self):
-        self.assertAlmostEqual(2 ** Rational(0, 1), 1.0, places=8)
+    # Raise a negative rational number to a positive integer power
 
-    # Test reduction to lowest terms
-    def test_reduce_positive(self):
-        self.assertEqual(Rational(2, 4), Rational(1, 2))
+    # Raise zero to an integer power
 
-    def test_reduce_negative(self):
-        self.assertEqual(Rational(-4, 6), Rational(-2, 3))
+    # Raise one to an integer power
 
-    def test_reduce_rational_with_negative_denominator(self):
-        self.assertEqual(Rational(3, -9), Rational(-1, 3))
+    # Raise a positive rational number to the power of zero
 
-    def test_reduce_zero(self):
-        self.assertEqual(Rational(0, 6), Rational(0, 1))
+    # Raise a negative rational number to the power of zero
 
-    def test_reduce_integer(self):
-        self.assertEqual(Rational(-14, 7), Rational(-2, 1))
+    # Tests of type: Exponentiation of a real number to a rational number
 
-    def test_reduce_one(self):
-        self.assertEqual(Rational(13, 13), Rational(1, 1))
+    # Raise a real number to a positive rational number
+
+    # Raise a real number to a negative rational number
+
+    # Raise a real number to a zero rational number
+
+    # Tests of type: Reduction to lowest terms
+
+    # Reduce a positive rational number to lowest terms
+
+    # Reduce a negative rational number to lowest terms
+
+    # Reduce a rational number with a negative denominator to lowest terms
+
+    # Reduce zero to lowest terms
+
+    # Reduce an integer to lowest terms
+
+    # Reduce one to lowest terms
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -114,7 +114,34 @@ class RationalNumbersTest(unittest.TestCase):
 
     # Tests of type: Exponentiation of a real number to a rational number
 
+    def test_raise_a_real_number_to_a_positive_rational_number(self):
+        self.assertEqual(8 ** Rational(4, 3), 16.0)
+
+    def test_raise_a_real_number_to_a_negative_rational_number(self):
+        self.assertEqual(9 ** Rational(-1, 2), 0.3333333333333333)
+
+    def test_raise_a_real_number_to_a_zero_rational_number(self):
+        self.assertEqual(2 ** Rational(0, 1), 1.0)
+
     # Tests of type: Reduction to lowest terms
+
+    def test_reduce_a_positive_rational_number_to_lowest_terms(self):
+        self.assertEqual(Rational(2, 4), Rational(1, 2))
+
+    def test_reduce_a_negative_rational_number_to_lowest_terms(self):
+        self.assertEqual(Rational(-4, 6), Rational(-2, 3))
+
+    def test_reduce_a_rational_number_with_a_negative_denominator_to_lowest_terms(self):
+        self.assertEqual(Rational(3, -9), Rational(-1, 3))
+
+    def test_reduce_zero_to_lowest_terms(self):
+        self.assertEqual(Rational(0, 6), Rational(0, 1))
+
+    def test_reduce_an_integer_to_lowest_terms(self):
+        self.assertEqual(Rational(-14, 7), Rational(-2, 1))
+
+    def test_reduce_one_to_lowest_terms(self):
+        self.assertEqual(Rational(13, 13), Rational(1, 1))
 
 
 if __name__ == "__main__":

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -115,13 +115,13 @@ class RationalNumbersTest(unittest.TestCase):
     # Tests of type: Exponentiation of a real number to a rational number
 
     def test_raise_a_real_number_to_a_positive_rational_number(self):
-        self.assertEqual(8 ** Rational(4, 3), 16.0)
+        self.assertAlmostEqual(8 ** Rational(4, 3), 16.0, places=8)
 
     def test_raise_a_real_number_to_a_negative_rational_number(self):
-        self.assertEqual(9 ** Rational(-1, 2), 0.3333333333333333)
+        self.assertAlmostEqual(9 ** Rational(-1, 2), 0.3333333333333333, places=8)
 
     def test_raise_a_real_number_to_a_zero_rational_number(self):
-        self.assertEqual(2 ** Rational(0, 1), 1.0)
+        self.assertAlmostEqual(2 ** Rational(0, 1), 1.0, places=8)
 
     # Tests of type: Reduction to lowest terms
 

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -95,28 +95,22 @@ class RationalNumbersTest(unittest.TestCase):
     # Tests of type: Exponentiation of a rational number
 
     def test_raise_a_positive_rational_number_to_a_positive_integer_power(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(1, 2) ** 3, Rational(1, 8))
 
     def test_raise_a_negative_rational_number_to_a_positive_integer_power(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(-1, 2) ** 3, Rational(-1, 8))
 
     def test_raise_zero_to_an_integer_power(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(0, 1) ** 5, Rational(0, 1))
 
     def test_raise_one_to_an_integer_power(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(1, 1) ** 4, Rational(1, 1))
 
     def test_raise_a_positive_rational_number_to_the_power_of_zero(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(1, 2) ** 0, Rational(1, 1))
 
     def test_raise_a_negative_rational_number_to_the_power_of_zero(self):
-        # xxx
-        pass
+        self.assertEqual(Rational(-1, 2) ** 0, Rational(1, 1))
 
     # Tests of type: Exponentiation of a real number to a rational number
 

--- a/exercises/rational-numbers/rational_numbers_test.py
+++ b/exercises/rational-numbers/rational_numbers_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rational_numbers import abs, add, div, exprational, expreal, mul, reduce, sub
+from rational_numbers import Rational
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
@@ -12,112 +12,120 @@ class RationalNumbersTest(unittest.TestCase):
     # Addition
 
     def test_add_two_positive_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(1, 2) + Rational(2, 3), Rational(7, 6))
 
     def test_add_a_positive_rational_number_and_a_negative_rational_number(self):
-        pass
+        self.assertEqual(Rational(1, 2) + Rational(-2, 3), Rational(-1, 6))
 
     def test_add_two_negative_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(-1, 2) + Rational(-2, 3), Rational(-7, 6))
 
     def test_add_a_rational_number_to_its_additive_inverse(self):
-        pass
+        self.assertEqual(Rational(1, 2) + Rational(-1, 2), Rational(0, 1))
 
     # Subtraction
 
     def test_subtract_two_positive_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(1, 2) - Rational(2, 3), Rational(-1, 6))
 
     def test_subtract_a_positive_rational_number_and_a_negative_rational_number(self):
-        pass
+        self.assertEqual(Rational(1, 2) - Rational(-2, 3), Rational(7, 6))
 
     def test_subtract_two_negative_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(-1, 2) - Rational(-2, 3), Rational(1, 6))
 
     def test_subtract_a_rational_number_from_itself(self):
-        pass
+        self.assertEqual(Rational(1, 2) - Rational(1, 2), Rational(0, 1))
 
     # Multiplication
 
     def test_multiply_two_positive_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(1, 2) * Rational(2, 3), Rational(1, 3))
 
     def test_multiply_a_negative_rational_number_by_a_positive_rational_number(self):
-        pass
+        self.assertEqual(Rational(-1, 2) * Rational(2, 3), Rational(-1, 3))
 
     def test_multiply_two_negative_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(-1, 2) * Rational(-2, 3), Rational(1, 3))
 
     def test_multiply_a_rational_number_by_its_reciprocal(self):
-        pass
+        self.assertEqual(Rational(1, 2) * Rational(2, 1), Rational(1, 1))
 
     def test_multiply_a_rational_number_by_1(self):
-        pass
+        self.assertEqual(Rational(1, 2) * Rational(1, 1), Rational(1, 2))
 
     def test_multiply_a_rational_number_by_0(self):
-        pass
+        self.assertEqual(Rational(1, 2) * Rational(0, 1), Rational(0, 1))
 
     # Division
 
     def test_divide_two_positive_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(1, 2) / Rational(2, 3), Rational(3, 4))
 
     def test_divide_a_positive_rational_number_by_a_negative_rational_number(self):
-        pass
+        self.assertEqual(Rational(1, 2) / Rational(-2, 3), Rational(-3, 4))
 
     def test_divide_two_negative_rational_numbers(self):
-        pass
+        self.assertEqual(Rational(-1, 2) / Rational(-2, 3), Rational(3, 4))
 
     def test_divide_a_rational_number_by_1(self):
-        pass
+        self.assertEqual(Rational(1, 2) / Rational(1, 1), Rational(1, 2))
 
     # Tests of type: Absolute value
 
-    # Absolute value of a positive rational number
+    def test_absolute_value_of_a_positive_rational_number(self):
+        # yyy
+        pass
 
-    # Absolute value of a positive rational number with negative numerator and denominator
+    def test_absolute_value_of_a_positive_rational_number_with_negative_numerator_and_denominator(
+        self
+    ):
+        # yyy
+        pass
 
-    # Absolute value of a negative rational number
+    def test_absolute_value_of_a_negative_rational_number(self):
+        # yyy
+        pass
 
-    # Absolute value of a negative rational number with negative denominator
+    def test_absolute_value_of_a_negative_rational_number_with_negative_denominator(
+        self
+    ):
+        # yyy
+        pass
 
-    # Absolute value of zero
+    def test_absolute_value_of_zero(self):
+        # yyy
+        pass
 
     # Tests of type: Exponentiation of a rational number
 
-    # Raise a positive rational number to a positive integer power
+    def test_raise_a_positive_rational_number_to_a_positive_integer_power(self):
+        # xxx
+        pass
 
-    # Raise a negative rational number to a positive integer power
+    def test_raise_a_negative_rational_number_to_a_positive_integer_power(self):
+        # xxx
+        pass
 
-    # Raise zero to an integer power
+    def test_raise_zero_to_an_integer_power(self):
+        # xxx
+        pass
 
-    # Raise one to an integer power
+    def test_raise_one_to_an_integer_power(self):
+        # xxx
+        pass
 
-    # Raise a positive rational number to the power of zero
+    def test_raise_a_positive_rational_number_to_the_power_of_zero(self):
+        # xxx
+        pass
 
-    # Raise a negative rational number to the power of zero
+    def test_raise_a_negative_rational_number_to_the_power_of_zero(self):
+        # xxx
+        pass
 
     # Tests of type: Exponentiation of a real number to a rational number
 
-    # Raise a real number to a positive rational number
-
-    # Raise a real number to a negative rational number
-
-    # Raise a real number to a zero rational number
-
     # Tests of type: Reduction to lowest terms
-
-    # Reduce a positive rational number to lowest terms
-
-    # Reduce a negative rational number to lowest terms
-
-    # Reduce a rational number with a negative denominator to lowest terms
-
-    # Reduce zero to lowest terms
-
-    # Reduce an integer to lowest terms
-
-    # Reduce one to lowest terms
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resovles #1975 

I've a problem with template and `if/elif` conditions. Maybe you can help me why `if` conditions only works for 'Arithmetic' description? When you look at `rational_numbers_test.py`: 74 the tests are only rendered for for that group of cases. Other like 'Absolute value' are omitted.