### PR TITLE
Docs and macros improvements

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -42,8 +42,8 @@ from {{ exercise | to_snake }} import ({% if imports -%}
         return self.assertRaisesRegex(exception, r".+")
 {%- endmacro %}
 
-{% macro footer(has_error_case) -%}
-{% if has_error_case %}
+{% macro footer(_has_error_case) -%}
+{% if has_error_case or _has_error_case %}
 {{ utility() }}
 {% endif %}
 if __name__ == '__main__':

--- a/docs/GENERATOR.md
+++ b/docs/GENERATOR.md
@@ -34,6 +34,11 @@ structure for the exercise you're working on, please consult
 error to be thrown (ex: `False`)
 - `additional_cases`: similar structure to `cases`, but is populated from the exercise's `.meta/additional_tests.json` file if one exists (for an example, see `exercises/word-count/.meta/additional_tests.json`)
 
+Additionally, the following template filters are added for convenience:
+- `to_snake`: Converts a string to snake_case (ex: `{{ "CamelCaseString" | to_snake }}` -> `camel_case_string`)
+- `camel_case`: Converts a string to CamelCase (ex: `{{ "snake_case_string" | camel_case }}` -> `SnakeCaseString` )
+- `error_case`: Checks if a test case expects an error to be thrown (ex: `{% for case in cases%}{% if case is error_case}`)
+
 ### Conventions
 
 - General-use macros for highly repeated template structures are defined in `config/generator_macros.j2`.

--- a/docs/GENERATOR.md
+++ b/docs/GENERATOR.md
@@ -38,6 +38,7 @@ Additionally, the following template filters are added for convenience:
 - `to_snake`: Converts a string to snake_case (ex: `{{ "CamelCaseString" | to_snake }}` -> `camel_case_string`)
 - `camel_case`: Converts a string to CamelCase (ex: `{{ "snake_case_string" | camel_case }}` -> `SnakeCaseString` )
 - `error_case`: Checks if a test case expects an error to be thrown (ex: `{% for case in cases%}{% if case is error_case}`)
+- `regex_replace`: Regex string replacement (ex: `{{ "abc123" | regex_replace("\\d", "D") }}` -> `abcDDD`)
 
 ### Conventions
 

--- a/exercises/binary-search/.meta/template.j2
+++ b/exercises/binary-search/.meta/template.j2
@@ -20,4 +20,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- endif %}
     {% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/bowling/.meta/template.j2
+++ b/exercises/bowling/.meta/template.j2
@@ -25,4 +25,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endfor %}
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -47,6 +47,16 @@ class HammingTest(unittest.TestCase):
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
 
+    # Utility functions
+    def setUp(self):
+        try:
+            self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/perfect-numbers/.meta/template.j2
+++ b/exercises/perfect-numbers/.meta/template.j2
@@ -21,4 +21,4 @@ class {{ case["description"] | camel_case }}Test(unittest.TestCase):
     {% endfor %}
 {% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/satellite/.meta/template.j2
+++ b/exercises/satellite/.meta/template.j2
@@ -15,4 +15,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {% endif %}
     {% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/scale-generator/.meta/template.j2
+++ b/exercises/scale-generator/.meta/template.j2
@@ -27,4 +27,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endfor %}
 
 
-{{ macros.footer(True) }}
+{{ macros.footer() }}

--- a/exercises/scale-generator/scale_generator_test.py
+++ b/exercises/scale-generator/scale_generator_test.py
@@ -77,16 +77,6 @@ class ScaleGeneratorTest(unittest.TestCase):
         expected = ["G", "G#", "B", "C#", "D#", "F", "F#"]
         self.assertEqual(Scale("G").interval("mAMMMmm"), expected)
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/series/.meta/template.j2
+++ b/exercises/series/.meta/template.j2
@@ -13,4 +13,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         self.assertEqual({{ case["property"] }}("{{ input["series"] }}", {{ input["sliceLength"] }}), {{ case["expected"] }})
         {% endif %}
     {% endfor %}
-{{ macros.footer(True) }}
+{{ macros.footer() }}

--- a/exercises/sgf-parsing/.meta/template.j2
+++ b/exercises/sgf-parsing/.meta/template.j2
@@ -44,4 +44,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case(case) }}
     {%- endfor -%}
 
-{{ macros.footer(True) }}
+{{ macros.footer() }}

--- a/exercises/variable-length-quantity/.meta/template.j2
+++ b/exercises/variable-length-quantity/.meta/template.j2
@@ -24,4 +24,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 
     {% endfor %}
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}

--- a/exercises/wordy/.meta/template.j2
+++ b/exercises/wordy/.meta/template.j2
@@ -25,4 +25,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- endif %}
 
 
-{{ macros.footer(has_error_case) }}
+{{ macros.footer() }}


### PR DESCRIPTION
- Document built-in generator filters
- For `macros.footer()`, do not require explicit _has_error_case param for footer macro, but still allow it