### PR TITLE
hamming: remove doubled utility methods

### DIFF
--- a/exercises/hamming/.meta/template.j2
+++ b/exercises/hamming/.meta/template.j2
@@ -22,6 +22,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- endif %}
     {% endfor %}
 
-    {{ macros.utility() }}
-
 {{ macros.footer() }}

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -47,16 +47,6 @@ class HammingTest(unittest.TestCase):
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
 
-    # Utility functions
-    def setUp(self):
-        try:
-            self.assertRaisesRegex
-        except AttributeError:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Small fix.
After #2084 change, hamming's test suite has utility methods section rendered twice.