### PR TITLE
generator: Add support for exercise plugins

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -195,7 +195,7 @@ def generate_exercise(env, spec_path, exercise, check=False):
         else:
             shutil.move(tmp.name, tests_path)
             print(f"{slug} generated at {tests_path}")
-    except (TypeError, UndefinedError) as e:
+    except (TypeError, UndefinedError, SyntaxError) as e:
         logger.debug(str(e))
         logger.error(f"{slug}: generation failed")
         return False
@@ -205,10 +205,6 @@ def generate_exercise(env, spec_path, exercise, check=False):
     except FileNotFoundError as e:
         logger.debug(str(e))
         logger.info(f"{slug}: no canonical data found; skipping")
-    except SyntaxError as e:
-        logger.debug(str(e))
-        logger.info(f"{slug}: SyntaxError in {plugins_source}")
-        return False
     return True
 
 

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -150,6 +150,13 @@ def generate_exercise(env, spec_path, exercise, check=False):
     False: saves rendered to tests file
     """
     slug = os.path.basename(exercise)
+    meta_dir = os.path.join(exercise, '.meta')
+    plugins = None
+    if os.path.isfile(os.path.join(meta_dir, 'plugins.py')):
+        import sys
+        sys.path.append(meta_dir)
+        import plugins
+        sys.path.pop()
     try:
         spec = load_canonical(slug, spec_path)
         additional_tests = load_additional_tests(slug)
@@ -160,6 +167,7 @@ def generate_exercise(env, spec_path, exercise, check=False):
             exercise, f'{to_snake(slug)}_test.py'
         )
         spec["has_error_case"] = has_error_case(spec["cases"])
+        spec["plugins"] = plugins
         logger.info(f'{slug}: attempting render')
         rendered = template.render(**spec)
         with NamedTemporaryFile('w', delete=False) as tmp:

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -155,14 +155,14 @@ def generate_exercise(env, spec_path, exercise, check=False):
     plugins_module = None
     plugins_name = "plugins"
     plugins_source = os.path.join(meta_dir, f"{plugins_name}.py")
-    if os.path.isfile(plugins_source):
-        plugins_spec = importlib.util.spec_from_file_location(
-            plugins_name, plugins_source
-        )
-        plugins_module = importlib.util.module_from_spec(plugins_spec)
-        sys.modules[plugins_name] = plugins_module
-        plugins_spec.loader.exec_module(plugins_module)
     try:
+        if os.path.isfile(plugins_source):
+            plugins_spec = importlib.util.spec_from_file_location(
+                plugins_name, plugins_source
+            )
+            plugins_module = importlib.util.module_from_spec(plugins_spec)
+            sys.modules[plugins_name] = plugins_module
+            plugins_spec.loader.exec_module(plugins_module)
         spec = load_canonical(slug, spec_path)
         additional_tests = load_additional_tests(slug)
         spec["additional_cases"] = additional_tests
@@ -205,6 +205,10 @@ def generate_exercise(env, spec_path, exercise, check=False):
     except FileNotFoundError as e:
         logger.debug(str(e))
         logger.info(f"{slug}: no canonical data found; skipping")
+    except SyntaxError as e:
+        logger.debug(str(e))
+        logger.info(f"{slug}: SyntaxError in {plugins_source}")
+        return False
     return True
 
 

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -14,6 +14,7 @@ Usage:
 """
 import argparse
 import filecmp
+import importlib.util
 import json
 import logging
 import os
@@ -29,13 +30,13 @@ from tempfile import NamedTemporaryFile
 
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound, UndefinedError
 
-VERSION = '0.1.1'
+VERSION = "0.2.0"
 
-DEFAULT_SPEC_LOCATION = os.path.join('..', 'problem-specifications')
-RGX_WORDS = re.compile(r'[-_\s]|(?=[A-Z])')
+DEFAULT_SPEC_LOCATION = os.path.join("..", "problem-specifications")
+RGX_WORDS = re.compile(r"[-_\s]|(?=[A-Z])")
 
 logging.basicConfig()
-logger = logging.getLogger('generator')
+logger = logging.getLogger("generator")
 logger.setLevel(logging.WARN)
 
 
@@ -44,8 +45,9 @@ def replace_all(string, chars, rep):
     Replace any char in chars with rep, reduce runs and strip terminal ends.
     """
     trans = str.maketrans(dict(zip(chars, repeat(rep))))
-    return re.sub("{0}+".format(re.escape(rep)), rep,
-                  string.translate(trans)).strip(rep)
+    return re.sub("{0}+".format(re.escape(rep)), rep, string.translate(trans)).strip(
+        rep
+    )
 
 
 def to_snake(string):
@@ -61,7 +63,7 @@ def camel_case(string):
     """
     Convert pretty much anything to CamelCase.
     """
-    return ''.join(w.title() for w in to_snake(string).split('_'))
+    return "".join(w.title() for w in to_snake(string).split("_"))
 
 
 def get_tested_properties(spec):
@@ -79,9 +81,9 @@ def get_tested_properties(spec):
 
 def error_case(case):
     return (
-        "expected" in case and
-        isinstance(case["expected"], dict) and
-        "error" in case["expected"]
+        "expected" in case
+        and isinstance(case["expected"], dict)
+        and "error" in case["expected"]
     )
 
 
@@ -103,9 +105,7 @@ def load_canonical(exercise, spec_path):
     """
     Loads the canonical data for an exercise as a nested dictionary
     """
-    full_path = os.path.join(
-        spec_path, 'exercises', exercise, 'canonical-data.json'
-    )
+    full_path = os.path.join(spec_path, "exercises", exercise, "canonical-data.json")
     with open(full_path) as f:
         spec = json.load(f)
     spec["properties"] = get_tested_properties(spec)
@@ -116,7 +116,7 @@ def load_additional_tests(exercise):
     """
     Loads additional tests from .meta/additional_tests.json
     """
-    full_path = os.path.join('exercises', exercise, '.meta', 'additional_tests.json')
+    full_path = os.path.join("exercises", exercise, ".meta", "additional_tests.json")
     try:
         with open(full_path) as f:
             data = json.load(f)
@@ -129,7 +129,7 @@ def format_file(path):
     """
     Runs black auto-formatter on file at path
     """
-    check_call(['black', '-q', path])
+    check_call(["black", "-q", path])
 
 
 def compare_existing(rendered, tests_path):
@@ -150,62 +150,70 @@ def generate_exercise(env, spec_path, exercise, check=False):
     False: saves rendered to tests file
     """
     slug = os.path.basename(exercise)
-    meta_dir = os.path.join(exercise, '.meta')
+    meta_dir = os.path.join(exercise, ".meta")
     plugins = None
-    if os.path.isfile(os.path.join(meta_dir, 'plugins.py')):
-        import sys
-        sys.path.append(meta_dir)
-        import plugins
-        sys.path.pop()
+    plugins_module = None
+    plugins_name = "plugins"
+    plugins_source = os.path.join(meta_dir, f"{plugins_name}.py")
+    if os.path.isfile(plugins_source):
+        plugins_spec = importlib.util.spec_from_file_location(
+            plugins_name, plugins_source
+        )
+        plugins_module = importlib.util.module_from_spec(plugins_spec)
+        sys.modules[plugins_name] = plugins_module
+        plugins_spec.loader.exec_module(plugins_module)
     try:
         spec = load_canonical(slug, spec_path)
         additional_tests = load_additional_tests(slug)
         spec["additional_cases"] = additional_tests
-        template_path = posixpath.join(slug, '.meta', 'template.j2')
+        template_path = posixpath.join(slug, ".meta", "template.j2")
         template = env.get_template(template_path)
-        tests_path = os.path.join(
-            exercise, f'{to_snake(slug)}_test.py'
-        )
+        tests_path = os.path.join(exercise, f"{to_snake(slug)}_test.py")
         spec["has_error_case"] = has_error_case(spec["cases"])
-        spec["plugins"] = plugins
-        logger.info(f'{slug}: attempting render')
+        if plugins_module is not None:
+            spec[plugins_name] = plugins_module
+        logger.info(f"{slug}: attempting render")
         rendered = template.render(**spec)
-        with NamedTemporaryFile('w', delete=False) as tmp:
+        with NamedTemporaryFile("w", delete=False) as tmp:
             tmp.write(rendered)
         try:
-            logger.debug(f'{slug}: formatting tmp file')
+            logger.debug(f"{slug}: formatting tmp file")
             format_file(tmp.name)
         except FileNotFoundError as e:
-            logger.error(f'{slug}: the black utility must be installed')
+            logger.error(f"{slug}: the black utility must be installed")
             return False
 
         if check:
             try:
                 if not filecmp.cmp(tmp.name, tests_path):
-                    logger.error(f'{slug}: check failed; tests must be regenerated with bin/generate_tests.py')
+                    logger.error(
+                        f"{slug}: check failed; tests must be regenerated with bin/generate_tests.py"
+                    )
                     return False
             finally:
                 os.remove(tmp.name)
         else:
             shutil.move(tmp.name, tests_path)
-            print(f'{slug} generated at {tests_path}')
+            print(f"{slug} generated at {tests_path}")
     except (TypeError, UndefinedError) as e:
         logger.debug(str(e))
-        logger.error(f'{slug}: generation failed')
+        logger.error(f"{slug}: generation failed")
         return False
     except TemplateNotFound as e:
         logger.debug(str(e))
-        logger.info(f'{slug}: no template found; skipping')
+        logger.info(f"{slug}: no template found; skipping")
     except FileNotFoundError as e:
         logger.debug(str(e))
-        logger.info(f'{slug}: no canonical data found; skipping')
+        logger.info(f"{slug}: no canonical data found; skipping")
     return True
 
 
 def generate(
-    exercise_glob, spec_path=DEFAULT_SPEC_LOCATION,
-    stop_on_failure=False, check=False,
-    **kwargs
+    exercise_glob,
+    spec_path=DEFAULT_SPEC_LOCATION,
+    stop_on_failure=False,
+    check=False,
+    **kwargs,
 ):
     """
     Primary entry point. Generates test files for all exercises matching exercise_glob
@@ -214,14 +222,14 @@ def generate(
     if not shutil.which("black"):
         logger.error("the black utility must be installed")
         sys.exit(1)
-    loader = FileSystemLoader(['config', 'exercises'])
+    loader = FileSystemLoader(["config", "exercises"])
     env = Environment(loader=loader, keep_trailing_newline=True)
-    env.filters['to_snake'] = to_snake
-    env.filters['camel_case'] = camel_case
-    env.filters['regex_replace'] = regex_replace
-    env.tests['error_case'] = error_case
+    env.filters["to_snake"] = to_snake
+    env.filters["camel_case"] = camel_case
+    env.filters["regex_replace"] = regex_replace
+    env.tests["error_case"] = error_case
     result = True
-    for exercise in glob(os.path.join('exercises', exercise_glob)):
+    for exercise in glob(os.path.join("exercises", exercise_glob)):
         if not generate_exercise(env, spec_path, exercise, check):
             result = False
             if stop_on_failure:
@@ -230,34 +238,28 @@ def generate(
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("exercise_glob", nargs="?", default="*", metavar="EXERCISE")
     parser.add_argument(
-        'exercise_glob', nargs='?', default='*', metavar='EXERCISE'
+        "--version",
+        action="version",
+        version="%(prog)s {} for Python {}".format(VERSION, sys.version.split("\n")[0]),
     )
+    parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument(
-        '--version', action='version',
-        version='%(prog)s {} for Python {}'.format(
-            VERSION, sys.version.split("\n")[0],
-        )
-    )
-    parser.add_argument('-v', '--verbose', action='store_true')
-    parser.add_argument(
-        '-p', '--spec-path',
+        "-p",
+        "--spec-path",
         default=DEFAULT_SPEC_LOCATION,
         help=(
-            'path to clone of exercism/problem-specifications '
-            '(default: %(default)s)'
-        )
+            "path to clone of exercism/problem-specifications " "(default: %(default)s)"
+        ),
     )
+    parser.add_argument("--stop-on-failure", action="store_true")
     parser.add_argument(
-        '--stop-on-failure',
-        action='store_true'
-    )
-    parser.add_argument(
-        '--check',
-        action='store_true',
-        help='check if tests are up-to-date, but do not modify test files'
+        "--check",
+        action="store_true",
+        help="check if tests are up-to-date, but do not modify test files",
     )
     opts = parser.parse_args()
     if opts.verbose:

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -151,7 +151,6 @@ def generate_exercise(env, spec_path, exercise, check=False):
     """
     slug = os.path.basename(exercise)
     meta_dir = os.path.join(exercise, ".meta")
-    plugins = None
     plugins_module = None
     plugins_name = "plugins"
     plugins_source = os.path.join(meta_dir, f"{plugins_name}.py")


### PR DESCRIPTION
Proposal to allow template authors to specify additional Python code to support their templates.

*Reason:* some things are very, very verbose in Jinja. The example that prompted this was the `react` exercise. The [spec](https://github.com/exercism/problem-specifications/blob/master/exercises/react/canonical-data.json) for this exercise is quite complex. There was a need to find all unique callback names in each test case. In Python, this is quite easy:
```
callbacks = sorted({
    op["name"]
    for op in case["input"]["operations"]
    if op["type"] == "add_callback"
})
```

In Jinja (which does not support comprehensions), this is quite difficult. However, if template authors were able to have a `.meta/plugins.py`, they could include the above snippet (which is totally not re-usable for other exercises, and thus has no place in the generator itself).