### PR TITLE
complex-numbers: Add test template

### DIFF
--- a/exercises/complex-numbers/.meta/template.j2
+++ b/exercises/complex-numbers/.meta/template.j2
@@ -1,0 +1,13 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        value = {{ case["input"]["value"] }}
+        expected = {{ case["expected"] }}
+        self.assertEqual({{ case["property"] }}(value), expected)
+
+    {% endfor %}
+
+{{ macros.footer() }}


### PR DESCRIPTION
Use the template provided by [this documentation](https://github.com/exercism/python/blob/master/docs/GENERATOR.md). That's as far as I've gotten with it due to errors mentioned in the issue (#1937). 