### PR TITLE
forth: add test template

### DIFF
--- a/exercises/forth/.meta/template.j2
+++ b/exercises/forth/.meta/template.j2
@@ -1,9 +1,19 @@
 {%- extends "master_template.j2" -%}
+{% set imports = ["evaluate", "StackUnderflowError"] %}
 
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         {%- if case is error_case %}
+        {%- if case["expected"]["error"] == "divide by zero" %}
+        # {{ case["expected"]["error"] }}
+        with self.assertRaisesWithMessage(ZeroDivisionError):
+        {%- else %}
+        {%- if "stack" in case["expected"]["error"] %}
+        with self.assertRaisesWithMessage(StackUnderflowError):
+        {%- else %}
         with self.assertRaisesWithMessage(ValueError):
+        {%- endif %}
+        {%- endif %}
             {{ case["property"] }}({{ case["input"]["instructions"] }})
         {%- else %}
         self.assertEqual({{ case["property"] }}({{ case["input"]["instructions"] }}), {{ case["expected"] }})

--- a/exercises/forth/.meta/template.j2
+++ b/exercises/forth/.meta/template.j2
@@ -1,0 +1,11 @@
+{%- extends "master_template.j2" -%}
+
+{% macro test_case(case) -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {%- if case is error_case %}
+        with self.assertRaisesWithMessage(ValueError):
+            {{ case["property"] }}({{ case["input"]["instructions"] }})
+        {%- else %}
+        self.assertEqual({{ case["property"] }}({{ case["input"]["instructions"] }}), {{ case["expected"] }})
+        {%- endif %}
+{%- endmacro %}

--- a/exercises/forth/example.py
+++ b/exercises/forth/example.py
@@ -1,3 +1,7 @@
+class StackUnderflowError(Exception):
+    pass
+
+
 def is_integer(string):
     try:
         int(string)
@@ -40,7 +44,7 @@ def evaluate(input_data):
             elif word == '/':
                 divisor = stack.pop()
                 if divisor == 0:
-                    raise ValueError("Attempted to divide by zero")
+                    raise ZeroDivisionError("Attempted to divide by zero")
                 stack.append(int(stack.pop() / divisor))
             elif word == 'dup':
                 stack.append(stack[-1])
@@ -54,5 +58,5 @@ def evaluate(input_data):
             else:
                 raise ValueError("{} has not been defined".format(word))
         except IndexError:
-            raise ValueError("Insufficient number of items in stack")
+            raise StackUnderflowError("Insufficient number of items in stack")
     return stack

--- a/exercises/forth/example.py
+++ b/exercises/forth/example.py
@@ -1,7 +1,3 @@
-class StackUnderflowError(Exception):
-    pass
-
-
 def is_integer(string):
     try:
         int(string)
@@ -44,7 +40,7 @@ def evaluate(input_data):
             elif word == '/':
                 divisor = stack.pop()
                 if divisor == 0:
-                    raise ZeroDivisionError("Attempted to divide by zero")
+                    raise ValueError("Attempted to divide by zero")
                 stack.append(int(stack.pop() / divisor))
             elif word == 'dup':
                 stack.append(stack[-1])
@@ -58,5 +54,5 @@ def evaluate(input_data):
             else:
                 raise ValueError("{} has not been defined".format(word))
         except IndexError:
-            raise StackUnderflowError("Insufficient number of items in stack")
+            raise ValueError("Insufficient number of items in stack")
     return stack

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from forth import evaluate
+from forth import evaluate, StackUnderflowError
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.1
 
@@ -18,11 +18,11 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["1 2 +"]), [3])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["+"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 +"])
 
     # subtraction
@@ -31,11 +31,11 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["3 4 -"]), [-1])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["-"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 -"])
 
     # multiplication
@@ -44,11 +44,11 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["2 4 *"]), [8])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["*"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 *"])
 
     # division
@@ -60,15 +60,16 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["8 3 /"]), [2])
 
     def test_errors_if_dividing_by_zero(self):
-        with self.assertRaisesWithMessage(ValueError):
+        # divide by zero
+        with self.assertRaisesWithMessage(ZeroDivisionError):
             evaluate(["4 0 /"])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["/"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 /"])
 
     # combined arithmetic
@@ -88,7 +89,7 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["1 2 dup"]), [1, 2, 2])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["dup"])
 
     # drop
@@ -100,7 +101,7 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["1 2 drop"]), [1])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["drop"])
 
     # swap
@@ -112,11 +113,11 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["1 2 3 swap"]), [1, 3, 2])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["swap"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 swap"])
 
     # over
@@ -128,11 +129,11 @@ class ForthTest(unittest.TestCase):
         self.assertEqual(evaluate(["1 2 3 over"]), [1, 2, 3, 2])
 
     def test_errors_if_there_is_nothing_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["over"])
 
     def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaisesWithMessage(StackUnderflowError):
             evaluate(["1 over"])
 
     # user-defined words

--- a/exercises/forth/forth_test.py
+++ b/exercises/forth/forth_test.py
@@ -1,300 +1,199 @@
 import unittest
 
-from forth import evaluate, StackUnderflowError
-
+from forth import evaluate
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.1
 
-class ForthUtilities(unittest.TestCase):
+
+class ForthTest(unittest.TestCase):
+
+    # parsing and numbers
+
+    def test_numbers_just_get_pushed_onto_the_stack(self):
+        self.assertEqual(evaluate(["1 2 3 4 5"]), [1, 2, 3, 4, 5])
+
+    # addition
+
+    def test_can_add_two_numbers(self):
+        self.assertEqual(evaluate(["1 2 +"]), [3])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["+"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 +"])
+
+    # subtraction
+
+    def test_can_subtract_two_numbers(self):
+        self.assertEqual(evaluate(["3 4 -"]), [-1])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["-"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 -"])
+
+    # multiplication
+
+    def test_can_multiply_two_numbers(self):
+        self.assertEqual(evaluate(["2 4 *"]), [8])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["*"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 *"])
+
+    # division
+
+    def test_can_divide_two_numbers(self):
+        self.assertEqual(evaluate(["12 3 /"]), [4])
+
+    def test_performs_integer_division(self):
+        self.assertEqual(evaluate(["8 3 /"]), [2])
+
+    def test_errors_if_dividing_by_zero(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["4 0 /"])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["/"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 /"])
+
+    # combined arithmetic
+
+    def test_addition_and_subtraction(self):
+        self.assertEqual(evaluate(["1 2 + 4 -"]), [-1])
+
+    def test_multiplication_and_division(self):
+        self.assertEqual(evaluate(["2 4 * 3 /"]), [2])
+
+    # dup
+
+    def test_copies_a_value_on_the_stack(self):
+        self.assertEqual(evaluate(["1 dup"]), [1, 1])
+
+    def test_copies_the_top_value_on_the_stack(self):
+        self.assertEqual(evaluate(["1 2 dup"]), [1, 2, 2])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["dup"])
+
+    # drop
+
+    def test_removes_the_top_value_on_the_stack_if_it_is_the_only_one(self):
+        self.assertEqual(evaluate(["1 drop"]), [])
+
+    def test_removes_the_top_value_on_the_stack_if_it_is_not_the_only_one(self):
+        self.assertEqual(evaluate(["1 2 drop"]), [1])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["drop"])
+
+    # swap
+
+    def test_swaps_the_top_two_values_on_the_stack_if_they_are_the_only_ones(self):
+        self.assertEqual(evaluate(["1 2 swap"]), [2, 1])
+
+    def test_swaps_the_top_two_values_on_the_stack_if_they_are_not_the_only_ones(self):
+        self.assertEqual(evaluate(["1 2 3 swap"]), [1, 3, 2])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["swap"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 swap"])
+
+    # over
+
+    def test_copies_the_second_element_if_there_are_only_two(self):
+        self.assertEqual(evaluate(["1 2 over"]), [1, 2, 1])
+
+    def test_copies_the_second_element_if_there_are_more_than_two(self):
+        self.assertEqual(evaluate(["1 2 3 over"]), [1, 2, 3, 2])
+
+    def test_errors_if_there_is_nothing_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["over"])
+
+    def test_errors_if_there_is_only_one_value_on_the_stack(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["1 over"])
+
+    # user-defined words
+
+    def test_can_consist_of_built_in_words(self):
+        self.assertEqual(evaluate([": dup-twice dup dup ;", "1 dup-twice"]), [1, 1, 1])
+
+    def test_execute_in_the_right_order(self):
+        self.assertEqual(evaluate([": countup 1 2 3 ;", "countup"]), [1, 2, 3])
+
+    def test_can_override_other_user_defined_words(self):
+        self.assertEqual(
+            evaluate([": foo dup ;", ": foo dup dup ;", "1 foo"]), [1, 1, 1]
+        )
+
+    def test_can_override_built_in_words(self):
+        self.assertEqual(evaluate([": swap dup ;", "1 swap"]), [1, 1])
+
+    def test_can_override_built_in_operators(self):
+        self.assertEqual(evaluate([": + * ;", "3 4 +"]), [12])
+
+    def test_can_use_different_words_with_the_same_name(self):
+        self.assertEqual(
+            evaluate([": foo 5 ;", ": bar foo ;", ": foo 6 ;", "bar foo"]), [5, 6]
+        )
+
+    def test_can_define_word_that_uses_word_with_the_same_name(self):
+        self.assertEqual(evaluate([": foo 10 ;", ": foo foo 1 + ;", "foo"]), [11])
+
+    def test_cannot_redefine_numbers(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate([": 1 2 ;"])
+
+    def test_errors_if_executing_a_non_existent_word(self):
+        with self.assertRaisesWithMessage(ValueError):
+            evaluate(["foo"])
+
+    # case-insensitivity
+
+    def test_dup_is_case_insensitive(self):
+        self.assertEqual(evaluate(["1 DUP Dup dup"]), [1, 1, 1, 1])
+
+    def test_drop_is_case_insensitive(self):
+        self.assertEqual(evaluate(["1 2 3 4 DROP Drop drop"]), [1])
+
+    def test_swap_is_case_insensitive(self):
+        self.assertEqual(evaluate(["1 2 SWAP 3 Swap 4 swap"]), [2, 3, 4, 1])
+
+    def test_over_is_case_insensitive(self):
+        self.assertEqual(evaluate(["1 2 OVER Over over"]), [1, 2, 1, 2, 1])
+
+    def test_user_defined_words_are_case_insensitive(self):
+        self.assertEqual(evaluate([": foo dup ;", "1 FOO Foo foo"]), [1, 1, 1, 1])
+
+    def test_definitions_are_case_insensitive(self):
+        self.assertEqual(evaluate([": SWAP DUP Dup dup ;", "1 swap"]), [1, 1, 1, 1])
+
     # Utility functions
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
 
 
-class ForthParsingTest(ForthUtilities):
-    def test_numbers_just_get_pushed_to_stack(self):
-        input_data = ["1 2 3 4 5"]
-        expected = [1, 2, 3, 4, 5]
-        self.assertEqual(evaluate(input_data), expected)
-
-
-class ForthAdditionTest(ForthUtilities):
-    def test_can_add_two_numbers(self):
-        input_data = ["1 2 +"]
-        expected = [3]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["+"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 +"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthSubtractionTest(ForthUtilities):
-    def test_can_subtract_two_numbers(self):
-        input_data = ["3 4 -"]
-        expected = [-1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["-"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 -"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthMultiplicationTest(ForthUtilities):
-    def test_can_multiply_two_numbers(self):
-        input_data = ["2 4 *"]
-        expected = [8]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["*"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 *"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthDivisionTest(ForthUtilities):
-    def test_can_divide_two_numbers(self):
-        input_data = ["12 3 /"]
-        expected = [4]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_performs_integer_division(self):
-        input_data = ["8 3 /"]
-        expected = [2]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_dividing_by_zero(self):
-        input_data = ["4 0 /"]
-        with self.assertRaisesWithMessage(ZeroDivisionError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["/"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 /"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthCombinedArithmeticTest(ForthUtilities):
-    def test_addition_and_subtraction(self):
-        input_data = ["1 2 + 4 -"]
-        expected = [-1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_multiplication_and_division(self):
-        input_data = ["2 4 * 3 /"]
-        expected = [2]
-        self.assertEqual(evaluate(input_data), expected)
-
-
-class ForthDupTest(ForthUtilities):
-    def test_copies_a_value_on_the_stack(self):
-        input_data = ["1 dup"]
-        expected = [1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_copies_the_top_value_on_the_stack(self):
-        input_data = ["1 2 dup"]
-        expected = [1, 2, 2]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["dup"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthDropTest(ForthUtilities):
-    def test_removes_the_top_value_on_the_stack_if_it_is_the_only_one(self):
-        input_data = ["1 drop"]
-        expected = []
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_removes_the_top_value_on_the_stack_if_it_not_the_only_one(self):
-        input_data = ["3 4 drop"]
-        expected = [3]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["drop"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthSwapTest(ForthUtilities):
-    def test_swaps_only_two_values_on_stack(self):
-        input_data = ["1 2 swap"]
-        expected = [2, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_swaps_two_two_values_on_stack(self):
-        input_data = ["1 2 3 swap"]
-        expected = [1, 3, 2]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["swap"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 swap"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthOverTest(ForthUtilities):
-    def test_copies_the_second_element_if_there_are_only_two(self):
-        input_data = ["1 2 over"]
-        expected = [1, 2, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_copies_the_second_element_if_there_are_more_than_two(self):
-        input_data = ["1 2 3 over"]
-        expected = [1, 2, 3, 2]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_errors_if_there_is_nothing_on_the_stack(self):
-        input_data = ["over"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-    def test_errors_if_there_is_only_one_value_on_the_stack(self):
-        input_data = ["1 over"]
-        with self.assertRaisesWithMessage(StackUnderflowError):
-            evaluate(input_data)
-
-
-class ForthUserDefinedWordsTest(ForthUtilities):
-    def test_can_consist_of_built_in_words(self):
-        input_data = [
-            ": dup-twice dup dup ;",
-            "1 dup-twice"
-        ]
-        expected = [1, 1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_execute_in_the_right_order(self):
-        input_data = [
-            ": countup 1 2 3 ;",
-            "countup"
-        ]
-        expected = [1, 2, 3]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_can_override_other_user_defined_words(self):
-        input_data = [
-            ": foo dup ;",
-            ": foo dup dup ;",
-            "1 foo"
-        ]
-        expected = [1, 1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_can_override_built_in_words(self):
-        input_data = [
-            ": swap dup ;",
-            "1 swap"
-        ]
-        expected = [1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_can_override_built_in_operators(self):
-        input_data = [
-            ": + * ;",
-            "3 4 +"
-        ]
-        expected = [12]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_can_use_different_words_with_same_name(self):
-        input_data = [
-            ": foo 5 ;",
-            ": bar foo ;",
-            ": foo 6 ;",
-            "bar foo"
-        ]
-        expected = [5, 6]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_can_define_word_that_uses_word_with_same_name(self):
-        input_data = [
-            ": foo 10 ;",
-            ": foo foo 1 + ;",
-            "foo"
-        ]
-        expected = [11]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_cannot_redefine_numbers(self):
-        input_data = [": 1 2 ;"]
-        with self.assertRaisesWithMessage(ValueError):
-            evaluate(input_data)
-
-    def test_errors_if_executing_a_non_existent_word(self):
-        input_data = ["foo"]
-        with self.assertRaisesWithMessage(ValueError):
-            evaluate(input_data)
-
-
-class ForthCaseInsensitivityTest(ForthUtilities):
-    def test_dup_is_case_insensitive(self):
-        input_data = ["1 DUP Dup dup"]
-        expected = [1, 1, 1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_drop_is_case_insensitive(self):
-        input_data = ["1 2 3 4 DROP Drop drop"]
-        expected = [1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_swap_is_case_insensitive(self):
-        input_data = ["1 2 SWAP 3 Swap 4 swap"]
-        expected = [2, 3, 4, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_over_is_case_insensitive(self):
-        input_data = ["1 2 OVER Over over"]
-        expected = [1, 2, 1, 2, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_user_defined_words_are_case_insensitive(self):
-        input_data = [
-            ": foo dup ;",
-            "1 FOO Foo foo"
-        ]
-        expected = [1, 1, 1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-    def test_definitions_are_case_insensitive(self):
-        input_data = [
-            ": SWAP DUP Dup dup ;",
-            "1 swap"
-        ]
-        expected = [1, 1, 1, 1]
-        self.assertEqual(evaluate(input_data), expected)
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds the test template for forth track.

I updated example.py as the template generates ValueError exceptions instead of StackUnderflowError or ZeroDivisionError.
There might be a test version to be updated somewhere to tell the test is not exactly the same as before but I didn't find where.

Resolves: #1949