### PR TITLE
resistor-color: Add test template

### DIFF
--- a/exercises/resistor-color/.meta/template.j2
+++ b/exercises/resistor-color/.meta/template.j2
@@ -1,0 +1,18 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    {%- if "cases" in case -%}
+    {% for subcase in case["cases"] -%}
+    def test_{{ subcase["description"] | to_snake }}(self):
+        self.assertEqual({{ subcase["property"] | to_snake }}("{{ subcase["input"]["color"] }}"), {{ subcase["expected"] }})
+    {% endfor %}
+    {%- else -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        expected = {{ case["expected"] }}
+        self.assertEqual({{ case["property"] | to_snake }}(), expected)
+    {%- endif -%}
+    {% endfor %}
+
+{{ macros.footer() }}

--- a/exercises/resistor-color/resistor_color_test.py
+++ b/exercises/resistor-color/resistor_color_test.py
@@ -2,34 +2,34 @@ import unittest
 
 from resistor_color import color_code, colors
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
+
 
 class ResistorColorTest(unittest.TestCase):
     def test_black(self):
-        self.assertEqual(color_code('black'), 0)
+        self.assertEqual(color_code("black"), 0)
 
     def test_white(self):
-        self.assertEqual(color_code('white'), 9)
+        self.assertEqual(color_code("white"), 9)
 
     def test_orange(self):
-        self.assertEqual(color_code('orange'), 3)
+        self.assertEqual(color_code("orange"), 3)
 
     def test_colors(self):
         expected = [
-            'black',
-            'brown',
-            'red',
-            'orange',
-            'yellow',
-            'green',
-            'blue',
-            'violet',
-            'grey',
-            'white'
+            "black",
+            "brown",
+            "red",
+            "orange",
+            "yellow",
+            "green",
+            "blue",
+            "violet",
+            "grey",
+            "white",
         ]
         self.assertEqual(colors(), expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I add the test template for Resistor Color exercise, resolve #1978