### PR TITLE
Add test template for alphametics

### DIFF
--- a/exercises/alphametics/.meta/template.j2
+++ b/exercises/alphametics/.meta/template.j2
@@ -1,0 +1,13 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases[0]["cases"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {% set value = case["input"]["puzzle"] -%}
+        {% set expected = case["expected"] -%}
+        self.assertEqual({{ case["property"] }}("{{ value }}"), {{ expected }})
+
+    {% endfor %}
+
+{{ macros.footer() }}

--- a/exercises/alphametics/.meta/template.j2
+++ b/exercises/alphametics/.meta/template.j2
@@ -3,8 +3,13 @@
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases[0]["cases"] -%}
-    def test_{{ case["description"] | to_snake }}(self):
-        {% set value = case["input"]["puzzle"] -%}
+    {% set description = case["description"] | to_snake -%}
+    {% set value = case["input"]["puzzle"] -%}
+    {% if value|length > 100 -%}
+    # Reason to skip this test at https://github.com/exercism/python/pull/1358
+    @unittest.skip("extra-credit")
+    {% endif %}
+    def test_{{ description }}(self):
         {% set expected = case["expected"] -%}
         self.assertEqual({{ case["property"] }}("{{ value }}"), {{ expected }})
 

--- a/exercises/alphametics/alphametics_test.py
+++ b/exercises/alphametics/alphametics_test.py
@@ -2,8 +2,8 @@ import unittest
 
 from alphametics import solve
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.3.0
+
 
 class AlphameticsTest(unittest.TestCase):
     def test_puzzle_with_three_letters(self):
@@ -18,102 +18,66 @@ class AlphameticsTest(unittest.TestCase):
     def test_puzzle_with_two_digits_final_carry(self):
         self.assertEqual(
             solve("A + A + A + A + A + A + A + A + A + A + A + B == BCC"),
-            {"A": 9,
-             "B": 1,
-             "C": 0})
+            {"A": 9, "B": 1, "C": 0},
+        )
 
     def test_puzzle_with_four_letters(self):
-        self.assertEqual(
-            solve("AS + A == MOM"), {"A": 9, "S": 2, "M": 1, "O": 0})
+        self.assertEqual(solve("AS + A == MOM"), {"A": 9, "S": 2, "M": 1, "O": 0})
 
     def test_puzzle_with_six_letters(self):
         self.assertEqual(
             solve("NO + NO + TOO == LATE"),
-            {"N": 7,
-             "O": 4,
-             "T": 9,
-             "L": 1,
-             "A": 0,
-             "E": 2})
+            {"N": 7, "O": 4, "T": 9, "L": 1, "A": 0, "E": 2},
+        )
 
     def test_puzzle_with_seven_letters(self):
         self.assertEqual(
             solve("HE + SEES + THE == LIGHT"),
-            {"E": 4,
-             "G": 2,
-             "H": 5,
-             "I": 0,
-             "L": 1,
-             "S": 9,
-             "T": 7})
+            {"E": 4, "G": 2, "H": 5, "I": 0, "L": 1, "S": 9, "T": 7},
+        )
 
     def test_puzzle_with_eight_letters(self):
         self.assertEqual(
             solve("SEND + MORE == MONEY"),
-            {"S": 9,
-             "E": 5,
-             "N": 6,
-             "D": 7,
-             "M": 1,
-             "O": 0,
-             "R": 8,
-             "Y": 2})
+            {"S": 9, "E": 5, "N": 6, "D": 7, "M": 1, "O": 0, "R": 8, "Y": 2},
+        )
 
     def test_puzzle_with_ten_letters(self):
         self.assertEqual(
             solve("AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"),
-            {"A": 5,
-             "D": 3,
-             "E": 4,
-             "F": 7,
-             "G": 8,
-             "N": 0,
-             "O": 2,
-             "R": 1,
-             "S": 6,
-             "T": 9})
+            {
+                "A": 5,
+                "D": 3,
+                "E": 4,
+                "F": 7,
+                "G": 8,
+                "N": 0,
+                "O": 2,
+                "R": 1,
+                "S": 6,
+                "T": 9,
+            },
+        )
 
-    @unittest.skip("extra-credit")
     def test_puzzle_with_ten_letters_and_199_addends(self):
         self.assertEqual(
             solve(
-                "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + "
-                "TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + "
-                "A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + "
-                "LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + "
-                "HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + "
-                "HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + "
-                "HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + "
-                "ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + "
-                "HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + "
-                "HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + "
-                "THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + "
-                "FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + "
-                "STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + "
-                "AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + "
-                "TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + "
-                "THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + "
-                "FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + "
-                "AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + "
-                "THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + "
-                "FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + "
-                "TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + "
-                "ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + "
-                "SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + "
-                "AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + "
-                "TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
+                "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
             ),
-            {"A": 1,
-             "E": 0,
-             "F": 5,
-             "H": 8,
-             "I": 7,
-             "L": 2,
-             "O": 6,
-             "R": 3,
-             "S": 4,
-             "T": 9})
+            {
+                "A": 1,
+                "E": 0,
+                "F": 5,
+                "H": 8,
+                "I": 7,
+                "L": 2,
+                "O": 6,
+                "R": 3,
+                "S": 4,
+                "T": 9,
+            },
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/alphametics/alphametics_test.py
+++ b/exercises/alphametics/alphametics_test.py
@@ -59,6 +59,8 @@ class AlphameticsTest(unittest.TestCase):
             },
         )
 
+    # Reason to skip this test at https://github.com/exercism/python/pull/1358
+    @unittest.skip("extra-credit")
     def test_puzzle_with_ten_letters_and_199_addends(self):
         self.assertEqual(
             solve(


### PR DESCRIPTION
Resolve #1925.

There's no skipped test in this commit. I don't find any field in the canonical file indicating that a test should be skipped.