### PR TITLE
generate_tests: option to wrap long lines

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -28,6 +28,7 @@ from itertools import repeat
 from string import punctuation, whitespace
 from subprocess import check_call
 from tempfile import NamedTemporaryFile
+from textwrap import wrap
 
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound, UndefinedError
 
@@ -65,6 +66,13 @@ def camel_case(string):
     Convert pretty much anything to CamelCase.
     """
     return "".join(w.title() for w in to_snake(string).split("_"))
+
+
+def wrap_overlong(string, width=70):
+    """
+    Break an overly long string literal into escaped lines.
+    """
+    return ["{0!r} \\".format(w) for w in wrap(string, width)]
 
 
 def get_tested_properties(spec):
@@ -242,6 +250,7 @@ def generate(
     env = Environment(loader=loader, keep_trailing_newline=True)
     env.filters["to_snake"] = to_snake
     env.filters["camel_case"] = camel_case
+    env.filters["wrap_overlong"] = wrap_overlong
     env.filters["regex_replace"] = regex_replace
     env.tests["error_case"] = error_case
     result = True

--- a/exercises/alphametics/.meta/template.j2
+++ b/exercises/alphametics/.meta/template.j2
@@ -11,8 +11,18 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% endif %}
     def test_{{ description }}(self):
         {% set expected = case["expected"] -%}
+        {% if value|length > 100 -%}
+        {% for line in value | wrap_overlong(width=62) -%}
+        {% if loop.index == 1 -%}
+        puzzle = {{ line }}
+        {% else -%}
+                 {{ line }}
+        {% endif -%}
+        {% endfor %}
+        self.assertEqual({{ case["property"] }}(puzzle), {{ expected }})
+        {% else -%}
         self.assertEqual({{ case["property"] }}("{{ value }}"), {{ expected }})
-
+        {% endif %}
     {% endfor %}
 
 {{ macros.footer() }}

--- a/exercises/alphametics/alphametics_test.py
+++ b/exercises/alphametics/alphametics_test.py
@@ -62,10 +62,34 @@ class AlphameticsTest(unittest.TestCase):
     # Reason to skip this test at https://github.com/exercism/python/pull/1358
     @unittest.skip("extra-credit")
     def test_puzzle_with_ten_letters_and_199_addends(self):
+        puzzle = (
+            "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL"
+            "+ A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE +"
+            "THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER +"
+            "THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST +"
+            "FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE +"
+            "TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS +"
+            "THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER +"
+            "SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE"
+            "+ RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE"
+            "+ FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE +"
+            "OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE"
+            "+ THE + STARES + OF + THE + OTHERS + AS + THE + TROLL +"
+            "ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF"
+            "+ OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS +"
+            "LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS +"
+            "THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS +"
+            "ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST +"
+            "OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE"
+            "+ FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL"
+            "+ ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS +"
+            "FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS +"
+            "STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL +"
+            "SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A +"
+            "ROOFS + FOR + THEIR + SAFE == FORTRESSES"
+        )
         self.assertEqual(
-            solve(
-                "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
-            ),
+            solve(puzzle),
             {
                 "A": 1,
                 "E": 0,


### PR DESCRIPTION
Adds a function to the render environment to allow line wrapping of VERY long strings. Updates the alphametics test file as an example, as it had a string that ran to over 1400 columns width.