### PR TITLE
phone-number: add test template

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 """
 Generates exercise test suites using an exercise's canonical-data.json
 (found in problem-specifications) and $exercise/.meta/template.j2.
@@ -12,6 +12,13 @@ Usage:
     generate_tests.py --check           Checks if test files are out of sync with templates
     generate_tests.py --check two-fer   Checks if two-fer test file is out of sync with template
 """
+import sys
+
+_py = sys.version_info
+if _py.major < 3 or (_py.major == 3 and _py.minor < 6):
+    print("Python version must be at least 3.6")
+    sys.exit(1)
+
 import argparse
 import difflib
 import filecmp
@@ -22,7 +29,6 @@ import os
 import posixpath
 import re
 import shutil
-import sys
 from glob import glob
 from itertools import repeat
 from string import punctuation, whitespace
@@ -32,7 +38,7 @@ from textwrap import wrap
 
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound, UndefinedError
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 DEFAULT_SPEC_LOCATION = os.path.join("..", "problem-specifications")
 RGX_WORDS = re.compile(r"[-_\s]|(?=[A-Z])")

--- a/exercises/phone-number/.meta/additional_tests.json
+++ b/exercises/phone-number/.meta/additional_tests.json
@@ -1,0 +1,29 @@
+{
+    "exercise": "phone-number",
+    "version": "1.7.0",
+    "cases": [{
+            "description": "area code",
+            "property": "area_code",
+            "input": {
+                "phrase": "2234567890"
+            },
+            "expected": "223"
+        },
+        {
+            "description": "pretty print",
+            "property": "pretty",
+            "input": {
+                "phrase": "2234567890"
+            },
+            "expected": "(223) 456-7890"
+        },
+        {
+            "description": "pretty print with full US phone number",
+            "property": "pretty",
+            "input": {
+                "phrase": "12234567890"
+            },
+            "expected": "(223) 456-7890"
+        }
+    ]
+}

--- a/exercises/phone-number/.meta/template.j2
+++ b/exercises/phone-number/.meta/template.j2
@@ -15,16 +15,16 @@ class {{ class }}Test(unittest.TestCase):
     {% endfor %}
 
     # Additional tests for this track
-    {% for case in additional_cases["cases"] -%}
+    {% for case in additional_cases -%}
     def test_{{ case["description"] | to_snake }}(self):
         {% set property = case["property"] -%}
         {% if property == "area_code" -%}
         {% set method = "" -%}
         {% else -%}
-        {% set method = ".()" -%}
+        {% set method = "()" -%}
         {% endif -%}
         number = {{ class }}("{{ case["input"]["phrase"] }}")
-        self.assertEqual(number.{{ case["property"] }}{{ method }}, {{ case["expected"] }})
+        self.assertEqual(number.{{ case["property"] }}{{ method }}, "{{ case["expected"] }}")
     {% endfor %}
 
 {{ macros.footer() }}

--- a/exercises/phone-number/.meta/template.j2
+++ b/exercises/phone-number/.meta/template.j2
@@ -1,0 +1,30 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{% set class = exercise | camel_case -%}
+{{ macros.header([class]) }}
+
+class {{ class }}Test(unittest.TestCase):
+    {% for case in cases[0]["cases"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {% if "error" in case["expected"] -%}
+        with self.assertRaisesWithMessage(ValueError):
+            {{ class }}("{{ case["input"]["phrase"] }}")
+        {% else -%}
+        number = {{ class }}("{{ case["input"]["phrase"] }}").number
+        self.assertEqual(number, "{{ case["expected"] }}")
+        {% endif %}
+    {% endfor %}
+
+    # Track specific tests
+    def test_area_code(self):
+        number = {{ class }}("2234567890")
+        self.assertEqual(number.area_code, "223")
+
+    def test_pretty_print(self):
+        number = {{ class }}("2234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
+
+    def test_pretty_print_with_full_us_phone_number(self):
+        number = {{ class }}("12234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
+
+{{ macros.footer() }}

--- a/exercises/phone-number/.meta/template.j2
+++ b/exercises/phone-number/.meta/template.j2
@@ -14,17 +14,17 @@ class {{ class }}Test(unittest.TestCase):
         {% endif %}
     {% endfor %}
 
-    # Track specific tests
-    def test_area_code(self):
-        number = {{ class }}("2234567890")
-        self.assertEqual(number.area_code, "223")
-
-    def test_pretty_print(self):
-        number = {{ class }}("2234567890")
-        self.assertEqual(number.pretty(), "(223) 456-7890")
-
-    def test_pretty_print_with_full_us_phone_number(self):
-        number = {{ class }}("12234567890")
-        self.assertEqual(number.pretty(), "(223) 456-7890")
+    # Additional tests for this track
+    {% for case in additional_cases["cases"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {% set property = case["property"] -%}
+        {% if property == "area_code" -%}
+        {% set method = "" -%}
+        {% else -%}
+        {% set method = ".()" -%}
+        {% endif -%}
+        number = {{ class }}("{{ case["input"]["phrase"] }}")
+        self.assertEqual(number.{{ case["property"] }}{{ method }}, {{ case["expected"] }})
+    {% endfor %}
 
 {{ macros.footer() }}

--- a/exercises/phone-number/example.py
+++ b/exercises/phone-number/example.py
@@ -1,7 +1,7 @@
 import re
 
 
-class Phone:
+class PhoneNumber:
     def __init__(self, number):
         self.number = self._clean(number)
         self.area_code = self.number[:3]
@@ -10,18 +10,14 @@ class Phone:
 
     def pretty(self):
         return "({}) {}-{}".format(
-            self.area_code,
-            self.exchange_code,
-            self.subscriber_number,
+            self.area_code, self.exchange_code, self.subscriber_number
         )
 
     def _clean(self, number):
-        return self._normalize(
-            re.sub(r'[^\d]', '', number),
-        )
+        return self._normalize(re.sub(r"[^\d]", "", number))
 
     def _normalize(self, number):
-        if len(number) == 10 or len(number) == 11 and number.startswith('1'):
+        if len(number) == 10 or len(number) == 11 and number.startswith("1"):
             valid = number[-10] in "23456789" and number[-7] in "23456789"
         else:
             valid = False

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -78,18 +78,7 @@ class PhoneNumberTest(unittest.TestCase):
         with self.assertRaisesWithMessage(ValueError):
             PhoneNumber("1 (223) 156-7890")
 
-    # Track specific tests
-    def test_area_code(self):
-        number = PhoneNumber("2234567890")
-        self.assertEqual(number.area_code, "223")
-
-    def test_pretty_print(self):
-        number = PhoneNumber("2234567890")
-        self.assertEqual(number.pretty(), "(223) 456-7890")
-
-    def test_pretty_print_with_full_us_phone_number(self):
-        number = PhoneNumber("12234567890")
-        self.assertEqual(number.pretty(), "(223) 456-7890")
+    # Additional tests for this track
 
     # Utility functions
     def assertRaisesWithMessage(self, exception):

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -1,94 +1,94 @@
 import unittest
 
-from phone_number import Phone
-
+from phone_number import PhoneNumber
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.7.0
 
+
 class PhoneNumberTest(unittest.TestCase):
-    def test_cleans_number(self):
-        number = Phone("(223) 456-7890").number
+    def test_cleans_the_number(self):
+        number = PhoneNumber("(223) 456-7890").number
         self.assertEqual(number, "2234567890")
 
-    def test_cleans_number_with_dots(self):
-        number = Phone("223.456.7890").number
+    def test_cleans_numbers_with_dots(self):
+        number = PhoneNumber("223.456.7890").number
         self.assertEqual(number, "2234567890")
 
-    def test_cleans_number_with_multiple_spaces(self):
-        number = Phone("223 456   7890   ").number
+    def test_cleans_numbers_with_multiple_spaces(self):
+        number = PhoneNumber("223 456   7890   ").number
         self.assertEqual(number, "2234567890")
 
     def test_invalid_when_9_digits(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("123456789")
+            PhoneNumber("123456789")
 
-    def test_invalid_when_11_digits_and_first_not_1(self):
+    def test_invalid_when_11_digits_does_not_start_with_a_1(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("22234567890")
+            PhoneNumber("22234567890")
 
-    def test_valid_when_11_digits_and_first_is_1(self):
-        number = Phone("12234567890").number
+    def test_valid_when_11_digits_and_starting_with_1(self):
+        number = PhoneNumber("12234567890").number
         self.assertEqual(number, "2234567890")
 
-    def test_valid_when_11_digits_and_first_is_1_with_punctuation(self):
-        number = Phone("+1 (223) 456-7890").number
+    def test_valid_when_11_digits_and_starting_with_1_even_with_punctuation(self):
+        number = PhoneNumber("+1 (223) 456-7890").number
         self.assertEqual(number, "2234567890")
 
     def test_invalid_when_more_than_11_digits(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("321234567890")
+            PhoneNumber("321234567890")
 
     def test_invalid_with_letters(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("123-abc-7890")
+            PhoneNumber("123-abc-7890")
 
-    def test_invalid_with_punctuation(self):
+    def test_invalid_with_punctuations(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("123-@:!-7890")
+            PhoneNumber("123-@:!-7890")
 
     def test_invalid_if_area_code_starts_with_0(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("(023) 456-7890")
+            PhoneNumber("(023) 456-7890")
 
     def test_invalid_if_area_code_starts_with_1(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("(123) 456-7890")
+            PhoneNumber("(123) 456-7890")
 
     def test_invalid_if_exchange_code_starts_with_0(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("(223) 056-7890")
+            PhoneNumber("(223) 056-7890")
 
     def test_invalid_if_exchange_code_starts_with_1(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("(223) 156-7890")
+            PhoneNumber("(223) 156-7890")
 
     def test_invalid_if_area_code_starts_with_0_on_valid_11_digit_number(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("1 (023) 456-7890")
+            PhoneNumber("1 (023) 456-7890")
 
     def test_invalid_if_area_code_starts_with_1_on_valid_11_digit_number(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("1 (123) 456-7890")
+            PhoneNumber("1 (123) 456-7890")
 
-    def test_invalid_exchange_code_starts_with_0_valid_11_digit_number(self):
+    def test_invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("1 (223) 056-7890")
+            PhoneNumber("1 (223) 056-7890")
 
-    def test_invalid_exchange_code_starts_with_1_valid_11_digit_number(self):
+    def test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number(self):
         with self.assertRaisesWithMessage(ValueError):
-            Phone("1 (223) 156-7890")
+            PhoneNumber("1 (223) 156-7890")
 
     # Track specific tests
     def test_area_code(self):
-        number = Phone("2234567890")
+        number = PhoneNumber("2234567890")
         self.assertEqual(number.area_code, "223")
 
     def test_pretty_print(self):
-        number = Phone("2234567890")
+        number = PhoneNumber("2234567890")
         self.assertEqual(number.pretty(), "(223) 456-7890")
 
     def test_pretty_print_with_full_us_phone_number(self):
-        number = Phone("12234567890")
+        number = PhoneNumber("12234567890")
         self.assertEqual(number.pretty(), "(223) 456-7890")
 
     # Utility functions
@@ -96,5 +96,5 @@ class PhoneNumberTest(unittest.TestCase):
         return self.assertRaisesRegex(exception, r".+")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/phone-number/phone_number_test.py
+++ b/exercises/phone-number/phone_number_test.py
@@ -79,6 +79,17 @@ class PhoneNumberTest(unittest.TestCase):
             PhoneNumber("1 (223) 156-7890")
 
     # Additional tests for this track
+    def test_area_code(self):
+        number = PhoneNumber("2234567890")
+        self.assertEqual(number.area_code, "223")
+
+    def test_pretty_print(self):
+        number = PhoneNumber("2234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
+
+    def test_pretty_print_with_full_us_phone_number(self):
+        number = PhoneNumber("12234567890")
+        self.assertEqual(number.pretty(), "(223) 456-7890")
 
     # Utility functions
     def assertRaisesWithMessage(self, exception):


### PR DESCRIPTION
Resolve #1966. I change the class name to `PhoneNumber` to make it consistent with the canonical file, and also auto-format the example file.