### PR TITLE
remove PyUp.io badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Python Track
 
-[![Build Status](https://travis-ci.org/exercism/python.svg?branch=master)](https://travis-ci.org/exercism/python) [![Requirements Status](https://pyup.io/repos/github/exercism/python/shield.svg)](https://pyup.io/repos/github/exercism/python/)
+[![Build Status](https://travis-ci.org/exercism/python.svg?branch=master)](https://travis-ci.org/exercism/python)
 [![Join the chat at https://gitter.im/exercism/python](https://badges.gitter.im/exercism/python.svg)](https://gitter.im/exercism/python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism exercises in Python


### PR DESCRIPTION
Looks like PyUp.io switched to a [paid model for organization repos](https://pyup.io/pricing/). No one here is paying for this, so drop the badge.

Resolves #2138