### PR TITLE
book-store: Add test checking that solutions can mix groups of 4 and 5

### DIFF
--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from book_store import total
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.0
 
 
 class BookStoreTest(unittest.TestCase):
@@ -87,6 +87,12 @@ class BookStoreTest(unittest.TestCase):
         results = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
         table = 8120
         self.assertEqual(total(results), table)
+
+    def test_shuffled_book_order(self):
+        results = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
+        table = 8120
+        self.assertEqual(total(results), table)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -83,6 +83,10 @@ class BookStoreTest(unittest.TestCase):
         table = 10240
         self.assertEqual(total(results), table)
 
+    def test_one_group_of_five_and_two_groups_of_four(self):
+        results = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
+        table = 8120
+        self.assertEqual(total(results), table)
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -83,8 +83,8 @@ class BookStoreTest(unittest.TestCase):
         table = 10240
         self.assertEqual(total(results), table)
 
-    def test_one_group_of_five_and_two_groups_of_four(self):
-        results = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
+    def test_two_groups_of_four_and_a_group_of_five(self):
+        results = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
         table = 8120
         self.assertEqual(total(results), table)
 

--- a/exercises/book-store/example.py
+++ b/exercises/book-store/example.py
@@ -47,6 +47,6 @@ def step(basket, book):
 def total(basket):
     if len(basket) == 0:
         return 0
-    basket.sort()
+    basket = sorted(basket)
     start = Grouping([{basket[0]}])
     return round(min(reduce(step, basket[1:], [start])).total())

--- a/exercises/book-store/example.py
+++ b/exercises/book-store/example.py
@@ -47,5 +47,6 @@ def step(basket, book):
 def total(basket):
     if len(basket) == 0:
         return 0
+    basket.sort()
     start = Grouping([{basket[0]}])
     return round(min(reduce(step, basket[1:], [start])).total())


### PR DESCRIPTION
Many of the "brute force" solutions I see do something like run a greedy solver multiple times with different maximum group sizes.  This allows them to solve test cases that check for finding 2 groups of 4 instead of a group of 5 and a group of 3.

However, this wouldn't solve cases where you need to use both groups of 5 and groups of 4.  For example, consider `books = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]`.  The cheapest price possible is achieved by splitting it into 1 group of 5 and 2 groups of 4, with cost = `800*(1*5*0.75 + 2*4*0.8) = 8120`.  Solutions like those described above will typically split it into 2 groups of 5 and 1 group of 3, with a cost of `800*(2*5*0.75 + 1*3*0.9) = 8160`.  An example is the compact brute force solution @yawpitch shows here: https://exercism.io/tracks/python/exercises/book-store/solutions/c58f3dcf78314e95820c717a30f787c9 (your recursive solution returns the correct value of 8120, of course).

This PR adds the test case described above.