### PR TITLE
Add Python 3.8 to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 dist: xenial
-  
+
 python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - nightly
 
 matrix:
@@ -42,6 +43,6 @@ matrix:
 
 before_script:
   - flake8
-  
-script: 
+
+script:
   - ./test/check-exercises.py

--- a/exercises/pov/.meta/template.j2
+++ b/exercises/pov/.meta/template.j2
@@ -23,7 +23,7 @@
 {%- macro test_path_to(case) -%}
         {% if case["expected"] -%}
         expected = {{ case["expected"] }}
-        self.assertEquals(tree.{{ case["property"] | to_snake }}("{{ case["input"]["from"] }}", "{{ case["input"]["to"]}}"), expected)
+        self.assertEqual(tree.{{ case["property"] | to_snake }}("{{ case["input"]["from"] }}", "{{ case["input"]["to"]}}"), expected)
         {% else -%}
         with self.assertRaisesWithMessage(ValueError):
             tree.{{ case["property"] | to_snake }}("{{ case["input"]["from"] }}", "{{ case["input"]["to"]}}")

--- a/exercises/pov/pov_test.py
+++ b/exercises/pov/pov_test.py
@@ -92,12 +92,12 @@ class PovTest(unittest.TestCase):
     def test_can_find_path_to_parent(self):
         tree = Tree("parent", [Tree("x"), Tree("sibling")])
         expected = ["x", "parent"]
-        self.assertEquals(tree.path_to("x", "parent"), expected)
+        self.assertEqual(tree.path_to("x", "parent"), expected)
 
     def test_can_find_path_to_sibling(self):
         tree = Tree("parent", [Tree("a"), Tree("x"), Tree("b"), Tree("c")])
         expected = ["x", "parent", "b"]
-        self.assertEquals(tree.path_to("x", "b"), expected)
+        self.assertEqual(tree.path_to("x", "b"), expected)
 
     def test_can_find_path_to_cousin(self):
         tree = Tree(
@@ -115,7 +115,7 @@ class PovTest(unittest.TestCase):
             ],
         )
         expected = ["x", "parent", "grandparent", "uncle", "cousin-1"]
-        self.assertEquals(tree.path_to("x", "cousin-1"), expected)
+        self.assertEqual(tree.path_to("x", "cousin-1"), expected)
 
     def test_can_find_path_not_involving_root(self):
         tree = Tree(
@@ -123,12 +123,12 @@ class PovTest(unittest.TestCase):
             [Tree("parent", [Tree("x"), Tree("sibling-0"), Tree("sibling-1")])],
         )
         expected = ["x", "parent", "sibling-1"]
-        self.assertEquals(tree.path_to("x", "sibling-1"), expected)
+        self.assertEqual(tree.path_to("x", "sibling-1"), expected)
 
     def test_can_find_path_from_nodes_other_than_x(self):
         tree = Tree("parent", [Tree("a"), Tree("x"), Tree("b"), Tree("c")])
         expected = ["a", "parent", "c"]
-        self.assertEquals(tree.path_to("a", "c"), expected)
+        self.assertEqual(tree.path_to("a", "c"), expected)
 
     def test_errors_if_destination_does_not_exist(self):
         tree = Tree(


### PR DESCRIPTION
I added Python 3.8 ([released Oct 14, 2019](https://docs.python.org/3/whatsnew/3.8.html)) to Travis CI config and change `assertEquals` to `assertEqual` in POV exercise to fix the deprecation warning.

```
#  pov

/tmp/tmppvu6epthpov/pov_test.py:131: DeprecationWarning: Please use assertEqual instead.

  self.assertEquals(tree.path_to("a", "c"), expected)
```

As far as I understand, they are just alias now: https://stackoverflow.com/questions/930995/assertequals-vs-assertequal-in-python/931011