### PR TITLE
say: add test template 

### DIFF
--- a/exercises/say/.meta/template.j2
+++ b/exercises/say/.meta/template.j2
@@ -1,0 +1,20 @@
+{%- import "generator_macros.j2" as macros with context -%}
+
+{%- macro test_call(case) %}
+            {{ case["property"] }}(
+                {{ case["input"]["number"] }}
+            )
+{% endmacro -%}
+
+{{ macros.header() }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {%- if case is error_case %}
+        with self.assertRaisesWithMessage(ValueError):
+            {{- test_call(case) }}
+        {%- else %}
+        self.assertEqual({{- test_call(case) }}, {{ case["expected"] }})
+        {%- endif %}
+    {% endfor %}

--- a/exercises/say/.meta/template.j2
+++ b/exercises/say/.meta/template.j2
@@ -18,3 +18,5 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         self.assertEqual({{- test_call(case) }}, "{{ case["expected"] }}")
         {%- endif %}
     {% endfor %}
+
+{{ macros.footer() }}

--- a/exercises/say/.meta/template.j2
+++ b/exercises/say/.meta/template.j2
@@ -15,6 +15,6 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         with self.assertRaisesWithMessage(ValueError):
             {{- test_call(case) }}
         {%- else %}
-        self.assertEqual({{- test_call(case) }}, {{ case["expected"] }})
+        self.assertEqual({{- test_call(case) }}, "{{ case["expected"] }}")
         {%- endif %}
     {% endfor %}

--- a/exercises/say/example.py
+++ b/exercises/say/example.py
@@ -15,7 +15,7 @@ def say(number, recursive=False):
         raise ValueError('number is too large: {}'.format(number))
 
     if number < 20:
-        return small[number] if not recursive else 'and ' + small[number]
+        return small[number] if not recursive else  + small[number]
 
     if number < 100:
         if number % 10 == 0:
@@ -25,7 +25,7 @@ def say(number, recursive=False):
     if number < k:
         if number % 100 == 0:
             return small[number // 100] + ' hundred'
-        return small[number // 100] + ' hundred and ' + say(number % 100)
+        return small[number // 100] + ' hundred ' + say(number % 100)
 
     if number < m:
         if number % k == 0:

--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -57,3 +57,11 @@ class SayTest(unittest.TestCase):
     def test_numbers_above_999_999_999_999_are_out_of_range(self):
         with self.assertRaisesWithMessage(ValueError):
             say(1000000000000)
+
+    # Utility functions
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exercises/say/say_test.py
+++ b/exercises/say/say_test.py
@@ -2,8 +2,8 @@ import unittest
 
 from say import say
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
+
 
 class SayTest(unittest.TestCase):
     def test_zero(self):
@@ -24,46 +24,36 @@ class SayTest(unittest.TestCase):
     def test_one_hundred(self):
         self.assertEqual(say(100), "one hundred")
 
-    # additional track specific test
     def test_one_hundred_twenty_three(self):
-        self.assertEqual(say(123), "one hundred and twenty-three")
+        self.assertEqual(say(123), "one hundred twenty-three")
 
     def test_one_thousand(self):
         self.assertEqual(say(1000), "one thousand")
 
     def test_one_thousand_two_hundred_thirty_four(self):
-        self.assertEqual(say(1234), "one thousand two hundred and thirty-four")
+        self.assertEqual(say(1234), "one thousand two hundred thirty-four")
 
     def test_one_million(self):
         self.assertEqual(say(1000000), "one million")
 
-    def test_1002345(self):
+    def test_one_million_two_thousand_three_hundred_forty_five(self):
         self.assertEqual(
-            say(1002345),
-            "one million two thousand three hundred and forty-five")
+            say(1002345), "one million two thousand three hundred forty-five"
+        )
 
     def test_one_billion(self):
         self.assertEqual(say(1000000000), "one billion")
 
-    def test_987654321123(self):
+    def test_a_big_number(self):
         self.assertEqual(
-            say(987654321123), ("nine hundred and eighty-seven billion "
-                                "six hundred and fifty-four million "
-                                "three hundred and twenty-one thousand "
-                                "one hundred and twenty-three"))
+            say(987654321123),
+            "nine hundred eighty-seven billion six hundred fifty-four million three hundred twenty-one thousand one hundred twenty-three",
+        )
 
-    def test_number_too_large(self):
-        with self.assertRaisesWithMessage(ValueError):
-            say(1000000000000)
-
-    def test_number_negative(self):
+    def test_numbers_below_zero_are_out_of_range(self):
         with self.assertRaisesWithMessage(ValueError):
             say(-1)
 
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_numbers_above_999_999_999_999_are_out_of_range(self):
+        with self.assertRaisesWithMessage(ValueError):
+            say(1000000000000)


### PR DESCRIPTION
I have a problem when I execute generate_test.py  
`error: cannot format /tmp/tmp3247y8ob: Cannot parse: 43:6: , one hundred)
Traceback (most recent call last):
  File "bin/generate_tests.py", line 331, in <module>
    generate(**opts.__dict__)
  File "bin/generate_tests.py", line 297, in generate
    if not generate_exercise(env, spec_path, exercise, check):
  File "bin/generate_tests.py", line 214, in generate_exercise
    format_file(tmp.name)
  File "bin/generate_tests.py", line 176, in format_file
    check_call(["black", "-q", path])
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['black', '-q', '/tmp/tmp3247y8ob']' returned non-zero exit status 123.
 `