### PR TITLE
word-count: Add multiple apostrophes test case

### DIFF
--- a/exercises/word-count/.meta/additional_tests.json
+++ b/exercises/word-count/.meta/additional_tests.json
@@ -35,7 +35,7 @@
       }
     },
     {
-      "description": "multiple_apostrophes_ignored",
+      "description": "multiple apostrophes ignored",
       "property": "countWords",
       "input": {
         "sentence": "''hey''"

--- a/exercises/word-count/.meta/additional_tests.json
+++ b/exercises/word-count/.meta/additional_tests.json
@@ -33,6 +33,16 @@
         "is": 1,
         "broken": 1
       }
+    },
+    {
+      "description": "multiple_apostrophes_ignored",
+      "property": "countWords",
+      "input": {
+        "sentence": "''hey''"
+      },
+      "expected": {
+        "hey": 1
+      }
     }
   ]
 }

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -108,7 +108,7 @@ class WordCountTest(unittest.TestCase):
     def test_multiple_apostrophes_ignored(self):
         self.assertEqual(
             count_words("''hey''"),
-            {"hey": 1}
+            {"hey": 1},
         )
 
 

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -105,12 +105,6 @@ class WordCountTest(unittest.TestCase):
             {"hey": 1, "my": 1, "spacebar": 1, "is": 1, "broken": 1},
         )
 
-    def test_multiple_apostrophes_ignored(self):
-        self.assertEqual(
-            count_words("''hey''"),
-            {"hey": 1},
-        )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -104,7 +104,7 @@ class WordCountTest(unittest.TestCase):
             count_words("hey,my_spacebar_is_broken"),
             {"hey": 1, "my": 1, "spacebar": 1, "is": 1, "broken": 1},
         )
-    
+
     def test_multiple_apostrophes_ignored(self):
         self.assertEqual(
             count_words("''hey''"),

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -104,6 +104,12 @@ class WordCountTest(unittest.TestCase):
             count_words("hey,my_spacebar_is_broken"),
             {"hey": 1, "my": 1, "spacebar": 1, "is": 1, "broken": 1},
         )
+    
+    def test_multiple_apostrophes_ignored(self):
+        self.assertEqual(
+            count_words("''hey''"),
+            {"hey": 1}
+        )
 
 
 if __name__ == "__main__":

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from word_count import count_words
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
 
 
 class WordCountTest(unittest.TestCase):

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -77,9 +77,6 @@ class WordCountTest(unittest.TestCase):
             count_words(",\n,one,\n ,two \n 'three'"), {"one": 1, "two": 1, "three": 1}
         )
 
-    def test_multiple_apostrophes_are_ignored(self):
-        self.assertEqual(count_words("''hey''"), {"hey": 1})
-
     # Additional tests for this track
 
     def test_tabs(self):

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -105,6 +105,12 @@ class WordCountTest(unittest.TestCase):
             {"hey": 1, "my": 1, "spacebar": 1, "is": 1, "broken": 1},
         )
 
+    def test_multiple_apostrophes_ignored(self):
+        self.assertEqual(
+            count_words("''hey''"),
+            {"hey": 1},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from word_count import count_words
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.4.0
+# Tests adapted from `problem-specifications//canonical-data.json` @ v1.5.0
 
 
 class WordCountTest(unittest.TestCase):
@@ -77,6 +77,9 @@ class WordCountTest(unittest.TestCase):
             count_words(",\n,one,\n ,two \n 'three'"), {"one": 1, "two": 1, "three": 1}
         )
 
+    def test_multiple_apostrophes_are_ignored(self):
+        self.assertEqual(count_words("''hey''"), {"hey": 1})
+
     # Additional tests for this track
 
     def test_tabs(self):
@@ -106,10 +109,7 @@ class WordCountTest(unittest.TestCase):
         )
 
     def test_multiple_apostrophes_ignored(self):
-        self.assertEqual(
-            count_words("''hey''"),
-            {"hey": 1},
-        )
+        self.assertEqual(count_words("''hey''"), {"hey": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a localized version of a change I discussed with the main problem-specs repo. They told me that, due to their lockdown, I should bring this to the language-specific repositories.

Effectively, the problem states that contractions ("can't", "won't", etc.) should treat apostrophes as part of the word, but rule 3 states:

Other than the apostrophe in a contraction all forms of punctuation are ignored
As such, I've added a very simple case testing that normal apostrophes are removed. The following code (while bad) should do a good job of showcasing a solution that passes all the live tests but fails the new one:

```
from string import punctuation
def count_words(sentence): 
    dict = {}
    punc = punctuation.replace("'",'')
    for val in punc:
        if val in sentence:
            sentence = sentence.replace(val, ' ')
    for word in sentence.split():
        if (w := word.lower())[0] == "'":
            w = w[1:]
        if w[-1] == "'":
            w = w[:-1]
        if w not in dict:
            dict[w] = 0
        dict[w] += 1
    return dict
```

Thanks!