### PR TITLE
[book-store] Add additional tests

### DIFF
--- a/exercises/book-store/.meta/additional_tests.json
+++ b/exercises/book-store/.meta/additional_tests.json
@@ -1,0 +1,22 @@
+{
+  "cases": [
+    {
+      "property": "total",
+      "description": "Two groups of four and a group of five",
+      "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4,5]]. Solutions can pass all the other tests if they just try to group without using any groups of 5. This test case breaks that since it requires both 4-groups and 5-groups."],
+      "input": {
+        "basket": [1,1,1,2,2,2,3,3,3,4,4,5,5]
+      },
+      "expected": 8120
+    },
+    {
+      "property": "total",
+      "description": "Shuffled book order",
+      "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4,5]]. All the other tests give the books in sorted order.  Robust solutions should be able to handle any order"],
+      "input": {
+        "basket": [1,2,3,4,5,1,2,3,4,5,1,2,3]
+      },
+      "expected": 8120
+    }
+  ]
+}

--- a/exercises/book-store/.meta/template.j2
+++ b/exercises/book-store/.meta/template.j2
@@ -1,14 +1,27 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
-
-class {{ exercise | camel_case }}Test(unittest.TestCase):
-    {% for casegroup in cases %}{% for case in casegroup["cases"] -%}
+{% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
         results = {{ input["basket"] }}
         table = {{ case["expected"] }}
         self.assertEqual({{ case["property"] }}(results), table)
+{%- endmacro %}
+{{ macros.header() }}
 
-    {% endfor %}{% endfor %}
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for casegroup in cases %}
+    {% for case in casegroup["cases"] -%}
+    {{ test_case(case) }}
+    {% endfor %}
+    {% endfor %}
+
+    {% if additional_cases | length -%}
+
+    # Additional tests for this track
+
+    {% for case in additional_cases -%}
+    {{ test_case(case) }}
+    {% endfor %}
+    {%- endif %}
 
 {{ macros.footer() }}

--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -71,14 +71,12 @@ class BookStoreTest(unittest.TestCase):
     # Additional tests for this track
 
     def test_two_groups_of_four_and_a_group_of_five(self):
-        results = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
-        table = 8120
-        self.assertEqual(total(results), table)
+        basket = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
+        self.assertEqual(total(basket), 8120)
 
     def test_shuffled_book_order(self):
-        results = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
-        table = 8120
-        self.assertEqual(total(results), table)
+        basket = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
+        self.assertEqual(total(basket), 8120)
 
 
 if __name__ == "__main__":

--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -83,6 +83,18 @@ class BookStoreTest(unittest.TestCase):
         table = 10240
         self.assertEqual(total(results), table)
 
+    # Additional tests for this track
+
+    def test_two_groups_of_four_and_a_group_of_five(self):
+        results = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
+        table = 8120
+        self.assertEqual(total(results), table)
+
+    def test_shuffled_book_order(self):
+        results = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]
+        table = 8120
+        self.assertEqual(total(results), table)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/exercises/book-store/example.py
+++ b/exercises/book-store/example.py
@@ -47,5 +47,6 @@ def step(basket, book):
 def total(basket):
     if len(basket) == 0:
         return 0
+    basket = sorted(basket)
     start = Grouping([{basket[0]}])
     return round(min(reduce(step, basket[1:], [start])).total())


### PR DESCRIPTION
Adds tests that requires use of booth groups of 4 and 5 volumes.

Closes #2141, which had gone stale.