### PR TITLE
[zipper] add template

### DIFF
--- a/exercises/zipper/.meta/template.j2
+++ b/exercises/zipper/.meta/template.j2
@@ -29,7 +29,7 @@
         {%- endif %}
 {%- endmacro %}
 
-{%- macro same_result_from_operations(input, expected) %}
+{%- macro same_result_from_operations(input, expected) -%}
         initial = {{ input["initialTree"] }}
         result = Zipper.from_tree(initial){{ chain(input["operations"]) }}.to_tree()
 

--- a/exercises/zipper/.meta/template.j2
+++ b/exercises/zipper/.meta/template.j2
@@ -1,0 +1,57 @@
+{%- import "generator_macros.j2" as macros with context -%}
+
+{%- macro test_case(case) %}
+    {%- set input = case["input"] -%}
+    {%- set expected = case["expected"] -%}
+    def test_{{ case["description"] | to_snake }}(self):
+        {%- if case["property"] == "sameResultFromOperations" %}
+        {{ same_result_from_operations(input, expected) }}
+        {%- else %}
+        {{ expected_value(input, expected) }}
+        {%- endif %}
+{%- endmacro -%}
+
+{%- macro expected_value(input, expected) %}
+        initial = {{ input["initialTree"] }}
+
+        {% if expected["type"] == "tree" %}
+        expected = {{ expected["value"] }}
+        {%- endif %}
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper{{ chain(input["operations"]) }}
+        {%- if expected["type"] == "tree" %}
+        self.assertEqual(result, expected) 
+        {%- elif expected["value"] is none %}
+        self.assertIsNone(result)
+        {%- else %}
+        self.assertEqual(result, {{ expected["value"] }})
+        {%- endif %}
+{%- endmacro %}
+
+{%- macro same_result_from_operations(input, expected) %}
+        initial = {{ input["initialTree"] }}
+        result = Zipper.from_tree(initial){{ chain(input["operations"]) }}.to_tree()
+
+        final = {{ expected["initialTree"] }}
+        expected = Zipper.from_tree(final){{ chain(expected["operations"]) }}.to_tree()
+
+        self.assertEqual(result, expected)
+{%- endmacro %}
+
+
+{%- macro chain(operations) %}
+    {%- for op in operations -%}
+        .{{ op["operation"] }}({{ op["item"] }})
+    {%- endfor %}
+{%- endmacro -%}
+
+{{ macros.header (imports=["Zipper"]) }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+{%- for case in cases %}
+    {{ test_case(case) }}
+{%- endfor %}
+
+{{ macros.footer() }}
+

--- a/exercises/zipper/.meta/template.j2
+++ b/exercises/zipper/.meta/template.j2
@@ -11,7 +11,7 @@
         {%- endif %}
 {%- endmacro -%}
 
-{%- macro expected_value(input, expected) %}
+{%- macro expected_value(input, expected) -%}
         initial = {{ input["initialTree"] }}
 
         {% if expected["type"] == "tree" %}
@@ -54,4 +54,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 {%- endfor %}
 
 {{ macros.footer() }}
-

--- a/exercises/zipper/example.py
+++ b/exercises/zipper/example.py
@@ -33,6 +33,8 @@ class Zipper:
         return self
 
     def up(self):
+        if not self.ancestors:
+            return None
         return Zipper(self.ancestors[-1], self.ancestors[:-1])
 
     def to_tree(self):

--- a/exercises/zipper/zipper_test.py
+++ b/exercises/zipper/zipper_test.py
@@ -2,75 +2,316 @@ import unittest
 
 from zipper import Zipper
 
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.1.0
 
+
 class ZipperTest(unittest.TestCase):
-    def bt(self, value, left, right):
-        return {
-            'value': value,
-            'left': left,
-            'right': right
+    def test_data_is_retained(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
         }
 
-    def leaf(self, value):
-        return self.bt(value, None, None)
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
 
-    def create_trees(self):
-        t1 = self.bt(1, self.bt(2, None, self.leaf(3)), self.leaf(4))
-        t2 = self.bt(1, self.bt(5, None, self.leaf(3)), self.leaf(4))
-        t3 = self.bt(1, self.bt(2, self.leaf(5), self.leaf(3)), self.leaf(4))
-        t4 = self.bt(1, self.leaf(2), self.leaf(4))
-        return (t1, t2, t3, t4)
+        zipper = Zipper.from_tree(initial)
+        result = zipper.to_tree()
+        self.assertEqual(result, expected)
 
-    def test_data_is_retained(self):
-        t1, _, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        tree = zipper.to_tree()
-        self.assertEqual(tree, t1)
+    def test_left_right_and_value(self):
 
-    def test_left_and_right_value(self):
-        t1, _, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        self.assertEqual(zipper.left().right().value(), 3)
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().right().value()
+        self.assertEqual(result, 3)
 
     def test_dead_end(self):
-        t1, _, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        self.assertIsNone(zipper.left().left())
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().left()
+        self.assertIsNone(result)
 
     def test_tree_from_deep_focus(self):
-        t1, _, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        self.assertEqual(zipper.left().right().to_tree(), t1)
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().right().to_tree()
+        self.assertEqual(result, expected)
+
+    def test_traversing_up_from_top(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.up()
+        self.assertIsNone(result)
+
+    def test_left_right_and_up(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().up().right().up().left().right().value()
+        self.assertEqual(result, 3)
 
     def test_set_value(self):
-        t1, t2, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_value(5)
-        tree = updatedZipper.to_tree()
-        self.assertEqual(tree, t2)
 
-    def test_set_left_with_value(self):
-        t1, _, t3, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_left(self.leaf(5))
-        tree = updatedZipper.to_tree()
-        self.assertEqual(tree, t3)
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
 
-    def test_set_right_to_none(self):
-        t1, _, _, t4 = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        updatedZipper = zipper.left().set_right(None)
-        tree = updatedZipper.to_tree()
-        self.assertEqual(tree, t4)
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 5,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().set_value(5).to_tree()
+        self.assertEqual(result, expected)
+
+    def test_set_value_after_traversing_up(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 5,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().right().up().set_value(5).to_tree()
+        self.assertEqual(result, expected)
+
+    def test_set_left_with_leaf(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": {"value": 5, "left": None, "right": None},
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = (
+            zipper.left().set_left({"value": 5, "left": None, "right": None}).to_tree()
+        )
+        self.assertEqual(result, expected)
+
+    def test_set_right_with_null(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {"value": 2, "left": None, "right": None},
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().set_right(None).to_tree()
+        self.assertEqual(result, expected)
+
+    def test_set_right_with_subtree(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {
+                "value": 6,
+                "left": {"value": 7, "left": None, "right": None},
+                "right": {"value": 8, "left": None, "right": None},
+            },
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.set_right(
+            {
+                "value": 6,
+                "left": {"value": 7, "left": None, "right": None},
+                "right": {"value": 8, "left": None, "right": None},
+            }
+        ).to_tree()
+        self.assertEqual(result, expected)
+
+    def test_set_value_on_deep_focus(self):
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        expected = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 5, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+
+        zipper = Zipper.from_tree(initial)
+        result = zipper.left().right().set_value(5).to_tree()
+        self.assertEqual(result, expected)
 
     def test_different_paths_to_same_zipper(self):
-        t1, _, _, _ = self.create_trees()
-        zipper = Zipper.from_tree(t1)
-        self.assertEqual(zipper.left().up().right().to_tree(),
-                         zipper.right().to_tree())
+
+        initial = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+        result = Zipper.from_tree(initial).left().up().right().to_tree()
+
+        final = {
+            "value": 1,
+            "left": {
+                "value": 2,
+                "left": None,
+                "right": {"value": 3, "left": None, "right": None},
+            },
+            "right": {"value": 4, "left": None, "right": None},
+        }
+        expected = Zipper.from_tree(final).right().to_tree()
+
+        self.assertEqual(result, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/zipper/zipper_test.py
+++ b/exercises/zipper/zipper_test.py
@@ -7,7 +7,6 @@ from zipper import Zipper
 
 class ZipperTest(unittest.TestCase):
     def test_data_is_retained(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -33,7 +32,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_left_right_and_value(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -49,7 +47,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, 3)
 
     def test_dead_end(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -65,7 +62,6 @@ class ZipperTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_tree_from_deep_focus(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -91,7 +87,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_traversing_up_from_top(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -107,7 +102,6 @@ class ZipperTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_left_right_and_up(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -123,7 +117,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, 3)
 
     def test_set_value(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -149,7 +142,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_set_value_after_traversing_up(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -175,7 +167,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_set_left_with_leaf(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -203,7 +194,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_set_right_with_null(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -225,7 +215,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_set_right_with_subtree(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -261,7 +250,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_set_value_on_deep_focus(self):
-
         initial = {
             "value": 1,
             "left": {
@@ -287,7 +275,6 @@ class ZipperTest(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_different_paths_to_same_zipper(self):
-
         initial = {
             "value": 1,
             "left": {


### PR DESCRIPTION
Adds a test template for `zipper`, removes the need for #2160, which was
going down a much more complicated path. Updates example.py for a minor
change in the canonical data for `Zipper.up()`.

Closes #2005.