### PR TITLE
[sgf-parsing] fix escaped characters

### DIFF
--- a/exercises/sgf-parsing/.meta/template.j2
+++ b/exercises/sgf-parsing/.meta/template.j2
@@ -2,7 +2,7 @@
 
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
-        input_string = '{{ case["input"]["encoded"] }}'
+        input_string = '{{ case["input"]["encoded"] | escape_invalid_escapes }}'
         {% if case["expected"]["error"] -%}
         with self.assertRaisesWithMessage(ValueError):
             {{ case["property"] | to_snake }}(input_string)

--- a/exercises/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/sgf-parsing/sgf_parsing_test.py
@@ -70,7 +70,7 @@ class SgfParsingTest(unittest.TestCase):
         self.assertEqual(parse(input_string), expected)
 
     def test_escaped_property(self):
-        input_string = "(;A[\]b\nc\nd\t\te \n\]])"
+        input_string = "(;A[\\]b\nc\nd\t\te \n\\]])"
         expected = SgfTree(properties={"A": ["]b\nc\nd  e \n]"]})
         self.assertEqual(parse(input_string), expected)
 


### PR DESCRIPTION
Fixes issue with pytest throwing a warning on invalid escapes.

Closes #2176