### PR TITLE
remove m-a-ge from maintainers list

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -22,16 +22,6 @@
       "bio": "I can not only fetch JSON, but parse it too."
     },
     {
-      "github_username": "m-a-ge",
-      "alumnus": false,
-      "show_on_website": false,
-      "name": null,
-      "link_text": null,
-      "link_url": null,
-      "avatar_url": null,
-      "bio": null
-    },
-    {
       "github_username": "cmccandless",
       "alumnus": false,
       "show_on_website": true,


### PR DESCRIPTION
This maintainer seems to have removed himself from @exercism/python, but not from maintainers.json. Furthermore, I believe his GitHub username has changed, so this is now an invalid entry.