### PR TITLE
Add CPython specific test case

### DIFF
--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -20,6 +20,9 @@ class HammingTest(unittest.TestCase):
 
     def test_long_different_strands(self):
         self.assertEqual(distance("GGACGGATTCTG", "AGGACGGATTCT"), 9)
+    
+    def test_very_long_different_strands(self):
+        self.assertEqual(distance("A" * 300 + "TT", "A" * 300 + "GG"), 2)
 
     def test_disallow_first_strand_longer(self):
         with self.assertRaisesWithMessage(ValueError):


### PR DESCRIPTION
I saw that some students use `is not` for comparing that have different length.
This actually works for strings smaller than 257 symbols, so they don't catch that error

By offloading this case to test case, then can learn about it offline.