### PR TITLE
diffie-hellman: add test template 

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -59,20 +59,16 @@ def replace_all(string, chars, rep):
     )
 
 
-def to_snake_base(string):
-    """
-    Converts string to to_snake.
-    """
-    clean = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", clean).lower()
-
-
-def to_snake(string):
+def to_snake(string, wordchars_only=False):
     """
     Convert pretty much anything to to_snake.
+
+    By default whitespace and punctuation will be converted
+    to underscores as well, pass wordchars_only=True to preserve these as is.
     """
-    clean = to_snake_base(string)
-    return replace_all(clean, whitespace + punctuation, "_")
+    clean = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
+    clean = re.sub("([a-z0-9])([A-Z])", r"\1_\2", clean).lower()
+    return clean if wordchars_only else replace_all(clean, whitespace + punctuation, "_")
 
 
 def camel_case(string):
@@ -332,7 +328,6 @@ def generate(
     loader = FileSystemLoader(["config", "exercises"])
     env = Environment(loader=loader, keep_trailing_newline=True)
     env.filters["to_snake"] = to_snake
-    env.filters["to_snake_base"] = to_snake_base
     env.filters["camel_case"] = camel_case
     env.filters["wrap_overlong"] = wrap_overlong
     env.filters["regex_replace"] = regex_replace

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -59,12 +59,19 @@ def replace_all(string, chars, rep):
     )
 
 
+def to_snake_base(string):
+    """
+    Converts string to to_snake.
+    """
+    clean = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", clean).lower()
+
+
 def to_snake(string):
     """
     Convert pretty much anything to to_snake.
     """
-    clean = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
-    clean = re.sub("([a-z0-9])([A-Z])", r"\1_\2", clean).lower()
+    clean = to_snake_base(string)
     return replace_all(clean, whitespace + punctuation, "_")
 
 
@@ -325,6 +332,7 @@ def generate(
     loader = FileSystemLoader(["config", "exercises"])
     env = Environment(loader=loader, keep_trailing_newline=True)
     env.filters["to_snake"] = to_snake
+    env.filters["to_snake_base"] = to_snake_base
     env.filters["camel_case"] = camel_case
     env.filters["wrap_overlong"] = wrap_overlong
     env.filters["regex_replace"] = regex_replace

--- a/exercises/diffie-hellman/.meta/template.j2
+++ b/exercises/diffie-hellman/.meta/template.j2
@@ -23,9 +23,9 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% elif property == "key_exchange"%}
     def test_{{ description }}(self):
         {% for key, val in input.items() -%}
-            {{ key | to_snake }} = {{ val  | string | to_snake_base }}
+            {{ key | to_snake }} = {{ val | string | to_snake(wordchars_only=True) }}
         {% endfor -%}
-        self.assertTrue({{ expected | to_snake_base }})
+        self.assertTrue({{ expected | to_snake(wordchars_only=True) }})
     {%  else %}
     def test_{{ description }}(self):
         self.assertEqual({{ expected }}, {{ property }}(*{{ input.values() | list }} ))

--- a/exercises/diffie-hellman/.meta/template.j2
+++ b/exercises/diffie-hellman/.meta/template.j2
@@ -14,8 +14,10 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         for p in primes:
             self.assertTrue(p < private_key(p) < p)
     {%- elif property == "private_key_is_random" %}
-        # Can fail due to randomness, but most likely will not,
-        # due to pseudo-randomness and the large number chosen
+        """
+        Can fail due to randomness, but most likely will not,
+        due to pseudo-randomness and the large number chosen
+        """
         p = 2147483647
         private_keys = [private_key(p) for _ in range(5)]
         self.assertEqual(len(set(private_keys)), len(private_keys))

--- a/exercises/diffie-hellman/.meta/template.j2
+++ b/exercises/diffie-hellman/.meta/template.j2
@@ -1,0 +1,35 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{% set class = exercise | camel_case -%}
+{{ macros.header(["private_key", "public_key", "secret"]) }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    {% for case in cases -%}
+    {% set property = case["property"] | to_snake -%}
+    {% set description = case["description"] | to_snake -%}
+    {% set expected = case['expected'] %}
+    {% set input = case['input'] %}
+    {% if property == "private_key_is_in_range" -%}
+    def test_{{ description }}(self):
+        primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
+        for i in primes:
+            self.assertTrue(1 < private_key(i) < i)
+    {% elif property == "private_key_is_random" -%}
+    def test_{{ description }}(self):
+        p = 2147483647
+        private_keys = []
+        for i in range(5):
+            private_keys.append(private_key(p))
+        self.assertEqual(len(set(private_keys)), len(private_keys))
+    {% elif property == "key_exchange"%}
+    def test_{{ description }}(self):
+        {% for key, val in input.items() -%}
+            {{ key | to_snake }} = {{ val  | string | to_snake_base }}
+        {% endfor -%}
+        self.assertTrue({{ expected | to_snake_base }})
+    {%  else %}
+    def test_{{ description }}(self):
+        self.assertEqual({{ expected }}, {{ property }}(*{{ input.values() | list }} ))
+    {%- endif -%}
+    {% endfor %}
+
+{{ macros.footer() }}

--- a/exercises/diffie-hellman/.meta/template.j2
+++ b/exercises/diffie-hellman/.meta/template.j2
@@ -8,27 +8,27 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% set description = case["description"] | to_snake -%}
     {% set expected = case['expected'] %}
     {% set input = case['input'] %}
-    {% if property == "private_key_is_in_range" -%}
     def test_{{ description }}(self):
+    {%- if property == "private_key_is_in_range" %}
         primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
-        for i in primes:
-            self.assertTrue(1 < private_key(i) < i)
-    {% elif property == "private_key_is_random" -%}
-    def test_{{ description }}(self):
+        for p in primes:
+            self.assertTrue(p < private_key(p) < p)
+    {%- elif property == "private_key_is_random" %}
+        # Can fail due to randomness, but most likely will not,
+        # due to pseudo-randomness and the large number chosen
         p = 2147483647
-        private_keys = []
-        for i in range(5):
-            private_keys.append(private_key(p))
+        private_keys = [private_key(p) for _ in range(5)]
         self.assertEqual(len(set(private_keys)), len(private_keys))
-    {% elif property == "key_exchange"%}
-    def test_{{ description }}(self):
+    {%- elif property == "key_exchange" %}
         {% for key, val in input.items() -%}
             {{ key | to_snake }} = {{ val | string | to_snake(wordchars_only=True) }}
         {% endfor -%}
         self.assertTrue({{ expected | to_snake(wordchars_only=True) }})
-    {%  else %}
-    def test_{{ description }}(self):
-        self.assertEqual({{ expected }}, {{ property }}(*{{ input.values() | list }} ))
+    {%-  else %}
+        {% for key, val in input.items() -%}
+            {{ key | to_snake }} = {{ val }}
+        {% endfor -%}
+        self.assertEqual({{ expected }}, {{ property }}({% for key in input.keys() %}{{ key | to_snake }},{% endfor %}))
     {%- endif -%}
     {% endfor %}
 

--- a/exercises/diffie-hellman/.meta/template.j2
+++ b/exercises/diffie-hellman/.meta/template.j2
@@ -12,7 +12,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- if property == "private_key_is_in_range" %}
         primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
         for p in primes:
-            self.assertTrue(p < private_key(p) < p)
+            self.assertTrue(1 < private_key(p) < p)
     {%- elif property == "private_key_is_random" %}
         """
         Can fail due to randomness, but most likely will not,

--- a/exercises/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/diffie-hellman/diffie_hellman_test.py
@@ -1,56 +1,40 @@
 import unittest
 
-import diffie_hellman
-
+from diffie_hellman import private_key, public_key, secret
 
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.0.0
 
-class DiffieHellmanTest(unittest.TestCase):
 
-    def test_private_key_is_in_range(self):
+class DiffieHellmanTest(unittest.TestCase):
+    def test_private_key_is_in_range_1_p(self):
         primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
         for i in primes:
-            self.assertTrue(1 < diffie_hellman.private_key(i) < i)
+            self.assertTrue(1 < private_key(i) < i)
 
-    # Can fail due to randomness, but most likely will not,
-    # due to pseudo-randomness and the large number chosen
     def test_private_key_is_random(self):
         p = 2147483647
         private_keys = []
         for i in range(5):
-            private_keys.append(diffie_hellman.private_key(p))
+            private_keys.append(private_key(p))
         self.assertEqual(len(set(private_keys)), len(private_keys))
 
     def test_can_calculate_public_key_using_private_key(self):
-        p = 23
-        g = 5
-        private = 6
-        expected = 8
-
-        actual = diffie_hellman.public_key(p, g, private)
-        self.assertEqual(actual, expected)
+        self.assertEqual(8, public_key(*[23, 5, 6]))
 
     def test_can_calculate_secret_using_other_party_s_public_key(self):
-        p = 23
-        public = 19
-        private = 6
-        expected = 2
-
-        actual = diffie_hellman.secret(p, public, private)
-        self.assertEqual(actual, expected)
+        self.assertEqual(2, secret(*[23, 19, 6]))
 
     def test_key_exchange(self):
         p = 23
         g = 5
-        alice_private_key = diffie_hellman.private_key(p)
-        bob_private_key = diffie_hellman.private_key(p)
-        alice_public_key = diffie_hellman.public_key(p, g, alice_private_key)
-        bob_public_key = diffie_hellman.public_key(p, g, bob_private_key)
-        secret_a = diffie_hellman.secret(p, bob_public_key, alice_private_key)
-        secret_b = diffie_hellman.secret(p, alice_public_key, bob_private_key)
+        alice_private_key = private_key(p)
+        bob_private_key = private_key(p)
+        alice_public_key = public_key(p, g, alice_private_key)
+        bob_public_key = public_key(p, g, bob_private_key)
+        secret_a = secret(p, bob_public_key, alice_private_key)
+        secret_b = secret(p, alice_public_key, bob_private_key)
+        self.assertTrue(secret_a == secret_b)
 
-        self.assertEqual(secret_a, secret_b)
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/exercises/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/diffie-hellman/diffie_hellman_test.py
@@ -9,7 +9,7 @@ class DiffieHellmanTest(unittest.TestCase):
     def test_private_key_is_in_range_1_p(self):
         primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
         for p in primes:
-            self.assertTrue(p < private_key(p) < p)
+            self.assertTrue(1 < private_key(p) < p)
 
     def test_private_key_is_random(self):
         """

--- a/exercises/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/diffie-hellman/diffie_hellman_test.py
@@ -12,8 +12,10 @@ class DiffieHellmanTest(unittest.TestCase):
             self.assertTrue(p < private_key(p) < p)
 
     def test_private_key_is_random(self):
-        # Can fail due to randomness, but most likely will not,
-        # due to pseudo-randomness and the large number chosen
+        """
+        Can fail due to randomness, but most likely will not,
+        due to pseudo-randomness and the large number chosen
+        """
         p = 2147483647
         private_keys = [private_key(p) for _ in range(5)]
         self.assertEqual(len(set(private_keys)), len(private_keys))

--- a/exercises/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/diffie-hellman/diffie_hellman_test.py
@@ -8,21 +8,27 @@ from diffie_hellman import private_key, public_key, secret
 class DiffieHellmanTest(unittest.TestCase):
     def test_private_key_is_in_range_1_p(self):
         primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
-        for i in primes:
-            self.assertTrue(1 < private_key(i) < i)
+        for p in primes:
+            self.assertTrue(p < private_key(p) < p)
 
     def test_private_key_is_random(self):
+        # Can fail due to randomness, but most likely will not,
+        # due to pseudo-randomness and the large number chosen
         p = 2147483647
-        private_keys = []
-        for i in range(5):
-            private_keys.append(private_key(p))
+        private_keys = [private_key(p) for _ in range(5)]
         self.assertEqual(len(set(private_keys)), len(private_keys))
 
     def test_can_calculate_public_key_using_private_key(self):
-        self.assertEqual(8, public_key(*[23, 5, 6]))
+        p = 23
+        g = 5
+        private_key = 6
+        self.assertEqual(8, public_key(p, g, private_key))
 
     def test_can_calculate_secret_using_other_party_s_public_key(self):
-        self.assertEqual(2, secret(*[23, 19, 6]))
+        p = 23
+        their_public_key = 19
+        my_private_key = 6
+        self.assertEqual(2, secret(p, their_public_key, my_private_key))
 
     def test_key_exchange(self):
         p = 23


### PR DESCRIPTION
 -Add jinja2 test template for Diffie Hellman exercise #1944 
- Split `to_snake` into two functions (`to_snake_base` and `to_snake`)
- Register `to_snake_base` jinja2 macro
- Generate new test template
