### PR TITLE
Added test case with an integer at two fer exercise

### DIFF
--- a/exercises/two-fer/two_fer_test.py
+++ b/exercises/two-fer/two_fer_test.py
@@ -14,6 +14,9 @@ class TwoFerTest(unittest.TestCase):
 
     def test_another_name_given(self):
         self.assertEqual(two_fer("Bob"), "One for Bob, one for me.")
+    
+    def test_an_integer_given(self):
+        self.assertEqual(two_fer(7), "One for 7, one for me.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, I am a mentor of python track. I often see people trying to concatenate strings like this:

```python
return "One for " + name + ", one for me."
```

But this causes the function to malfunction if argument is an integer. So, I added a test which will check if the function rewritten by user is able to work with integer.