### PR TITLE
Marking `error-handling` Side Exercise Deprecated

### DIFF
--- a/config.json
+++ b/config.json
@@ -1284,7 +1284,8 @@
       "difficulty": 3,
       "topics": [
         "exception_handling"
-      ]
+      ], 
+      "deprecated": true
     },
     {
       "slug": "dominoes",

--- a/config.json
+++ b/config.json
@@ -1282,9 +1282,7 @@
       "core": false,
       "unlocked_by": "hamming",
       "difficulty": 3,
-      "topics": [
-        "exception_handling"
-      ], 
+      "topics": null, 
       "deprecated": true
     },
     {

--- a/config.json
+++ b/config.json
@@ -1282,7 +1282,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 0,
-      "topics": null, 
+      "topics": null,
       "deprecated": true
     },
     {

--- a/config.json
+++ b/config.json
@@ -1280,8 +1280,8 @@
       "slug": "error-handling",
       "uuid": "0dac0feb-e1c8-497e-9a1b-e96e0523eea6",
       "core": false,
-      "unlocked_by": "hamming",
-      "difficulty": 3,
+      "unlocked_by": null,
+      "difficulty": 0,
       "topics": null, 
       "deprecated": true
     },


### PR DESCRIPTION
Per discussions on [issue 1780](https://github.com/exercism/python/issues/1780), the `error-handling` exercise probably needs a full re-write.  Until that can be completed, we're deprecating the exercise for the Python track.