### PR TITLE
Updated concept exercise status for current concept exercises.

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
         "uuid": "7ecd42c1-2ed5-487a-bc89-71c9cbad9b05",
         "concepts": ["tuples"],
         "prerequisites": ["bools", "loops", "conditionals", "numbers"],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "guidos-gorgeous-lasagna",
@@ -46,7 +46,7 @@
         "uuid": "c050470d-ef22-4187-aaac-239e07955a4d",
         "concepts": ["bools"],
         "prerequisites": ["basics"],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "pretty-leaflet",
@@ -132,7 +132,7 @@
         "uuid": "09c322bc-5c04-480b-8441-fd9ef5c7a3b4",
         "concepts": ["string-methods"],
         "prerequisites": ["basics", "strings"],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "currency-exchange",


### PR DESCRIPTION
**Supersedes**  #2313   Updated our current concept exercises with `status`. While all of these are still pending implementation tests, I felt as though some of them were close enough to done to be flagged `beta`. This will be updated again as we complete more exercises:

"name": "Processing Logs", ("strings")
"status": "wip"

"name": "Tisbury Treasure Hunt" ("tuples")
"status": "beta"

"name": "Guido's Gorgeous Lasagna" ("basics")
"status": "beta"

"name": "Ghost Gobble Arcade Game" ("bools")
"status": "beta"

"name": "Pretty Leaflet"("string-formatting")
"status": "wip"

"name": "Inventory Management"("dicts")
"status": "wip"

"name": "Log Levels"("enums")
"status": "wip"

"name": "Elyse's Enchantments"("lists")
"status": "wip"

"name": "Chaitana's Colossal Coaster"("list-methods")
"status": "wip"

"name": "Restaurant Rozalynn"("none")
"status": "wip"

"name": "Making the Grade" ("loops")
"status": "wip"

"name": "Little Sister's Essay", ("string-methods")
"status": "beta"

"name": "Currency Exchange" ("numbers")
"status": "wip"