### PR TITLE
use pytest in CI script

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -65,6 +65,9 @@ jobs:
       if: ${{ matrix.python-version == '3.6' }}
       run: pip install dataclasses
 
+    - name: Install pytest
+      run: pip install pytest
+
     - name: Check exercises
       run: |
         ./bin/test_exercises.py

--- a/bin/test_exercises.py
+++ b/bin/test_exercises.py
@@ -53,7 +53,7 @@ def main():
             failures.append('{} (FileNotFound)'.format(exercise.slug))
         else:
             if check_assignment(exercise):
-                failures.append('{} (TestFailed)'.format(exercise))
+                failures.append('{} (TestFailed)'.format(exercise.slug))
         print('')
 
     print('TestEnvironment:', sys.executable.capitalize(), '\n\n')

--- a/bin/test_exercises.py
+++ b/bin/test_exercises.py
@@ -31,7 +31,7 @@ def check_assignment(exercise: ExerciseInfo, quiet=False) -> int:
         if quiet:
             kwargs['stdout'] = subprocess.DEVNULL
             kwargs['stderr'] = subprocess.DEVNULL
-        return subprocess.run([sys.executable, test_file_out], **kwargs).returncode
+        return subprocess.run([sys.executable, '-m', 'pytest', test_file_out], **kwargs).returncode
     finally:
         shutil.rmtree(workdir)
 

--- a/exercises/concept/currency-exchange/.meta/config.json
+++ b/exercises/concept/currency-exchange/.meta/config.json
@@ -22,8 +22,8 @@
     }
   ],
   "files": {
-    "solution": ["numbers.py"],
-    "test": ["numbers_test.py"],
+    "solution": ["exchange.py"],
+    "test": ["exchange_test.py"],
     "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -2,7 +2,7 @@ def estimate_value(budget, exchange_rate):
 	return budget / exchange_rate
 
 
-def get_changes(budget, exchanging_value):
+def get_change(budget, exchanging_value):
 	return budget - exchanging_value
 
 

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -16,7 +16,7 @@ def get_number_of_bills(budget, denomination):
 
 def exchangeable_value(budget, exchange_rate, spread, minimum_denomination):
     pass
-  
-  
+
+
 def unexchangeable_value(budget, exchange_rate, spread, denomination):
     pass

--- a/exercises/concept/currency-exchange/exchange_test.py
+++ b/exercises/concept/currency-exchange/exchange_test.py
@@ -1,9 +1,9 @@
 import unittest
-from numbers import *
+from exchange import *
 
 
 class TestNumbers(unittest.TestCase):
-    
+
     # Problem 1
     def test_estimate_value(self):
         input_data = [
@@ -68,7 +68,7 @@ class TestNumbers(unittest.TestCase):
         for input, output in zip(input_data, output_data):
             with self.subTest(input=input, output=output):
                 self.assertEqual(exchangeable_value(input[0], input[1], input[2], input[3]), output)
-        
+
     # Problem 6
     def test_unexchangeable_value(self):
 
@@ -87,5 +87,3 @@ class TestNumbers(unittest.TestCase):
         for input, output in zip(input_data, output_data):
             with self.subTest(input=input, output=output):
                 self.assertEqual(unexchangeable_value(input[0], input[1], input[2], input[3]), output)
-
-    

--- a/exercises/concept/making-the-grade/.meta/exemplar.py
+++ b/exercises/concept/making-the-grade/.meta/exemplar.py
@@ -5,17 +5,17 @@ def count_failed_students(student_marks):
             failed_marks += 1
     return failed_marks
 
-def above_threshold(student_marks, threshold):
+def above_threshold(student_marks, x):
     above_marks = []
     for mark in student_marks:
-        if mark >= threshold:
+        if mark >= x:
             above_marks.append(mark)
     return above_marks
 
 def first_k_student_marks(student_marks, k):
     i = 0
     marks = []
-    while i <= k:
+    while i < k:
         marks.append(student_marks[i])
         i += 1
     return marks
@@ -25,4 +25,4 @@ def perfect_score(student_info):
         if mark == 100:
             return name
     else:
-        return "No hundreds"
+        return "No Centums"

--- a/exercises/concept/making-the-grade/.meta/exemplar.py
+++ b/exercises/concept/making-the-grade/.meta/exemplar.py
@@ -2,15 +2,14 @@ def count_failed_students(student_marks):
     failed_marks = 0
     for mark in student_marks:
         if mark <=40:
-            failed_marks +=1
+            failed_marks += 1
     return failed_marks
 
-def above_threshold(student_marks, x):
+def above_threshold(student_marks, threshold):
     above_marks = []
     for mark in student_marks:
-        if mark < x:
-            continue
-        above_marks.append(mark)
+        if mark >= threshold:
+            above_marks.append(mark)
     return above_marks
 
 def first_k_student_marks(student_marks, k):
@@ -18,6 +17,7 @@ def first_k_student_marks(student_marks, k):
     marks = []
     while i <= k:
         marks.append(student_marks[i])
+        i += 1
     return marks
 
 def perfect_score(student_info):


### PR DESCRIPTION
Certain exercises were missing the `unittest.main` footer, preventing their tests from running in CI. As much of our tooling depends on pytest anyway, this PR changes the script to invoke pytest from the current Python executable. Will fail if pytest not installed for that Python version.