### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/bin/data.py
+++ b/bin/data.py
@@ -194,6 +194,14 @@ class Feature:
 
 
 @dataclass
+class FilePatterns:
+    solution: List[str]
+    test: List[str]
+    example: List[str]
+    exemplar: List[str]
+
+
+@dataclass
 class Config:
     language: str
     slug: str
@@ -206,6 +214,7 @@ class Config:
     concepts: List[Concept]
     key_features: List[Feature] = None
     tags: List[Any] = None
+    files: FilePatterns = None
 
     def __post_init__(self):
         if isinstance(self.status, dict):
@@ -214,6 +223,8 @@ class Config:
             self.online_editor = EditorSettings(**self.online_editor)
         if isinstance(self.exercises, dict):
             self.exercises = Exercises(**self.exercises)
+        if isinstance(self.files, dict):
+            self.files = FilePatterns(**self.files)
         self.concepts = [
             (Concept(**c) if isinstance(c, dict) else c) for c in self.concepts
         ]

--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
     "indent_style": "space",
     "indent_size": 4
   },
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [
       {

--- a/config.json
+++ b/config.json
@@ -16,16 +16,16 @@
   },
   "files": {
     "solution": [
-      "path/to/%{kebab_slug}.ext"
+      "%{snake_slug}.py"
     ],
     "test": [
-      "path/to/%{kebab_slug}.ext"
+      "%{snake_slug}_test.py"
     ],
     "example": [
-      "path/to/%{kebab_slug}.ext"
+      ".meta/example.py"
     ],
     "exemplar": [
-      "path/to/%{kebab_slug}.ext"
+      ".meta/exemplar.py"
     ]
   },
   "exercises": {


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
