### PR TITLE
secret-handshake: make input a binary string instead of integer

### DIFF
--- a/exercises/practice/secret-handshake/.docs/instructions.append.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.append.md
@@ -1,0 +1,6 @@
+To keep things simple (and to let you focus on the important part of this exercise), your function will receive its inputs as binary strings:
+
+```
+>>> commands("00011")
+["wink", "double blink"]
+```

--- a/exercises/practice/secret-handshake/.meta/example.py
+++ b/exercises/practice/secret-handshake/.meta/example.py
@@ -1,7 +1,7 @@
-gestures = ['wink', 'double blink', 'close your eyes', 'jump']
+gestures = ["jump", "close your eyes", "double blink", "wink"]
 
 
-def commands(number):
-    actions = [gestures[i] for i in range(len(gestures))
-               if (number >> i) % 2 == 1]
-    return actions if number < 16 else list(reversed(actions))
+def commands(binary_str):
+    reverse, *bits = [digit == "1" for digit in binary_str]
+    actions = [gesture for gesture, bit in zip(gestures, bits) if bit]
+    return actions if reverse else actions[::-1]

--- a/exercises/practice/secret-handshake/.meta/plugins.py
+++ b/exercises/practice/secret-handshake/.meta/plugins.py
@@ -1,0 +1,2 @@
+def to_binary(num, digits=5):
+    return bin(num)[2:].zfill(digits)

--- a/exercises/practice/secret-handshake/.meta/template.j2
+++ b/exercises/practice/secret-handshake/.meta/template.j2
@@ -5,7 +5,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases -%}
     {% for case in supercase["cases"] -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{ case["property"] }}({{ case["input"]["number"] }}), {{ case["expected"] }})
+        self.assertEqual({{ case["property"] }}("{{ plugins.to_binary(case["input"]["number"]) }}"), {{ case["expected"] }})
     {% endfor %}
     {% endfor %}
 

--- a/exercises/practice/secret-handshake/secret_handshake.py
+++ b/exercises/practice/secret-handshake/secret_handshake.py
@@ -1,2 +1,2 @@
-def commands(number):
+def commands(binary_str):
     pass

--- a/exercises/practice/secret-handshake/secret_handshake_test.py
+++ b/exercises/practice/secret-handshake/secret_handshake_test.py
@@ -9,41 +9,41 @@ from secret_handshake import (
 
 class SecretHandshakeTest(unittest.TestCase):
     def test_wink_for_1(self):
-        self.assertEqual(commands(1), ["wink"])
+        self.assertEqual(commands("00001"), ["wink"])
 
     def test_double_blink_for_10(self):
-        self.assertEqual(commands(2), ["double blink"])
+        self.assertEqual(commands("00010"), ["double blink"])
 
     def test_close_your_eyes_for_100(self):
-        self.assertEqual(commands(4), ["close your eyes"])
+        self.assertEqual(commands("00100"), ["close your eyes"])
 
     def test_jump_for_1000(self):
-        self.assertEqual(commands(8), ["jump"])
+        self.assertEqual(commands("01000"), ["jump"])
 
     def test_combine_two_actions(self):
-        self.assertEqual(commands(3), ["wink", "double blink"])
+        self.assertEqual(commands("00011"), ["wink", "double blink"])
 
     def test_reverse_two_actions(self):
-        self.assertEqual(commands(19), ["double blink", "wink"])
+        self.assertEqual(commands("10011"), ["double blink", "wink"])
 
     def test_reversing_one_action_gives_the_same_action(self):
-        self.assertEqual(commands(24), ["jump"])
+        self.assertEqual(commands("11000"), ["jump"])
 
     def test_reversing_no_actions_still_gives_no_actions(self):
-        self.assertEqual(commands(16), [])
+        self.assertEqual(commands("10000"), [])
 
     def test_all_possible_actions(self):
         self.assertEqual(
-            commands(15), ["wink", "double blink", "close your eyes", "jump"]
+            commands("01111"), ["wink", "double blink", "close your eyes", "jump"]
         )
 
     def test_reverse_all_possible_actions(self):
         self.assertEqual(
-            commands(31), ["jump", "close your eyes", "double blink", "wink"]
+            commands("11111"), ["jump", "close your eyes", "double blink", "wink"]
         )
 
     def test_do_nothing_for_zero(self):
-        self.assertEqual(commands(0), [])
+        self.assertEqual(commands("00000"), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #2380 