### PR TITLE
Corrected JSON formatting error.

### DIFF
--- a/concepts/numbers/links.json
+++ b/concepts/numbers/links.json
@@ -32,7 +32,7 @@
     "description": "cmath:  mathematical operations for complex numbers"
   },
   {
-    "URL": "https://docs.python.org/3/library/numeric.html",
+    "url": "https://docs.python.org/3/library/numeric.html",
     "description": "Pythons Numerical and Mathematical Modules"
   }
 ]


### PR DESCRIPTION
`URL` --> `url`. 
Python had a configlet linting error :  `Invalid capitalization of the url key:`, as referenced in https://github.com/exercism/configlet/pull/171.  
This fixes that error.