### PR TITLE
.meta and config.json Stubs for Concepts

### DIFF
--- a/concepts/aliasing/.meta/config.json
+++ b/concepts/aliasing/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/anonymous-functions/.meta/config.json
+++ b/concepts/anonymous-functions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/basics/.meta/config.json
+++ b/concepts/basics/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/binary-data/.meta/config.json
+++ b/concepts/binary-data/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/bitflags/.meta/config.json
+++ b/concepts/bitflags/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/bitwise-operators/.meta/config.json
+++ b/concepts/bitwise-operators/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/bools/.meta/config.json
+++ b/concepts/bools/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/bytes/.meta/config.json
+++ b/concepts/bytes/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/class-composition/.meta/config.json
+++ b/concepts/class-composition/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/class-customization/.meta/config.json
+++ b/concepts/class-customization/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/class-inheritance/.meta/config.json
+++ b/concepts/class-inheritance/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/class-interfaces/.meta/config.json
+++ b/concepts/class-interfaces/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/classes/.meta/config.json
+++ b/concepts/classes/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/collections/.meta/config.json
+++ b/concepts/collections/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/comparisons/.meta/config.json
+++ b/concepts/comparisons/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/complex-numbers/.meta/config.json
+++ b/concepts/complex-numbers/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/conditionals/.meta/config.json
+++ b/concepts/conditionals/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/context-manager-customization/.meta/config.json
+++ b/concepts/context-manager-customization/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/dataclasses-and-namedtuples/.meta/config.json
+++ b/concepts/dataclasses-and-namedtuples/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/decorators/.meta/config.json
+++ b/concepts/decorators/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/descriptors/.meta/config.json
+++ b/concepts/descriptors/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/dict-methods/.meta/config.json
+++ b/concepts/dict-methods/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/dicts/.meta/config.json
+++ b/concepts/dicts/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/enums/.meta/config.json
+++ b/concepts/enums/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/function-arguments/.meta/config.json
+++ b/concepts/function-arguments/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/functional-tools/.meta/config.json
+++ b/concepts/functional-tools/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/functions/.meta/config.json
+++ b/concepts/functions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/functools/.meta/config.json
+++ b/concepts/functools/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/generator-expressions/.meta/config.json
+++ b/concepts/generator-expressions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/generators/.meta/config.json
+++ b/concepts/generators/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/higher-order-functions/.meta/config.json
+++ b/concepts/higher-order-functions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/iteration/.meta/config.json
+++ b/concepts/iteration/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/iterators/.meta/config.json
+++ b/concepts/iterators/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/itertools/.meta/config.json
+++ b/concepts/itertools/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/list-comprehensions/.meta/config.json
+++ b/concepts/list-comprehensions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/list-methods/.meta/config.json
+++ b/concepts/list-methods/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/lists/.meta/config.json
+++ b/concepts/lists/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/loops/.meta/config.json
+++ b/concepts/loops/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/memoryview/.meta/config.json
+++ b/concepts/memoryview/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/none/.meta/config.json
+++ b/concepts/none/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/number-variations/.meta/config.json
+++ b/concepts/number-variations/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/numbers/.meta/config.json
+++ b/concepts/numbers/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/operator-overloading/.meta/config.json
+++ b/concepts/operator-overloading/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/other-comprehensions/.meta/config.json
+++ b/concepts/other-comprehensions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/raising-and-handling-errors/.meta/config.json
+++ b/concepts/raising-and-handling-errors/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/regular-expressions/.meta/config.json
+++ b/concepts/regular-expressions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/rich-comparisons/.meta/config.json
+++ b/concepts/rich-comparisons/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/sequences/.meta/config.json
+++ b/concepts/sequences/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/sets/.meta/config.json
+++ b/concepts/sets/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/string-formatting/.meta/config.json
+++ b/concepts/string-formatting/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/string-methods-splitting/.meta/config.json
+++ b/concepts/string-methods-splitting/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/string-methods/.meta/config.json
+++ b/concepts/string-methods/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/strings/.meta/config.json
+++ b/concepts/strings/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/testing/.meta/config.json
+++ b/concepts/testing/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/text-processing/.meta/config.json
+++ b/concepts/text-processing/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/tuples/.meta/config.json
+++ b/concepts/tuples/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/type-hinting/.meta/config.json
+++ b/concepts/type-hinting/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/unicode-regular-expressions/.meta/config.json
+++ b/concepts/unicode-regular-expressions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/unpacking-and-multiple-assignment/.meta/config.json
+++ b/concepts/unpacking-and-multiple-assignment/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/user-defined-errors/.meta/config.json
+++ b/concepts/user-defined-errors/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/walrus-operator/.meta/config.json
+++ b/concepts/walrus-operator/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/with-statement/.meta/config.json
+++ b/concepts/with-statement/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for this concept",
+  "authors": [],
+  "contributors": []
+}


### PR DESCRIPTION
Added `/.meta` directory and a `config.json` stub for each currently identified concept.
Updates with authors and contributors to follow.