### PR TITLE
Added concept blurbs and authors for existing concept exercises.

### DIFF
--- a/concepts/basics/.meta/config.json
+++ b/concepts/basics/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "Python is a dynamic and strongly typed object-oriented programming language. It employs both duck typing and gradual typing (via type hints). Variables can be bound and re-bound to any data type and are resolved at run-time. Python uses significant indentation (similar to Haskell) for code blocks and puts strong emphasis on code readability.",
+  "authors": ["BethanyG"],
+  "contributors": ["cmccandless"]
 }

--- a/concepts/bools/.meta/config.json
+++ b/concepts/bools/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "Python represents true and false values with the 'bool' type. There are only two values: 'True' and 'False'. These values can be bound to a variable, used in comparisons, or returned from a function.  Bools are a subclass of 'int'.",
+  "authors": ["neenjaw"],
+  "contributors": ["cmccandless", "BethanyG"]
 }

--- a/concepts/dicts/.meta/config.json
+++ b/concepts/dicts/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "A dictionary (\"dict\") is a data structure that associates hashable keys to values -- known in other programming languages as a hash table or hashmap. Like most collections, dicts can hold reference to any/multiple data type(s) -- including other dictionaries. \"dicts\" enable the retrieval of a value in constant time, given the key.",
+  "authors": ["j08k"],
+  "contributors": ["valentin-p", "bethanyG"]
 }

--- a/concepts/enums/.meta/config.json
+++ b/concepts/enums/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "An enum is a set of unique names that are bound to unique, *constant* values and thereafter are immutable. Enums are defined by inheriting an \"Enum\" class. Built-in enum types are available in the module \"enum\" and the class \"Enum\" can be imported using \"from enum import Enum\" syntax.",
+  "authors": ["mohanrajanr", "BethanyG"],
+  "contributors": ["valentin-p"]
 }

--- a/concepts/list-methods/.meta/config.json
+++ b/concepts/list-methods/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "The list class has many useful methods for working with lists like \".append(), .insert(), .remove(), .reverse(), and .sort(). Additionally, lists support all common sequence operations as well as mutable sequence operations. They can be iterated over using \"for item in <list>\" syntax, and copied via slice notation or by calling .copy().",
+  "authors": ["mohanrajanr", "BethanyG"],
+  "contributors": ["valentin-p"]
 }

--- a/concepts/lists/.meta/config.json
+++ b/concepts/lists/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
+  "blurb": "A list is a mutable collection of items in a sequence. Like most collections, lists can hold any/multiple data type(s) -- including other lists. Lists support all common sequence operations as well as mutable sequence operations like \".append()\" and \".reverse()\". They can be iterated over using the \"for item in <list>\" syntax.",
+  "authors": ["BethanyG"],
   "contributors": []
 }

--- a/concepts/none/.meta/config.json
+++ b/concepts/none/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
+  "blurb": "None is a singleton object frequently used to represent the *absence* of a value -- a placeholder to define a nil (empty, undefined, or null) variable, object, or argument. This \"placeholder\" can then be replaced by specific values or types later as needed.  None is also automatically returned from functions that do not have a return specified.",
+  "authors": ["mohanrajanr", "BethanyG"],
   "contributors": []
 }

--- a/concepts/numbers/.meta/config.json
+++ b/concepts/numbers/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "There are three different types of built-in numbers: integers (\"int\"), floating-point (\"float\"), and complex (\"complex\"). Ints have arbitrary precision and floats typically have 15 decimal places of precision -- but both Int and float precision vary by host system. Complex numbers have a real and an imaginary part - each represented by floats.",
+  "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007"],
+  "contributors": ["BethanyG"]
 }

--- a/concepts/string-formatting/.meta/config.json
+++ b/concepts/string-formatting/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "Surprisingly, there are four \"main\" string formats.  A \"%\" formatting mini-language is supported \n directly and through \".format()\", but is considered \"old\". String interpolation is newer, and can be used for complex or conditional substitution. \"string.template()\" substitution is used for internationalization - where \"f-strings\" won't translate.",
+  "authors": ["valentin-p"],
+  "contributors": ["j08k", "BethanyG"]
 }

--- a/concepts/string-methods/.meta/config.json
+++ b/concepts/string-methods/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "The str class provides many useful methods that can be used to manipulate str types. These methods can be used for cleaning, splitting, translating, or otherwise working with any str object. Because str are immutable, any functions or methods that operate on a  str will return a new instance or copy of that str, instead of modifying the original.",
+  "authors": ["kimolivia"],
+  "contributors": [ "valentin-p", "bethanyg"]
 }

--- a/concepts/strings/.meta/config.json
+++ b/concepts/strings/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
-  "contributors": []
+  "blurb": "A  string (\"str\") is an immutable sequence of unicode code points. There is no separate \"character\" or \"rune\" type. Slicing copying, or concatenating will produce a new string.  Like any sequence, code points within a \"str\" can be referenced by 0-based index number and can be iterated over in a loop by using the \"for item in <str>\" construct.",
+  "authors": ["aldraco"],
+  "contributors": ["BethanyG"]
 }

--- a/concepts/tuples/.meta/config.json
+++ b/concepts/tuples/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for this concept",
-  "authors": [],
+  "blurb": "A tuple is an immutable collection of items in sequence. Like most collections, tuples can hold any/multiple data type(s) -- including other tuples. Tuples support all common sequence operations, and items are referenced by 0-based index number.  Tuples can be iterated over in a loop by using the \"for item in <tuple>\" syntax.",
+  "authors": ["BethanyG"],
   "contributors": []
 }


### PR DESCRIPTION
Added concept blurbs, authors and contributors for the following concepts:

- `basics`
- `bools`
- `dicts`
- `enums`
- `list-methods`
- `lists`
- `none`
- `numbers`
- `string-formatting`
- `string-methods`
- `strings`
- `tuples`