### PR TITLE
Fix duplicate prerequisite

### DIFF
--- a/config.json
+++ b/config.json
@@ -1774,7 +1774,6 @@
           "lists",
           "list-methods",
           "list-comprehensions",
-          "list-methods",
           "strings",
           "string-methods",
           "string-formatting",


### PR DESCRIPTION
There was a duplicate prerequisite for the atbash-cipher exercise, which causes the track to not sync properly.

Closes https://github.com/exercism/website/issues/846
