### PR TITLE
Gracefully fail with user-friendly error text when unrecognized datac…

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ jobs:
   housekeeping:
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - name: Set up Python
       uses: actions/setup-python@v2.2.2
@@ -55,7 +55,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - uses: actions/setup-python@v2.2.2
       with:

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v2.3.4
 
     - name: Fetch configlet
       uses: exercism/github-actions/configlet-ci@main

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -10,6 +10,6 @@ jobs:
   test-runner:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - name: Run test-runner
         run: docker-compose run test-runner

--- a/bin/data.py
+++ b/bin/data.py
@@ -10,38 +10,38 @@ from typing import List, Any, Dict, Type
 
 def _custom_dataclass_init(self, *args, **kwargs):
     # print(self.__class__.__name__, "__init__")
-    names = [f.name for f in fields(self)]
+    names = [field.name for field in fields(self)]
     used_names = set()
 
     # Handle positional arguments
-    for v in args:
+    for value in args:
         try:
-            k = names.pop(0)
+            name = names.pop(0)
         except IndexError:
             raise TypeError(f"__init__() given too many positional arguments")
         # print(f'setting {k}={v}')
-        setattr(self, k, v)
-        used_names.add(k)
+        setattr(self, name, value)
+        used_names.add(name)
 
     # Handle keyword arguments
-    for k, v in kwargs.items():
-        if k in names:
+    for name, value in kwargs.items():
+        if name in names:
             # print(f'setting {k}={v}')
-            setattr(self, k, v)
-            used_names.add(k)
-        elif k in used_names:
-            raise TypeError(f"__init__() got multiple values for argument '{k}'")
+            setattr(self, name, value)
+            used_names.add(name)
+        elif name in used_names:
+            raise TypeError(f"__init__() got multiple values for argument '{name}'")
         else:
             raise TypeError(
-                f"Unrecognized field '{k}' for dataclass {self.__class__.__name__}."
+                f"Unrecognized field '{name}' for dataclass {self.__class__.__name__}."
                 "\nIf this field is valid, please add it to the dataclass in data.py."
                 "\nIf adding an object-type field, please create a new dataclass for it."
             )
 
     # Check for missing positional arguments
     missing = [
-        f"'{f.name}'" for f in fields(self)
-        if isinstance(f.default, dataclasses._MISSING_TYPE) and f.name not in used_names
+        f"'{field.name}'" for field in fields(self)
+        if isinstance(field.default, dataclasses._MISSING_TYPE) and field.name not in used_names
     ]
     if len(missing) == 1:
         raise TypeError(f"__init__() missing 1 required positional argument: {missing[0]}")
@@ -321,8 +321,8 @@ class Config:
         except IOError:
             print(f"FAIL: {path} file not found")
             raise SystemExit(1)
-        except TypeError as e:
-            print(f"FAIL: {e}")
+        except TypeError as ex:
+            print(f"FAIL: {ex}")
             raise SystemExit(1)
 
 

--- a/bin/data.py
+++ b/bin/data.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, fields
 from itertools import chain
 import json
 from pathlib import Path
@@ -7,8 +7,25 @@ import toml
 from typing import List, Any, Dict
 
 
+def _custom_dataclass_init(self, **kwargs):
+    names = set([f.name for f in fields(self)])
+    for k, v in kwargs.items():
+        if k in names:
+            setattr(self, k, v)
+        else:
+            raise TypeError(
+                f"Unrecognized field '{k}' for dataclass {self.__class__.__name__}."
+                "\nIf this field is valid, please add it to the dataclass in data.py."
+                "\nIf adding an object-type field, please create a new dataclass for it."
+            )
+    if hasattr(self, "__post_init__"):
+        self.__post_init__()
+
+
 @dataclass
 class TrackStatus:
+    __init__ = _custom_dataclass_init
+
     concept_exercises: bool = False
     test_runner: bool = False
     representer: bool = False
@@ -27,11 +44,16 @@ class TestRunnerSettings:
 
 @dataclass
 class EditorSettings:
+    __init__ = _custom_dataclass_init
+
     indent_style: IndentStyle = IndentStyle.Space
     indent_size: int = 4
     ace_editor_language: str = "python"
     highlightjs_language: str = "python"
+<<<<<<< HEAD
 
+=======
+>>>>>>> Gracefully fail with user-friendly error text when unrecognized dataclass fields are detected
 
     def __post_init__(self):
         if isinstance(self.indent_style, str):
@@ -47,6 +69,8 @@ class ExerciseStatus(str, Enum):
 
 @dataclass
 class ExerciseFiles:
+    __init__ = _custom_dataclass_init
+
     solution: List[str]
     test: List[str]
     exemplar: List[str] = None
@@ -71,6 +95,8 @@ class ExerciseFiles:
 
 @dataclass
 class ExerciseConfig:
+    __init__ = _custom_dataclass_init
+
     files: ExerciseFiles
     authors: List[str] = None
     forked_from: str = None
@@ -95,6 +121,8 @@ class ExerciseConfig:
 
 @dataclass
 class ExerciseInfo:
+    __init__ = _custom_dataclass_init
+
     path: Path
     slug: str
     name: str
@@ -160,6 +188,8 @@ class ExerciseInfo:
 
 @dataclass
 class Exercises:
+    __init__ = _custom_dataclass_init
+
     concept: List[ExerciseInfo]
     practice: List[ExerciseInfo]
     foregone: List[str] = None
@@ -190,6 +220,8 @@ class Exercises:
 
 @dataclass
 class Concept:
+    __init__ = _custom_dataclass_init
+
     uuid: str
     slug: str
     name: str
@@ -197,6 +229,8 @@ class Concept:
 
 @dataclass
 class Feature:
+    __init__ = _custom_dataclass_init
+
     title: str
     content: str
     icon: str
@@ -204,6 +238,8 @@ class Feature:
 
 @dataclass
 class FilePatterns:
+    __init__ = _custom_dataclass_init
+
     solution: List[str]
     test: List[str]
     example: List[str]
@@ -212,6 +248,8 @@ class FilePatterns:
 
 @dataclass
 class Config:
+    __init__ = _custom_dataclass_init
+
     language: str
     slug: str
     active: bool
@@ -253,10 +291,15 @@ class Config:
         except IOError:
             print(f"FAIL: {path} file not found")
             raise SystemExit(1)
+        except TypeError as e:
+            print(f"FAIL: {e}")
+            raise SystemExit(1)
 
 
 @dataclass
 class TestCaseTOML:
+    __init__ = _custom_dataclass_init
+
     uuid: str
     description: str
     include: bool = True
@@ -265,6 +308,8 @@ class TestCaseTOML:
 
 @dataclass
 class TestsTOML:
+    __init__ = _custom_dataclass_init
+
     cases: Dict[str, TestCaseTOML]
 
     @classmethod

--- a/bin/data.py
+++ b/bin/data.py
@@ -50,10 +50,6 @@ class EditorSettings:
     indent_size: int = 4
     ace_editor_language: str = "python"
     highlightjs_language: str = "python"
-<<<<<<< HEAD
-
-=======
->>>>>>> Gracefully fail with user-friendly error text when unrecognized dataclass fields are detected
 
     def __post_init__(self):
         if isinstance(self.indent_style, str):


### PR DESCRIPTION
…lass fields are detected

Example:
```bash
$ bin/test_exercises.py acronym
FAIL: dataclass EditorSettings does not have field 'fancy_colors'.
If this field is valid, please add it to the dataclass in data.py.
If adding an object-type field, please create a new dataclass for it.
```