### PR TITLE
[PR2431 Re-Do]: Added Website icons to .meta/config.json exercise files.

### DIFF
--- a/exercises/concept/black-jack/.meta/config.json
+++ b/exercises/concept/black-jack/.meta/config.json
@@ -1,6 +1,7 @@
 {
   "blurb": "Learn about comparisons by implementing some Black Jack judging rules.",
   "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007"],
+  "icon": "poker",
   "contributors": ["bethanyg"],
   "files": {
     "solution": ["black_jack.py"],

--- a/exercises/concept/card-games/.meta/config.json
+++ b/exercises/concept/card-games/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Learn about lists by tracking hands in card games.",
-  "contributors": [
-    "valentin-p"
-  ],
-  "authors": [
-    "itamargal",
-    "isaacg",
-    "bethanyg"
-  ],
+  "icon": "poker",
+  "contributors": ["valentin-p"],
+  "authors": ["itamargal", "isaacg", "bethanyg"],
   "files": {
-    "solution": [
-      "lists.py"
-    ],
-    "test": [
-      "lists_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["lists.py"],
+    "test": ["lists_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
+++ b/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn useful list methods helping Chaitana manage the lines for her colossal rollercoaster.",
-  "contributors": [
-    "valentin-p"
-  ],
-  "authors": [
-    "mohanrajanr",
-    "BethanyG"
-  ],
+  "icon": "spiral-matrix",
+  "contributors": ["valentin-p"],
+  "authors": ["mohanrajanr", "BethanyG"],
   "files": {
-    "solution": [
-      "list_methods.py"
-    ],
-    "test": [
-      "list_methods_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["list_methods.py"],
+    "test": ["list_methods_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/currency-exchange/.meta/config.json
+++ b/exercises/concept/currency-exchange/.meta/config.json
@@ -1,21 +1,10 @@
 {
   "blurb": "Learn about numbers by solving Chandler's currency exchange conundrums.",
-  "authors": [
-    "Ticktakto",
-    "Yabby1997",
-    "limm-jk",
-    "OMEGA-Y",
-    "wnstj2007"
-  ],
+  "icon": "hyperia-forex",
+  "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007"],
   "files": {
-    "solution": [
-      "exchange.py"
-    ],
-    "test": [
-      "exchange_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["exchange.py"],
+    "test": ["exchange_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
@@ -1,24 +1,13 @@
 {
   "blurb": "Learn about bools by setting up the rules for the Ghost Gobble arcade game.",
-  "authors": [
-    "neenjaw"
-  ],
-  "contributors": [
-    "cmccandless"
-  ],
+  "icon": "matching-brackets",
+  "authors": ["neenjaw"],
+  "contributors": ["cmccandless"],
   "files": {
-    "solution": [
-      "arcade_game.py"
-    ],
-    "test": [
-      "arcade_game_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["arcade_game.py"],
+    "test": ["arcade_game_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
-  "forked_from": [
-    "elixir/booleans"
-  ],
+  "forked_from": ["elixir/booleans"],
   "language_versions": ">=3.5"
 }

--- a/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
+++ b/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn the basics of Python by cooking Guido's Gorgeous Lasagna.",
-  "authors": [
-    "BethanyG"
-  ],
+  "icon": "lasagna",
+  "authors": ["BethanyG"],
   "files": {
-    "solution": [
-      "lasagna.py"
-    ],
-    "test": [
-      "lasagna_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["lasagna.py"],
+    "test": ["lasagna_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
-  "forked_from": [
-    "csharp/basics",
-    "ruby/basics"
-  ]
+  "forked_from": ["csharp/basics", "ruby/basics"]
 }

--- a/exercises/concept/inventory-management/.meta/config.json
+++ b/exercises/concept/inventory-management/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn about dicts by managing warehouse inventory.",
-  "authors": [
-    "j08k"
-  ],
-  "contributors": [
-    "valentin-p",
-    "bethanyG"
-  ],
+  "icon": "high-scores",
+  "authors": ["j08k"],
+  "contributors": ["valentin-p", "bethanyG"],
   "files": {
-    "solution": [
-      "dicts.py"
-    ],
-    "test": [
-      "dicts_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["dicts.py"],
+    "test": ["dicts_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/little-sisters-essay/.meta/config.json
+++ b/exercises/concept/little-sisters-essay/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn about string methods while improving your little sister's school essay.",
-  "contributors": [
-    "valentin-p",
-    "bethanyg"
-  ],
-  "authors": [
-    "kimolivia"
-  ],
+  "icon": "anagrams",
+  "contributors": ["valentin-p", "bethanyg"],
+  "authors": ["kimolivia"],
   "files": {
-    "solution": [
-      "string_methods.py"
-    ],
-    "test": [
-      "string_methods_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["string_methods.py"],
+    "test": ["string_methods_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -1,23 +1,12 @@
 {
   "blurb": "Learn about enums by automating your tedious logging-level tasks.",
-  "contributors": [
-    "valentin-p"
-  ],
-  "authors": [
-    "mohanrajanr"
-  ],
+  "icon": "log-levels",
+  "contributors": ["valentin-p"],
+  "authors": ["mohanrajanr"],
   "files": {
-    "solution": [
-      "enums.py"
-    ],
-    "test": [
-      "enums_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["enums.py"],
+    "test": ["enums_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
-  "forked_from": [
-    "csharp/enums"
-  ]
+  "forked_from": ["csharp/enums"]
 }

--- a/exercises/concept/making-the-grade/.meta/config.json
+++ b/exercises/concept/making-the-grade/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Learn about loops by grading and organzing your students exam scores.",
+  "icon": "grep",
   "authors": ["mohanrajanr", "BethanyG"],
   "files": {
     "solution": ["loops.py"],

--- a/exercises/concept/pretty-leaflet/.meta/config.json
+++ b/exercises/concept/pretty-leaflet/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn about string formatting by \"prettifying\" promotional leaflets.",
-  "contributors": [
-    "j08k",
-    "BethanyG"
-  ],
-  "authors": [
-    "valentin-p"
-  ],
+  "icon": "scale-generator",
+  "contributors": ["j08k", "BethanyG"],
+  "authors": ["valentin-p"],
   "files": {
-    "solution": [
-      "string_formatting.py"
-    ],
-    "test": [
-      "string_formatting_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["string_formatting.py"],
+    "test": ["string_formatting_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/restaurant-rozalynn/.meta/config.json
+++ b/exercises/concept/restaurant-rozalynn/.meta/config.json
@@ -1,18 +1,10 @@
 {
   "blurb": "Learn about None by managing the reservations at Restaurant Rozalynn.",
-  "authors": [
-    "mohanrajanr",
-    "BethanyG"
-  ],
+  "icon": "kindergarten-garden",
+  "authors": ["mohanrajanr", "BethanyG"],
   "files": {
-    "solution": [
-      "none.py"
-    ],
-    "test": [
-      "none_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["none.py"],
+    "test": ["none_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/sets/.meta/config.json
+++ b/exercises/concept/sets/.meta/config.json
@@ -1,17 +1,10 @@
 {
   "blurb": "TODO: add blurb for sets exercise",
-  "authors": [
-    "bethanyg"
-  ],
+  "icon": "meetup",
+  "authors": ["bethanyg"],
   "files": {
-    "solution": [
-      "sets.py"
-    ],
-    "test": [
-      "sets_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["sets.py"],
+    "test": ["sets_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/exercises/concept/tisbury-treasure-hunt/.meta/config.json
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/config.json
@@ -1,17 +1,10 @@
 {
   "blurb": "Learn about tuples by helping out competitors in the Tisbury Treasure Hunt.",
-  "authors": [
-    "bethanyg"
-  ],
+  "icon": "proverb",
+  "authors": ["bethanyg"],
   "files": {
-    "solution": [
-      "tuples.py"
-    ],
-    "test": [
-      "tuples_test.py"
-    ],
-    "exemplar": [
-      ".meta/exemplar.py"
-    ]
+    "solution": ["tuples.py"],
+    "test": ["tuples_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }


### PR DESCRIPTION
This is a re-implementation of [PR2431](https://github.com/exercism/python/pull/2431), minus the picked-up history.

Includes

- `black-jack` (_comparisons_)
- `card-games` (_lists_)
- `chaitanas-colossal-coaster` (_list-methods_)
- `currency-exchange` (_numbers_)
- `ghost-gobble-arcade-game` (_bools_)
- `guidos-gorgeous-lasagna` (_basics_)
- `inventory-management` (_dicts_)
- `little-sisters-essay` (_string methods_)
- `log-levels` (_enums_)
- `making-the-grade` (_loops_)
- `pretty-leaflet` (_string-formatting_)
- `restaurant-rozalynn`(_none_)
-  `sets`
- `tisbury-treasure-hunt` (_tuples_)