### PR TITLE
Fix Missing EndQuote on Line 163

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -160,7 +160,7 @@
   color: "DEA3EA"
 
 - name: "status/wontfix  🙅🏽"
-  description: "While this may be an issue, it will not be fixed at this time.
+  description: "While this may be an issue, it will not be fixed at this time."
   color: "DEA3EA"
 
 - name: "wip/content-checking  ☑"


### PR DESCRIPTION
Added Missing EndQuote on Line 163, to fix YAML linting errors on combined labels file.