### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -3366,32 +3366,32 @@
     {
       "title": "Batteries Included",
       "content": "Epic & well-documented standard library. Need more? Use a PyPi package - there's one for everything.",
-      "icon": ""
+      "icon": "powerful"
     },
     {
       "title": "Easy",
       "content": "Human-friendly Syntax and a vibrant, supportive community. Quick to learn & intuitive to use.",
-      "icon": ""
+      "icon": "fun"
     },
     {
       "title": "Extensible",
       "content": "Need to call Fortran from a web API? Done. Need to process images using C? Python can do that.",
-      "icon": ""
+      "icon": "extensible"
     },
     {
       "title": "Flexible",
       "content": "Duck, dynamic, & strong typing. Easy to debug. Fun for experiments, robust for large applications.",
-      "icon": ""
+      "icon": "general-purpose"
     },
     {
       "title": "Multi-paradigm",
       "content": "OOP, structured, functional, & aspect-oriented. Adaptable to how you structure your programs.",
-      "icon": ""
+      "icon": "multi-paradigm"
     },
     {
       "title": "Ubiquitous",
       "content": "Accepted for almost any use. Easily interface with other languages & execute almost everywhere.",
-      "icon": ""
+      "icon": "community"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

Feel free to change these to whatever's preferred. The list of icons can be seen [here](https://github.com/exercism/docs/issues/189).

---

![`powerful`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/powerful.svg) Batteries Included
Epic & well-documented standard library. Need more? Use a PyPi package - there's one for everything.

![`fun`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fun.svg) Easy
Human-friendly Syntax and a vibrant, supportive community. Quick to learn & intuitive to use.

![`extensible`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/extensible.svg) Extensible
Need to call Fortran from a web API? Done. Need to process images using C? Python can do that.

![`general-purpose`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/general-purpose.svg) Flexible
Duck, dynamic, & strong typing. Easy to debug. Fun for experiments, robust for large applications.

![`multi-paradigm`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) Multi-paradigm
OOP, structured, functional, & aspect-oriented. Adaptable to how you structure your programs.

![`community`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/community.svg) Ubiquitous
Accepted for almost any use. Easily interface with other languages & execute almost everywhere.