### PR TITLE
Concept Typo Patrol for Lists and List-Methods

### DIFF
--- a/concepts/list-methods/about.md
+++ b/concepts/list-methods/about.md
@@ -9,7 +9,7 @@ Items can be iterated over using the `for item in <list>` construct, and `for in
 
 Python provides many useful [methods][list-methods] for working with lists.
 
-Becasue `lists` are mutable, list-methods **alter the original list object** passed into the method.
+Because `lists` are mutable, list-methods **alter the original list object** passed into the method.
 If mutation is undesirable, the original `list` needs to at least be copied via `shallow copy` via `slice` or `<list>.copy()`.
 
 ## Adding Items
@@ -205,7 +205,9 @@ Remember that variables in Python are labels that point to underlying objects an
 
 Assigning a `list` object to a new variable _name_ does not copy the object or any of its referenced data. Any change made to the items in the `list` using the new variable name will also _impact the original_.
 
-`<list>.copy()` will create a new `list` object, but **will not** create new objects for the referenced list _elements_. This is called a `shallow copy`. A `shallow copy` is usually enough when you want to add or remove items from one of the `list` objects without modifying the other. But if there is any chance that the _underlying_ elements of a `list` might be accidentally mutated (_thereby mutating all related shallow copies_), [`copy.deepcopy()`][deepcopy] in the `copy` module should be used to create a complete or "deep" copy of **all** references and objects.
+`<list>.copy()` will create a new `list` object, but **will not** create new objects for the referenced list _elements_. This is called a `shallow copy`.
+A `shallow copy` is usually enough when you want to add or remove items from one of the `list` objects without modifying the other.
+But if there is any chance that the _underlying_ elements of a `list` might be accidentally mutated (_thereby mutating all related shallow copies_), [`copy.deepcopy()`][deepcopy] in the `copy` module should be used to create a complete or "deep" copy of **all** references and objects.
 
 For a detailed explanation of names, values, list, and nested list behavior, take a look at this excellent blog post from [Ned Batchelder][ned batchelder] -- [Names and values: making a game board][names and values].
 

--- a/concepts/list-methods/introduction.md
+++ b/concepts/list-methods/introduction.md
@@ -1,6 +1,12 @@
 # Introduction
 
-A [list][list] is a mutable collection of items in _sequence_.  They're an extremely flexible and useful data structure that many built-in methods and operations in Python produce as output.  Lists can hold reference to any (or multiple) data type(s) - including other `lists` or data structures such as [tuples][tuples], [sets][sets], or [dicts][dicts]. Python provides many useful and convenient [methods][list-methods] for working with lists.
+A [list][list] is a mutable collection of items in _sequence_.
+Lists can hold reference to any (or multiple) data type(s) - including other lists or data structures such as [tuples][tuples], [sets][sets], or [dicts][dicts].
+Content can be iterated over using `for item in <list>` construct.
+If indexes are needed with the content, `for item in enumerate(<list>)` can be used.
+Elements within a `list` can be accessed via `0-based index` number from the left, or `-1-based index` number from the right.
+Lists can be copied in whole or in part using  _slice notation_ or `<list>.copy()`.
+Python provides many useful and convenient [methods][list-methods] for working with lists.
 
 [tuples]: https://github.com/exercism/python/tree/main/concepts/tuples
 [dicts]: https://github.com/exercism/python/tree/main/concepts/dicts

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -1,18 +1,25 @@
 # About
 
-A [`list`][list] is a mutable collection of items in _sequence_. Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists. Like any [sequence][sequence type], items are referenced by `0-based index` number and can be copied in whole or in part via [slice notation][slice notation].
+A [`list`][list] is a mutable collection of items in _sequence_.
+Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists.
+Like any [sequence][sequence type], items can be accessed via `0-based index` number from the left and `-1-base index` from the right.
+Lists can be copied in whole or in part via [slice notation][slice notation] or `<list>.copy()`
 
-Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence opterations like `min()`/`max()`, `<list>.index()`, `.append()` and `.reverse()`. Items can be iterated over using the `for item in <list>` construct. `for item in enumerate(<list)` can be used when both the item value and item index are needed.
+Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence operations such as `min()`/`max()`, `<list>.index()`, `.append()` and `.reverse()`.
+List elements can be iterated over using the `for item in <list>` construct. `for item in enumerate(<list)` can be used when both the element index and the element value are needed.
 
 Lists are implemented as [dynamic arrays][dynamic array] -- similar to Java's [`Arraylist`][arraylist] type, and are most often used to store groups of similar data (_strings, numbers, sets etc._) of unknown length (_the number of entries may arbitrarily expand or shrink_).
 
-Accessing elements, checking for membership via `in`, or appending items to the "right-hand" side of a list are all very efficient. Prepending (_appending to the "left-hand" side_) or inserting into the middle of a list are much _less_ efficient because those operations require shifting elements to keep them in sequence. For a  similar data structure that supports memory efficient appends/pops from both sides, see [`collections.deque`][deque], which has approximately the same O(1) performance in either direction.
+Accessing elements, checking for membership via `in`, or appending items to the "right-hand" side of a list are all very efficient.
+Prepending (_appending to the "left-hand" side_) or inserting into the middle of a list are much _less_ efficient because those operations require shifting elements to keep them in sequence.
+For a similar data structure that supports memory efficient `appends`/`pops` from both sides, see [`collections.deque`][deque], which has approximately the same O(1) performance in either direction.
 
-Because lists are mutable and can contain references to arbitrary objects, they also take up more space in memory than a fixed-size `array.array` type of the same apparent length. Despite this, lists are an extremely flexible and useful data structure and many built-in methods and operations in Python produce lists as their output.
+Because lists are mutable and can contain references to arbitrary objects, they also take up more space in memory than a fixed-size [`array.array`][array.array] type of the same apparent length.
+Despite this, lists are an extremely flexible and useful data structure and many built-in methods and operations in Python produce lists as their output.
 
 ## Construction
 
-A list can be declared as a _list literal_ with square `[]` brackets and commas between elements:
+A `list` can be declared as a _literal_ with square `[]` brackets and commas between elements:
 
 ```python
 >>> no_elements = []
@@ -109,7 +116,7 @@ TypeError: 'int' object is not iterable
 
 ## Accessing elements
 
-Items inside lists (_as well as elements in other sequence types such as [`str`][string] & [`tuple`][tuple]_), can be accessed via `0-based index` and _bracket notation_. Indexes can be from **`left`** --> **`right`** (_starting at zero_) or **`right`** --> **`left`** (_starting at -1_).
+Items inside lists (_as well as elements in other sequence types such as [`str`][string] & [`tuple`][tuple]_), can be accessed using  _bracket notation_. Indexes can be from **`left`** --> **`right`** (_starting at zero_) or **`right`** --> **`left`** (_starting at -1_).
 
 
 <table>
@@ -250,12 +257,16 @@ Lists can also be combined via various techniques:
 
 ## Some cautions
 
-Recall that variables in Python are _labels_ that point to _underlying objects_. `lists` add one more layer as  _container objects_ -- they hold object references for their collected items.  This can lead to multiple potential issues when working with lists, if not handled properly.
+Recall that variables in Python are _labels_ that point to _underlying objects_.
+`lists` add one more layer as  _container objects_ -- they hold object references for their collected items.
+This can lead to multiple potential issues when working with lists, if not handled properly.
 
 ### Assigning more than one variable name
-Assigning a `list` object to a new variable _name_ **does not copy the `list` object nor its elements**. Any change made to the elements in the `list` under the _new_ name _impact the original_.
+Assigning a `list` object to a new variable _name_ **does not copy the `list` object nor its elements**.
+Any change made to the elements in the `list` under the _new_ name _impact the original_.
 
-Making a `shallow_copy` via `list.copy()` or slice will avoid this first-leve referencing complicaton. A `shallow_copy` will create a new `list` object, but **will not** create new objects for the contained list _elements_. This type of copy will usually be enough for you to add or remove items from the two `list` objects independantly, and effectively have two "seperate" lists. (More about the differences between a shallow_copy and a deep_copy a little later).
+Making a `shallow_copy` via `list.copy()` or slice will avoid this first-leve referencing complication.
+A `shallow_copy` will create a new `list` object, but **will not** create new objects for the contained list _elements_. This type of copy will usually be enough for you to add or remove items from the two `list` objects independently, and effectively have two "separate" lists.
 
 ```python
 >>> actual_names = ["Tony", "Natasha", "Thor", "Bruce"]
@@ -354,7 +365,9 @@ from pprint import pprint
  [0, 0, 0, 0, 0, 0, 0, 'X']]
 ```
 
-But as mentioned earlier, lists are containers of _references_, so there is a second layer of potential complicaton. If a list contains variables, objects, or nested data structures, those second-level references **will not be copied** via `shallow_copy` or slice. Mutating the underlying objects will then affect _any and all_ copies, since each `list` object only contains _references pointing to_ the contained elements.
+As mentioned earlier, lists are containers of _references_, so there is a second layer of potential complication.
+If a list contains variables, objects, or nested data structures, those second-level references **will not be copied** via `shallow_copy` or slice.
+Mutating the underlying objects will then affect _any and all_ copies, since each `list` object only contains _references pointing to_ the contained elements.
 
 ```python
 from pprint import pprint
@@ -389,7 +402,10 @@ from pprint import pprint
 
 ## Related data types
 
-Lists are often used as _stacks_ and _queues_ -- although their underlying implementation makes prepending and inserting slow. The [collections][collections] module offers a [deque][deque] variant optimized for fast appends and pops from either end that is implemented as a [doubly linked list][doubly linked list]. Nested lists are also used to model small _matrices_ -- although the [Numpy][numpy] and [Pandas][pandas] libraries are much more robust for efficient matrix and tabular data manipulation. The collections module also provides a `UserList` type that can be customized to fit specialized list needs.
+Lists are often used as _stacks_ and _queues_ -- although their underlying implementation makes prepending and inserting slow.
+The [collections][collections] module offers a [deque][deque] variant optimized for fast appends and pops from either end that is implemented as a [doubly linked list][doubly linked list].
+Nested lists are also used to model small _matrices_ -- although the [Numpy][numpy] and [Pandas][pandas] libraries are much more robust for efficient matrix and tabular data manipulation.
+The collections module also provides a `UserList` type that can be customized to fit specialized list needs.
 
 [list]: https://docs.python.org/3/library/stdtypes.html#list
 [tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
@@ -410,3 +426,4 @@ Lists are often used as _stacks_ and _queues_ -- although their underlying imple
 [pandas]: https://pandas.pydata.org/
 [names and values]: https://nedbatchelder.com/blog/201308/names_and_values_making_a_game_board.html
 [ned batchelder]: https://nedbatchelder.com/
+[array.array]: https://docs.python.org/3/library/array.html

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -1,6 +1,12 @@
 # Introduction
 
-A [list][list] is a mutable collection of items in _sequence_.  They're an extremely flexible and useful data structure that many built-in methods and operations in Python produce as output.  Lists can hold reference to any (or multiple) data type(s) - including other lists or data structures such as [tuples][tuples], [sets][sets], or [dicts][dicts]. Content can be iterated over using the `for item in <list>` construct. `Lists` be copied in whole or in part using  _slice notation_ or `<list>.copy()` and elements within can be accessed via `0-based index number`
+A [list][list] is a mutable collection of items in _sequence_.
+They're an extremely flexible and useful data structure that many built-in methods and operations in Python produce as output.
+Lists can hold reference to any (or multiple) data type(s) - including other lists or data structures such as [tuples][tuples], [sets][sets], or [dicts][dicts].
+Content can be iterated over using `for item in <list>` construct.
+If indexes are needed with the content, `for item in enumerate(<list>)` can be used.
+Elements within a `list` can be accessed via `0-based index` number from the left, or `-1-based index` number from the right.
+Lists can be copied in whole or in part using  _slice notation_ or `<list>.copy()`.
 
 [tuples]: https://github.com/exercism/python/tree/main/concepts/tuples
 [dicts]: https://github.com/exercism/python/tree/main/concepts/dicts

--- a/exercises/concept/card-games/.docs/introduction.md
+++ b/exercises/concept/card-games/.docs/introduction.md
@@ -1,10 +1,16 @@
 # Introduction
 
-In Python, a [list][list] is a mutable collection of items in _sequence_. Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists.
+A [`list`][list] is a mutable collection of items in _sequence_.
+Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists.
+Like any [sequence][sequence type], items can be accessed via `0-based index` number from the left and `-1-base index` from the right.
+Lists can be copied in whole or in part via [slice notation][slice notation] or `<list>.copy()`
 
-Like any [sequence][sequence type], items are referenced by 0-based index number, and can be copied in whole or in part via _slice notation_. `list`s support all [common sequence operations][common sequence operations], as well as [mutable sequence operations][mutable sequence operations] such as `<list>.append()` and `<list>.reverse()`. They can be iterated over in a loop by using the `for item in <list>` construct.
+Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence operations such as `min()`/`max()`, `<list>.index()`, `.append()` and `.reverse()`.
+List elements can be iterated over using the `for item in <list>` construct. `for item in enumerate(<list)` can be used when both the element index and the element value are needed.
 
-Under the hood, `lists` are implemented as [dynamic arrays][dynamic array] -- similar to Java's [`Arraylist`][arraylist] type. Lists are most often used to store groups of similar data (_strings, numbers, sets etc._) of unknown length. Lists are an extremely flexible and useful data structure and many built-in methods and operations in Python produce lists as their output.
+Under the hood, `lists` are implemented as [dynamic arrays][dynamic array] -- similar to Java's [`Arraylist`][arraylist] type.
+Lists are most often used to store groups of similar data (_strings, numbers, sets etc._) of unknown length.
+Lists are an extremely flexible and useful data structure and many built-in methods and operations in Python produce lists as their output.
 
 ## Construction
 
@@ -221,3 +227,5 @@ Lists can also be combined via various techniques:
 [mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#typesseq-mutable
 [dynamic array]: https://en.wikipedia.org/wiki/Dynamic_array
 [arraylist]: https://beginnersbook.com/2013/12/java-arraylist/
+
+[slice notation]: https://docs.python.org/3/reference/expressions.html#slicings

--- a/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
@@ -1,12 +1,14 @@
 # Introduction
 
-A [`list`][list] is a mutable collection of items in _sequence_. Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists.  They can be copied in whole or in part via [slice notation][slice notation]. Like any [sequence][sequence type], elements within `lists` are referenced by `0-based index` number.
+A [`list`][list] is a mutable collection of items in _sequence_. Like most collections (_see the built-ins [`tuple`][tuple], [`dict`][dict] and [`set`][set]_), lists can hold reference to any (or multiple) data type(s) - including other lists.  They can be copied in whole or in part via [slice notation][slice notation]. Like any [sequence][sequence type], elements within `lists` are referenced by `0-based index` number from the left, or `-1-based index` number from the right.
 
-Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence opterations like `min()`/`max()`, `<list>.index()`, `.append()` and `.reverse()`. Items can be iterated over using the `for item in <list>` construct, and `for index, item in enumerate(<list>)` can be used when both and item value and index are needed.
+Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence operations like `min(<list>)`/`max(<list>)`, `<list>.index()`, `<list>.append()` and `<list>.reverse()`.
+Elements inside a `list`  can be iterated over using the `for item in <list>` construct.
+`for index, item in enumerate(<list>)` can be used when both the element index and element value are needed.
 
 Python provides many useful [methods][list-methods] for working with lists. Let's take a look at some of them.
 
-Keep in mind that when you manipulate a list with a list-method, **you alter the list** object that has been passed. If you do not wish to mutate your original `list`, you will need to at least make a `shallow copy` of it via slice or `<list>.copy()`.
+But keep in mind that when you manipulate a `list` with a list-method, **you alter the list** object that has been passed. If you do not wish to mutate your original `list`, you will need to at least make a `shallow copy` of it via slice or `<list>.copy()`.
 
 ## Adding Items
 
@@ -181,10 +183,6 @@ ValueError: 10 is not in list
 [sequence type]: https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
 [mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#typesseq-mutable
-[tuples]: https://github.com/exercism/python/tree/main/concepts/tuples
-[dicts]: https://github.com/exercism/python/tree/main/concepts/dicts
-[sets]: https://github.com/exercism/python/tree/main/concepts/sets
-
 [tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
 [slice notation]: https://docs.python.org/3/reference/expressions.html#slicings
 [set]: https://docs.python.org/3/library/stdtypes.html#set


### PR DESCRIPTION
This is to fix spelling errors/typos, index reference errors, and other language problems with `list` and `list-method` related documents & concept exercises.  It covers:

- [x] `about.md` for `lists` & `list-methods`
- [x]  `introduction.md` for `lists` & `list-methods`
- [x]  `exercises/concept/card-games/.docs/introduction.md`
- [x]   `exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md`   