### PR TITLE
Tuple Typo and Language Patrol

### DIFF
--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -1,12 +1,21 @@
 # About
 
-In Python, a [tuple](https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/tuple.md) is an immutable collection of items in _sequence_. Like most collections (_see the built-ins [`list`](https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/list.md), [`dict`](https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/dict.md) and [`set`](https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/set.md)_), tuples can hold any (or multiple) data type(s) -- including other tuples. Like any [sequence](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range), items are referenced by 0-based index number, and can be copied in whole or in part via _slice notation_. Tuples support all [common sequence operations](https://docs.python.org/3/library/stdtypes.html#common-sequence-operations).
+A [tuple][tuple] is an _immutable_ collection of items in _sequence_.
+Like most collections (_see the built-ins [`list`][list], [`dict`][dict] and [`set`][set]_), `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
+The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
+If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+Like any [sequence][sequence], elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
+ Tuples can be copied in whole or in part via _slice notation_ or `<tuple>.copy()`, and support all [common sequence operations][common sequence operations].
+  Being _immutable_, `tuples` **do not** support [mutable sequence operations][mutable sequence operations].
 
-Tuples take up very little memory space compared to other collection types and have constant (_O(1)_) access time. However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
+Tuples take up very little memory space compared to other collection types and have constant (_O(1)_) access time when using an index.
+However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
+If frequent updates or expansions are required, a `list`, `collections.deque`, or `array.array` might be a better data structure.
+
 
 ## Tuple Construction
 
-Tuples can be formed in multiple ways, using either the `tuple` class constructor or the `tuple` literal declaration.
+Tuples can be formed in multiple ways, using either the `tuple` class constructor or the `(<element_1>, <element_2>)` (_`tuple` literal_) declaration.
 
 ### Using the `tuple()` constructor empty or with an _iterable_:
 
@@ -14,40 +23,48 @@ Tuples can be formed in multiple ways, using either the `tuple` class constructo
 >>> no_elements = tuple()
 ()
 
-#the string elements (characters) are iterated through and added to the tuple
+# The constructor *requires* an iterable, so single elements must be passed in a list or another tuple.
+>>> one_element = tuple([16])
+(16,)
+```
+
+Strings are iterable, so using a single `str` as an argument to the `tuple()` constructor can have surprising results:
+
+```python
+# String elements (characters) are iterated through and added to the tuple
 >>> multiple_elements_string = tuple("Timbuktu")
 ('T', 'i', 'm', 'b', 'u', 'k', 't', 'u')
+```
 
+Other iterables also have their elements added one by one:
+
+```python
 >>> multiple_elements_list = tuple(["Parrot", "Bird", 334782])
 ("Parrot", "Bird", 334782)
 
 >>> multiple_elements_set = tuple({2, 3, 5, 7, 11})
 (2,3,5,7,11)
+```
 
+The iteration default for `dict` is over the **keys**.
+To include both keys and values in a tuple made from a dictionary, use `<dict>.items()`,
+which will return an iterator of (`key`, `value`) `tuples`.
 
-"""
-The iteration default for dictionaries is over the keys.
-To include both keys and values in a tuple made from a dictionary, use dict.items(),
-which returns a list of (key, value) tuples.
-"""
-source_data = {"fish": "gold", "monkey": "brown"}
+```python
+source_data = {"fish": "gold", 
+               "monkey": "brown"}
+
 >>> multiple_elements_dict_1 = tuple(source_data)
 ('fish', 'monkey')
 
 >>> multiple_elements_dict_2 = tuple(source_data.items())
 (('fish', 'gold'), ('monkey', 'brown'))
-
-
-"""
-because the tuple constructor only takes _iterables_ (or nothing), it is much easier to create
- a one-tuple via the literal method.
-"""
->>> one_element = tuple([16])
-(16,)
-
 ```
 
 #### Declaring a tuple as a _literal_ :
+
+Because the `tuple()` constructor only takes _iterables_ (or nothing) as arguments, it is much easier to create
+ a one-tuple via the literal method.
 
 ```python
 >>> no_elements = ()
@@ -55,33 +72,98 @@ because the tuple constructor only takes _iterables_ (or nothing), it is much ea
 
 >>> one_element = ("Guava",)
 ("Guava",)
+```
 
+Note that generally parentheses are **not** required to create a `tuple` literal - only commas.
+However, using `(<element)1>, <element_2>)` is considered more readable in most circumstances.
+Parentheses are also required in cases of ambiguity, such as an empty or one-item tuple or where a function takes a tuple as an argument.
+
+```python
 >>> elements_separated_with_commas = "Parrot", "Bird", 334782
 ("Parrot", "Bird", 334782)
 
 >>> elements_with_commas_and_parentheses = ("Triangle", 60, 60, 60)
 ("Triangle", 60, 60, 60)
+```
 
+Other data structures can be included as `tuple` elements, including other `tuples`.
+
+```python
 >>> nested_data_structures = ({"fish": "gold", "monkey": "brown", "parrot" : "grey"}, ("fish", "mammal", "bird"))
 ({"fish": "gold", "monkey": "brown", "parrot" : "grey"}, ("fish", "mammal", "bird"))
 
-#using the plus + operator unpacks each tuple and creates a new tuple.
+>>> nested_data_structures_1 : (["fish", "gold", "monkey", "brown", "parrot", "grey"], ("fish", "mammal", "bird"))
+(["fish", "gold", "monkey", "brown", "parrot", "grey"], ("fish", "mammal", "bird"))
+```
+
+Tuples can be concatenated using plus `+` operator, which unpacks each `tuple` creating a new, combined `tuple`.
+
+```python
 >>> new_via_concatenate = ("George", 5) + ("cat", "Tabby")
 ("George", 5, "cat", "Tabby")
 
-#likewise, using the multiplication operator * is the equvilent of using + n times
+#likewise, using the multiplication operator * is the equivalent of using + n times
 >>> first_group = ("cat", "dog", "elephant")
 
 >>> multiplied_group = first_group * 3
 ('cat', 'dog', 'elephant', 'cat', 'dog', 'elephant', 'cat', 'dog', 'elephant')
-
 ```
 
-Note that generally parentheses are not _required_ to create a `tuple` literal - only commas. Parentheses are required in cases of ambiguity, such as an empty or one-item tuple or where a function takes a tuple as an argument.
+## Accessing Data
 
-## Tuples as related information
+Elements inside tuples (_like the other sequence types `str` and `list`_), can be accessed via _bracket notation_.
+Indexes can be from **`left`** --> **`right`** (_starting at zero_) or **`right`** --> **`left`** (_starting at -1_).
+Tuples can also be copied in whole or in part via _slice notation_ or using `<tuple>.copy()`.
 
-Tuples are often used as _records_ containing heterogeneous data that is _organizationally_ or _conceptually_ related and treated as a single unit of information.
+```python
+
+>>> student_info = ("Alyssa", "grade 3", "female", 8 )
+
+#name is at index 0 or index -4
+>>> student_name = student_info[0]
+Alyssa
+
+>>> student_name = student_info[-4]
+Alyssa
+
+#age is at index 3 or index -1
+>>> student_age_1 = student_info[3]
+8
+
+>>> student_age_2 = student_info[-1]
+8
+```
+
+## Iteration Over Elements
+
+Elements inside tuples can be _iterated over_ in a loop using `for item in <tuple>` syntax.
+If both indexes and values are needed, `for index, item in enumerate(<tuple>)` can be used.
+
+```python
+>>> student_info = ("Alyssa", "grade 3", "female", 8 )
+>>> for item in student_info:
+...   print(item)
+
+...
+Alyssa
+grade 3
+female
+8
+
+>>> for index, item in enumerate(student_info):
+...  print("Index is: " + str(index) + ", value is: " + str(item) +".")
+
+...
+Index is: 0, value is: Alyssa.
+Index is: 1, value is: grade 3.
+Index is: 2, value is: female.
+Index is: 3, value is: 8.
+```
+
+
+## Tuples as Homogeneous Information
+
+Tuples are often used as _records_ containing data that is _organizationally_ or _conceptually_ homogeneous and treated as a single unit of information -- even if individual elements are of  _heterogeneous_ data types.
 
 ```python
 
@@ -89,9 +171,10 @@ Tuples are often used as _records_ containing heterogeneous data that is _organi
 
 ```
 
-Tuples are also used when homogeneous immutable sequences of data are needed for [`hashability`](https://docs.python.org/3/glossary.html#hashable), storage in a set, or creation of keys in a dictionary.
+Tuples are also used when homogeneous immutable sequences of data are needed for [`hashability`][hashability], storage in a `set`, or creation of keys in a dictionary.
 
-Note that while tuples are in most cases _immutable_, because they can contain _any_ data structure or object they can become mutable if any of their elements is a _mutable type_. Using a mutable data type within a tuple will make the enclosing tuple un-hashable.
+Note that while `tuples` are in most cases _immutable_, because they can contain _any_ data structure or object they can _become mutable_ if any of their elements is a _mutable type_.
+Using a mutable data type within a `tuple` will make the enclosing `tuple` **un-hashable**.
 
 ```python
 
@@ -119,49 +202,22 @@ TypeError: unhashable type: 'list'
 
 ```
 
-## Accessing data inside a tuple
-
-Items inside tuples (_like the sequence types `string` and `list`_), can be accessed via 0-based index and _bracket notation_. Indexes can be from **`left`** --> **`right`** (_starting at zero_) or **`right`** --> **`left`** (_starting at -1_).
-
-Items inside tuples can also be _iterated over_ in a loop using `for item in` syntax.
-
-```python
-
->>> student_info = ("Alyssa", "grade 3", "female", 8 )
-
-#name is at index 0 or index -4
->>> student_name = student_info[0]
-Alyssa
-
->>> student_name = student_info[-4]
-Alyssa
-
-#grade is at index 1 or index -3
->>> student_grade = student_info[1]
-'grade 3'
-
->>> student_grade = student_info[-3]
-'grade 3'
-
-#age is at index 3 or index -1
->>> student_age_1 = student_info[3]
-8
-
->>> student_age_2 = student_info[-1]
-8
-
-
->>> for item in student_info:
->>>     print(item)
-
-....
-Alyssa
-grade 3
-female
-8
-
-```
-
 ## Extended tuples and related data types
 
-Tuples are often used as _records_, but the data inside them can only be accessed via _position_/_index_. The [`namedtuple()`](https://docs.python.org/3/library/collections.html#collections.namedtuple) class in the [`collections`](https://docs.python.org/3/library/collections.html#module-collections) module extends basic tuple functionality to allow access of elements by _name_. Additionally, users can adapt a [`dataclass`](https://docs.python.org/3/library/dataclasses.html) to provide similar named attribute functionality, with a some [pros and cons](https://stackoverflow.com/questions/51671699/data-classes-vs-typing-namedtuple-primary-use-cases).
+Tuples are often used as _records_, but the data inside them can only be accessed via _position_/_index_.
+The [`namedtuple()`][namedtuple] class in the [`collections`][collections] module extends basic tuple functionality to allow access of elements by _name_.
+Additionally, users can adapt a [`dataclass`][dataclass] to provide similar named attribute functionality, with a some [pros and cons][dataclass pros and cons].
+
+
+[tuple]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/tuple.md
+[list]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/list.md
+[dict]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/dict.md
+[set]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/set.md
+[sequence]: https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range
+[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+[namedtuple]: https://docs.python.org/3/library/collections.html#collections.namedtuple
+[collections]: https://docs.python.org/3/library/collections.html#module-collections
+[dataclass pros and cons]: https://stackoverflow.com/questions/51671699/data-classes-vs-typing-namedtuple-primary-use-cases
+[dataclass]: https://docs.python.org/3/library/dataclasses.html
+[mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+[hashability]: https://docs.python.org/3/glossary.html#hashable

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -1,3 +1,12 @@
 # Introduction
 
-In Python, a [tuple](https://docs.python.org/3/library/stdtypes.html#tuple) is an immutable collection of items in _sequence_. Like most collections, tuples can hold any (or multiple) data type(s) -- including other tuples. Like any sequence, items are referenced by 0-based index number. Tuples support all [common sequence operations](https://docs.python.org/3/library/stdtypes.html#common-sequence-operations).
+In Python, a [tuple][tuple] is an _immutable_ collection of items in _sequence_.
+Like most collections, `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
+Tuples support all [common sequence operations][common sequence operations], but **do not** support [mutable sequence operations][mutable sequence operations].
+The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
+If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+Like any sequence, elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
+
+[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
+[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+[mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
@@ -1,57 +1,144 @@
 # Introduction
 
-In Python, a [tuple](https://docs.python.org/3/library/stdtypes.html#tuple) is an immutable collection of items in _sequence_. Like most collections, tuples can hold any (or multiple) data type(s) -- including other tuples. Like any sequence, items are referenced by 0-based index number. Tuples support all [common sequence operations](https://docs.python.org/3/library/stdtypes.html#common-sequence-operations).
+In Python, a [tuple][tuple] is an _immutable_ collection of items in _sequence_.
+Like most collections, `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
+Tuples support all [common sequence operations][common sequence operations], but **do not** support [mutable sequence operations][mutable sequence operations].
+The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
+If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+Like any sequence, elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
+
 
 ## Tuple Construction
 
-Tuples can be formed in multiple ways, using either the `tuple` class constructor or the `tuple` literal declaration.
+Tuples can be formed in multiple ways, using either the `tuple(<iterable>)` class constructor or the `tuple` literal declaration.
 
-### Using the `tuple()` constructor:
+### Using the `tuple()` constructor empty or with an _iterable_:
 
 ```python
-#elements are iterated through and added to the tuple in order
+>>> no_elements = tuple()
+()
+
+# The constructor *requires* an iterable, so single elements must be passed in a list or another tuple.
+>>> one_element = tuple([16])
+(16,)
+```
+
+Strings are iterable, so using a single `str` as an argument to the `tuple()` constructor can have surprising results:
+
+```python
+# String elements (characters) are iterated through and added to the tuple
 >>> multiple_elements_string = tuple("Timbuktu")
 ('T', 'i', 'm', 'b', 'u', 'k', 't', 'u')
-
->>> multiple_elements = tuple(("Parrot", "Bird", 334782))
-("Parrot", "Bird", 334782)
 ```
 
-### Declaring a tuple _literal_ :
+Single iterables have their elements added one by one:
 
 ```python
->>> elements_separated_with_commas = "Parrot", "Bird", 334782
+>>> multiple_elements_list = tuple(["Parrot", "Bird", 334782])
 ("Parrot", "Bird", 334782)
 
->>> elements_with_commas_and_parentheses = ("Triangle", (60, 60, 60))
-("Triangle", (60, 60, 60))
+>>> multiple_elements_set = tuple({2, 3, 5, 7, 11})
+(2,3,5,7,11)
 ```
 
-## Concatenation
+#### Declaring a tuple as a _literal_ :
 
-Tuples can be _concatenated_ via the plus `+` operator, which returns a new tuple.
+Because the `tuple(<iterable>)` constructor only takes _iterables_ (or nothing) as arguments, it is much easier to create
+ a one-tuple via the literal method.
+
+```python
+>>> no_elements = ()
+()
+
+>>> one_element = ("Guava",)
+("Guava",)
+```
+
+Nested data structures can be included as `tuple` elements, including other `tuples`:
+
+```python
+>>> nested_data_structures = ({"fish": "gold", "monkey": "brown", "parrot" : "grey"}, ("fish", "mammal", "bird"))
+({"fish": "gold", "monkey": "brown", "parrot" : "grey"}, ("fish", "mammal", "bird"))
+
+>>> nested_data_structures_1 : (["fish", "gold", "monkey", "brown", "parrot", "grey"], ("fish", "mammal", "bird"))
+(["fish", "gold", "monkey", "brown", "parrot", "grey"], ("fish", "mammal", "bird"))
+```
+
+## Tuple Concatenation
+
+Tuples can be concatenated using plus `+` operator, which unpacks each `tuple` creating a new, combined `tuple`.
 
 ```python
 >>> new_via_concatenate = ("George", 5) + ("cat", "Tabby")
 ("George", 5, "cat", "Tabby")
+
+#likewise, using the multiplication operator * is the equivalent of using + n times
+>>> first_group = ("cat", "dog", "elephant")
+
+>>> multiplied_group = first_group * 3
+('cat', 'dog', 'elephant', 'cat', 'dog', 'elephant', 'cat', 'dog', 'elephant')
 ```
 
-## Accessing data
+## Accessing Elements Inside a Tuple
 
-Items inside tuples can be accessed via 0-based index and _bracket notation_.
+Elements within a `tuple` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
 
 ```python
 student_info = ("Alyssa", "grade 3", "female", 8 )
 
-#gender is at index 2
+#gender is at index 2 or index -2
 >>> student_gender = student_info[2]
-female
+'female'
+
+>>> student_gender = student_info[-2]
+'female'
+
+#name is at index 0 or index -4
+>>> student_name = student_info[0]
+Alyssa
+
+>>> student_name = student_info[-4]
+Alyssa
 ```
 
-## Iterating through a tuple
+## Iterating Over a Tuples Elements
 
-Items inside tuples can be _iterated over_ in a loop using `for item in` syntax.
+Elements inside a `tuple` can be _iterated over_ in a loop using `for item in <tuple>` syntax.
+If both indexes and values are needed, `for index, item in enumerate(<tuple>)` can be used.
 
-## Checking membership
+```python
+>>> student_info = ("Alyssa", "grade 3", "female", 8 )
+>>> for item in student_info:
+...   print(item)
 
-The `in` operator can be used to check membership in a tuple.
+...
+Alyssa
+grade 3
+female
+8
+
+>>> for index, item in enumerate(student_info):
+...  print("Index is: " + str(index) + ", value is: " + str(item) +".")
+
+...
+Index is: 0, value is: Alyssa.
+Index is: 1, value is: grade 3.
+Index is: 2, value is: female.
+Index is: 3, value is: 8.
+```
+
+## Checking Membership in a Tuple
+
+The `in` operator can be used to check membership in a `tuple`.
+
+```python
+>>> multiple_elements_list = tuple(["Parrot", "Bird", 334782])
+("Parrot", "Bird", 334782)
+
+>>> "Parrot" in multiple_elements_list
+True
+```
+
+[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
+[mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types


### PR DESCRIPTION
This is to fix spelling errors/typos, index reference errors, and other language problems with `tuples` related documents & concept exercise.  It covers:

- [x] `about.md` for `tuples`
- [x] `introduction.md` for `tuples` 
- [x] `exercises/concept/tisbury-treasure-hunt/.docs/introduction.md`