### PR TITLE
Fixed formatting in about and fixed instruction typos per bug 2502.

### DIFF
--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -1,17 +1,23 @@
 # About
 
 A [tuple][tuple] is an _immutable_ collection of items in _sequence_.
+
+
 Like most collections (_see the built-ins [`list`][list], [`dict`][dict] and [`set`][set]_), `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
-The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
-If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+  The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
+  If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+
+
 Like any [sequence][sequence], elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
- Tuples can be copied in whole or in part via _slice notation_ or `<tuple>.copy()`, and support all [common sequence operations][common sequence operations].
+  Tuples can be copied in whole or in part via _slice notation_ or `<tuple>.copy()`, and support all [common sequence operations][common sequence operations].
   Being _immutable_, `tuples` **do not** support [mutable sequence operations][mutable sequence operations].
 
-Tuples take up very little memory space compared to other collection types and have constant (_O(1)_) access time when using an index.
-However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
-If frequent updates or expansions are required, a `list`, `collections.deque`, or `array.array` might be a better data structure.
 
+Tuples take up very little memory space compared to other collection types and have constant (_O(1)_) access time when using an index.
+  However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
+  If frequent updates or expansions are required, a `list`, `collections.deque`, or `array.array` might be a better data structure.
+
+<br>
 
 ## Tuple Construction
 
@@ -209,15 +215,15 @@ The [`namedtuple()`][namedtuple] class in the [`collections`][collections] modul
 Additionally, users can adapt a [`dataclass`][dataclass] to provide similar named attribute functionality, with a some [pros and cons][dataclass pros and cons].
 
 
-[tuple]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/tuple.md
-[list]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/list.md
-[dict]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/dict.md
-[set]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/set.md
-[sequence]: https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range
-[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
-[namedtuple]: https://docs.python.org/3/library/collections.html#collections.namedtuple
 [collections]: https://docs.python.org/3/library/collections.html#module-collections
+[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
 [dataclass pros and cons]: https://stackoverflow.com/questions/51671699/data-classes-vs-typing-namedtuple-primary-use-cases
 [dataclass]: https://docs.python.org/3/library/dataclasses.html
-[mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+[dict]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/dict.md
 [hashability]: https://docs.python.org/3/glossary.html#hashable
+[list]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/list.md
+[mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+[namedtuple]: https://docs.python.org/3/library/collections.html#collections.namedtuple
+[sequence]: https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range
+[set]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/set.md
+[tuple]: https://github.com/exercism/v3/blob/master/languages/python/reference/concepts/builtin_types/tuple.md

--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -49,7 +49,7 @@ Aazra and Rui are teammates competing in a pirate-themed treasure hunt.
 <br>
 
 But things are a bit disorganized: Azara's coordinates appear to be formatted and sorted differently from Rui's, and they have to keep looking from one list to the other to figure out which treasures go with which locations.
-  Being budding pythonistas, they've come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
+  Being budding pythonistas, they have come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
 
 
 ## 1. Extract coordinates
@@ -87,7 +87,7 @@ True
 
 ## 4. Combine matched records
 
-Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinates _do not_ match, return the string **"not a match"**
+Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis' list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinates _do not_ match, return the string **"not a match"**
   Re-format the coordinate as needed for accurate comparison.
 
 

--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -1,6 +1,8 @@
 # Instructions
 
-Aazra and Rui are teammates competing in a pirate-themed treasure hunt. One has a list of treasures with map coordinates, the other a list of location names with map coordinates. They've also been given blank maps with a starting place marked YOU ARE HERE.
+Aazra and Rui are teammates competing in a pirate-themed treasure hunt.
+  One has a list of treasures with map coordinates, the other a list of location names with map coordinates.
+  They've also been given blank maps with a starting place marked YOU ARE HERE.
 
 <br>
 <table>
@@ -46,7 +48,9 @@ Aazra and Rui are teammates competing in a pirate-themed treasure hunt. One has 
 
 <br>
 
-But things are a bit disorganized: Azara's coordinates appear to be formatted and sorted differently from Rui's, and they have to keep looking from one list to the other to figure out which treasures go with which locations. Being budding pythonistas, they've come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
+But things are a bit disorganized: Azara's coordinates appear to be formatted and sorted differently from Rui's, and they have to keep looking from one list to the other to figure out which treasures go with which locations.
+  Being budding pythonistas, they've come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
+
 
 ## 1. Extract coordinates
 
@@ -62,7 +66,6 @@ Implement the `get_cooordinate()` function that takes a `(treasure, coordinate)`
 
 Implement the `convert_coordinate()` function that takes a coordinate in the format "2A" and returns a tuple in the format `("2", "A")`.
 
-​
 
 ```python
 >>> convert_coordinate("2A")
@@ -72,6 +75,7 @@ Implement the `convert_coordinate()` function that takes a coordinate in the for
 ## 3. Match coordinates
 
 Implement the `compare_records()` function that takes a `(treasure, coordinate)` pair and a `(location, coordinate, quadrant)` record and compares coordinates from each. Return **`True`** if the coordinates "match", and return **`False`** if they do not. Re-format coordinates as needed for accurate comparison.
+
 
 ```python
 >>> compare_records(('Brass Spyglass', '4B'),('Seaside Cottages', ("1", "C"), 'blue'))
@@ -83,20 +87,24 @@ True
 
 ## 4. Combine matched records
 
-Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinats _do not_ match, return the string "not a match.". Re-format the coordinate as needed for accurate comparison.
+Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinates _do not_ match, return the string **"not a match"**
+  Re-format the coordinate as needed for accurate comparison.
+
 
 ```python
 >>> create_record(('Brass Spyglass', '4B'),('Abandoned Lighthouse', ("4", "B"), 'Blue'))
 ('Brass Spyglass', '4B', 'Abandoned Lighthouse', ("4", "B"), 'Blue')
 
 >>> create_record(('Brass Spyglass', '4B'),(("1", "C"), 'Seaside Cottages', 'blue'))
-"not a match."
+"not a match"
 ```
 
 ## 5. "Clean up" & make a report of all records
 
 Clean up the combined records from Azara and Rui so that there's only one set of coordinates per record. Make a report so they can see one list of everything they need to put on their maps.
-Implement the `clean_up()` function that takes a tuple of tuples (_everything from both lists_), looping through the _outer_ tuple, dropping the unwanted coordinates from each _inner_ tuple and adding each to a 'report'. Format and return the 'report' so that there is one cleaned record on each line.
+  Implement the `clean_up()` function that takes a tuple of tuples (_everything from both lists_), looping through the _outer_ tuple, dropping the unwanted coordinates from each _inner_ tuple and adding each to a 'report'.
+  Format and return the 'report' so that there is one cleaned record on each line.
+
 
 ```python
 >>> clean_up((('Brass Spyglass', '4B', 'Abandoned Lighthouse', '("4", "B")', 'Blue'), ('Vintage Pirate Hat', '7E', 'Quiet Inlet (Island of Mystery)', '("7", "E")', 'Orange'), ('Crystal Crab', '6A', 'Old Schooner', '("6", "A")', 'Purple')))


### PR DESCRIPTION
Fixes #2502 (minus the table formatting)

Corrected `instructions.md` task 4 to have the function return the string **`"not a match"`** (minus the period) for both the instructions and the code example.

Also fixed some formatting issues in the `about.md` file.