### PR TITLE
Removed excess leading spaces from Tuples about and Tisbury Instructions

### DIFF
--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -4,18 +4,18 @@ A [tuple][tuple] is an _immutable_ collection of items in _sequence_.
 
 
 Like most collections (_see the built-ins [`list`][list], [`dict`][dict] and [`set`][set]_), `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
-  The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
-  If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
+The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
+If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
 
 
 Like any [sequence][sequence], elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
-  Tuples can be copied in whole or in part via _slice notation_ or `<tuple>.copy()`, and support all [common sequence operations][common sequence operations].
-  Being _immutable_, `tuples` **do not** support [mutable sequence operations][mutable sequence operations].
+Tuples can be copied in whole or in part via _slice notation_ or `<tuple>.copy()`, and support all [common sequence operations][common sequence operations].
+Being _immutable_, `tuples` **do not** support [mutable sequence operations][mutable sequence operations].
 
 
 Tuples take up very little memory space compared to other collection types and have constant (_O(1)_) access time when using an index.
-  However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
-  If frequent updates or expansions are required, a `list`, `collections.deque`, or `array.array` might be a better data structure.
+However, they cannot be resized, sorted, or altered once created, so are less flexible when frequent changes or updates to data are needed.
+If frequent updates or expansions are required, a `list`, `collections.deque`, or `array.array` might be a better data structure.
 
 <br>
 

--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -1,8 +1,8 @@
 # Instructions
 
 Aazra and Rui are teammates competing in a pirate-themed treasure hunt.
-  One has a list of treasures with map coordinates, the other a list of location names with map coordinates.
-  They've also been given blank maps with a starting place marked YOU ARE HERE.
+One has a list of treasures with map coordinates, the other a list of location names with map coordinates.
+They've also been given blank maps with a starting place marked YOU ARE HERE.
 
 <br>
 <table>
@@ -49,13 +49,13 @@ Aazra and Rui are teammates competing in a pirate-themed treasure hunt.
 <br>
 
 But things are a bit disorganized: Azara's coordinates appear to be formatted and sorted differently from Rui's, and they have to keep looking from one list to the other to figure out which treasures go with which locations.
-  Being budding pythonistas, they have come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
+Being budding pythonistas, they have come to you for help in writing a small program (a set of functions, really) to better organize their hunt information.
 
 
 ## 1. Extract coordinates
 
 Implement the `get_cooordinate()` function that takes a `(treasure, coordinate)` pair from Azaras list and returns only the extracted map coordinate.
-​
+
 
 ```python
 >>> get_coordinate(("Scrimshaw Whale's Tooth", "2A"))
@@ -74,7 +74,8 @@ Implement the `convert_coordinate()` function that takes a coordinate in the for
 
 ## 3. Match coordinates
 
-Implement the `compare_records()` function that takes a `(treasure, coordinate)` pair and a `(location, coordinate, quadrant)` record and compares coordinates from each. Return **`True`** if the coordinates "match", and return **`False`** if they do not. Re-format coordinates as needed for accurate comparison.
+Implement the `compare_records()` function that takes a `(treasure, coordinate)` pair and a `(location, coordinate, quadrant)` record and compares coordinates from each. Return **`True`** if the coordinates "match", and return **`False`** if they do not.
+Re-format coordinates as needed for accurate comparison.
 
 
 ```python
@@ -88,7 +89,7 @@ True
 ## 4. Combine matched records
 
 Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis' list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinates _do not_ match, return the string **"not a match"**
-  Re-format the coordinate as needed for accurate comparison.
+Re-format the coordinate as needed for accurate comparison.
 
 
 ```python
@@ -102,8 +103,8 @@ Implement the `create_record()` function that takes a `(treasure, coordinate)` p
 ## 5. "Clean up" & make a report of all records
 
 Clean up the combined records from Azara and Rui so that there's only one set of coordinates per record. Make a report so they can see one list of everything they need to put on their maps.
-  Implement the `clean_up()` function that takes a tuple of tuples (_everything from both lists_), looping through the _outer_ tuple, dropping the unwanted coordinates from each _inner_ tuple and adding each to a 'report'.
-  Format and return the 'report' so that there is one cleaned record on each line.
+Implement the `clean_up()` function that takes a tuple of tuples (_everything from both lists_), looping through the _outer_ tuple, dropping the unwanted coordinates from each _inner_ tuple and adding each to a 'report'.
+Format and return the 'report' so that there is one cleaned record on each line.
 
 
 ```python

--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -74,7 +74,8 @@ Implement the `convert_coordinate()` function that takes a coordinate in the for
 
 ## 3. Match coordinates
 
-Implement the `compare_records()` function that takes a `(treasure, coordinate)` pair and a `(location, coordinate, quadrant)` record and compares coordinates from each. Return **`True`** if the coordinates "match", and return **`False`** if they do not.
+Implement the `compare_records()` function that takes a `(treasure, coordinate)` pair and a `(location, coordinate, quadrant)` record and compares coordinates from each.
+Return **`True`** if the coordinates "match", and return **`False`** if they do not.
 Re-format coordinates as needed for accurate comparison.
 
 
@@ -88,7 +89,8 @@ True
 
 ## 4. Combine matched records
 
-Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis' list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**. If the coordinates _do not_ match, return the string **"not a match"**
+Implement the `create_record()` function that takes a `(treasure, coordinate)` pair from Azaras list and a `(location, coordinate, quadrant)` record from Ruis' list and returns `(treasure, coordinate, location, coordinate, quadrant)` **if the coordinates match**.
+If the coordinates _do not_ match, return the string **"not a match"**
 Re-format the coordinate as needed for accurate comparison.
 
 


### PR DESCRIPTION
Removed the excess leading spaces as per the unaccepted feedback from [PR #2503](https://github.com/exercism/python/pull/2503).  @kotp  -- you were right (of course 😄 ).