### PR TITLE
test_round_scores at Making the Grade accepts any order of rounded data

### DIFF
--- a/exercises/concept/making-the-grade/.docs/instructions.md
+++ b/exercises/concept/making-the-grade/.docs/instructions.md
@@ -14,7 +14,7 @@ There shouldn't be any scores that have more than two places after the decimal p
 
 Create the function `round_scores()` that takes a `list` of `student_scores`.
 This function should _consume_ the input `list` and `return` a new list with all the scores converted to `int`s.
-The order of the scores in the resulting list is not important.
+The order of the scores in the resulting `list` is not important.
 
 ```python
 >>> student_scores = [90.33, 40.5, 55.44, 70.05, 30.55, 25.45, 80.45, 95.3, 38.7, 40.3]

--- a/exercises/concept/making-the-grade/.docs/instructions.md
+++ b/exercises/concept/making-the-grade/.docs/instructions.md
@@ -14,6 +14,7 @@ There shouldn't be any scores that have more than two places after the decimal p
 
 Create the function `round_scores()` that takes a `list` of `student_scores`.
 This function should _consume_ the input `list` and `return` a new list with all the scores converted to `int`s.
+The order of the scores in the resulting list is not important.
 
 ```python
 >>> student_scores = [90.33, 40.5, 55.44, 70.05, 30.55, 25.45, 80.45, 95.3, 38.7, 40.3]

--- a/exercises/concept/making-the-grade/loops_test.py
+++ b/exercises/concept/making-the-grade/loops_test.py
@@ -32,7 +32,7 @@ class MakingTheGradeTest(unittest.TestCase):
 
         for variant, scores, results in zip(number_of_variants, input_data, result_data):
             with self.subTest(f"variation #{variant}", scores=scores, results=results):
-                self.assertEqual(round_scores(scores), results,
+                self.assertEqual(sorted(round_scores(scores)), sorted(results),
                                  msg=f'Expected: {results} but one or more {scores} were rounded incorrectly.')
 
 


### PR DESCRIPTION
Related to issue #2526, `test_round_scores()` at Making the Grade should accept any order of rounded data, not just a reversed one.