### PR TITLE
Follow unittest method naming conventions

### DIFF
--- a/exercises/concept/little-sisters-essay/string_methods_test.py
+++ b/exercises/concept/little-sisters-essay/string_methods_test.py
@@ -26,12 +26,12 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(check_sentence_ending("Fittonia are nice"), False)
 
     @pytest.mark.task(taskno=3)
-    def remove_extra_spaces_only_start(self):
+    def test_remove_extra_spaces_only_start(self):
         self.assertEqual(clean_up_spacing("  A rolling stone gathers no moss"),
                         "A rolling stone gathers no moss")
 
     @pytest.mark.task(taskno=3)
-    def remove_extra_spaces(self):
+    def test_remove_extra_spaces(self):
         self.assertEqual(clean_up_spacing("  Elephants can't jump.  "),
                         "Elephants can't jump.")
 


### PR DESCRIPTION
Some tests were not executing since every test method has to be prefixed with `test`