### PR TITLE
Added missing 'unexchangeable_value' function to exchange.py

### DIFF
--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -1,54 +1,67 @@
 def estimate_value(budget, exchange_rate):
-    '''
+    """
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
     :return:
-    '''
+    """
 
     pass
 
 def get_change(budget, exchanging_value):
-    '''
+    """
 
     :param budget: float - amount of money you own.
     :param exchanging_value: int - amount of your money you want to exchange now.
     :return:
-    '''
+    """
 
     pass
 
 
 def get_value(denomination, number_of_bills):
-    '''
+    """
 
     :param denomination: int - the value of a bill.
     :param number_of_bills: int amount of bills you received.
     :return:
-    '''
+    """
 
     pass
 
 
 def get_number_of_bills(budget, denomination):
-    '''
+    """
 
     :param budget: float - the amount of money you are planning to exchange.
     :param denomination: int - the value of a single bill.
     :return:
-    '''
+    """
 
     pass
 
 
 def exchangeable_value(budget, exchange_rate, spread, denomination):
-    '''
+    """
 
     :param budget: float - the amount of your money you are planning to exchange.
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
     :return:
-    '''
+    """
+
+    pass
+
+
+def unexchangeable_value(budget, exchange_rate, spread, denomination):
+    """
+
+    :param budget: float - the amount of your money you are planning to exchange.
+    :param exchange_rate: float - the unit value of the foreign currency.
+    :param spread: int - percentage that is taken as an exchange fee.
+    :param denomination: int - the value of a single bill.
+    :return:
+    """
 
     pass


### PR DESCRIPTION
Added missing function to [Currency Exchange](https://exercism.org/tracks/python/exercises/currency-exchange) exercise's `exchange.py` file.

Function `unexchangeable_value()` exists in tests and instructions but not in `exchange.py` file. I don't think it's intentional since this is a learning exercise.

Also changed single to double triple quotes