### PR TITLE
Fixed docstrings for Currency Exchange

### DIFF
--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -64,7 +64,7 @@ def unexchangeable_value(budget, exchange_rate, spread, denomination):
 	:param exchange_rate: float - unit value of the foreign currency.
 	:param spread: int - the percentage taken as an exchange fee.
 	:param denomination:  int - the value of a single bill.
-	:return: unexchangeable value
+	:return: int - unexchangeable value
 	"""
 
 	exchange_fee = (exchange_rate / 100) * spread

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -1,56 +1,56 @@
 def estimate_value(budget, exchange_rate):
-	'''
+	"""
 
 	:param budget: float - amount of money you are planning to exchange.
 	:param exchange_rate: float - unit value of the foreign currency.
-	:return:
-	'''
+	:return: float - estimated value of the foreign currency you can receive
+	"""
 
 	return budget / exchange_rate
 
 
 def get_change(budget, exchanging_value):
-	'''
+	"""
 
 	:param budget: float - amount of money you own.
 	:param exchanging_value: int - amount of your money you want to exchange now.
-	:return:
-	'''
+	:return: float - amount left of your starting currency after exchanging
+	"""
 
 	return budget - exchanging_value
 
 
 def get_value(denomination, number_of_bills):
-	'''
+	"""
 
 	:param denomination: int - the value of a bill.
 	:param number_of_bills: int amount of bills you received.
-	:return:
-	'''
+	:return: int - total value of bills you now have
+	"""
 
 	return number_of_bills * denomination
 
 
 def get_number_of_bills(budget, denomination):
-	'''
+	"""
 
 	:param budget: float - the amount of money you are planning to exchange.
 	:param denomination: int - the value of a single bill.
-	:return:
-	'''
+	:return: int - number of bills after exchanging all your money
+	"""
 
 	return int(budget / denomination)
 
 
 def exchangeable_value(budget, exchange_rate, spread, denomination):
-	'''
+	"""
 
 	:param budget: float - the amount of your money you are planning to exchange.
 	:param exchange_rate: float - the unit value of the foreign currency.
 	:param spread: int - percentage that is taken as an exchange fee.
 	:param denomination: int - the value of a single bill.
-	:return:
-	'''
+	:return: int - maximum value you can get
+	"""
 
 	exchange_fee = (exchange_rate / 100) * spread
 	actual_rate = exchange_rate + exchange_fee
@@ -58,14 +58,15 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
 	return exchangeable_amount * denomination
 
 def unexchangeable_value(budget, exchange_rate, spread, denomination):
-	'''
+	"""
 
 	:param budget: float - amount of money you are planning to exchange.
 	:param exchange_rate: float - unit value of the foreign currency.
 	:param spread: int - the percentage taken as an exchange fee.
 	:param denomination:  int - the value of a single bill.
-	:return:
-	'''
+	:return: unexchangeable value
+	"""
+
 	exchange_fee = (exchange_rate / 100) * spread
 	actual_rate = exchange_rate + exchange_fee
 	unexchangeable_amount = int((budget / actual_rate) % denomination)

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -3,7 +3,7 @@ def estimate_value(budget, exchange_rate):
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
-    :return:
+    :return: float - estimated value of the foreign currency you can receive
     """
 
     pass
@@ -13,7 +13,7 @@ def get_change(budget, exchanging_value):
 
     :param budget: float - amount of money you own.
     :param exchanging_value: int - amount of your money you want to exchange now.
-    :return:
+    :return: float - amount left of your starting currency after exchanging
     """
 
     pass
@@ -23,8 +23,8 @@ def get_value(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int amount of bills you received.
-    :return:
+    :param number_of_bills: int - amount of bills you received.
+    :return: int - total value of bills you now have
     """
 
     pass
@@ -35,7 +35,7 @@ def get_number_of_bills(budget, denomination):
 
     :param budget: float - the amount of money you are planning to exchange.
     :param denomination: int - the value of a single bill.
-    :return:
+    :return: int - number of bills after exchanging all your money
     """
 
     pass
@@ -48,7 +48,7 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
-    :return:
+    :return: int - maximum value you can get
     """
 
     pass
@@ -61,7 +61,7 @@ def unexchangeable_value(budget, exchange_rate, spread, denomination):
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
-    :return:
+    :return: int - unexchangeable value
     """
 
     pass

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -1,54 +1,67 @@
 def estimate_value(budget, exchange_rate):
-    '''
+    """
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
     :return:
-    '''
+    """
 
     pass
 
 def get_change(budget, exchanging_value):
-    '''
+    """
 
     :param budget: float - amount of money you own.
     :param exchanging_value: int - amount of your money you want to exchange now.
     :return:
-    '''
+    """
 
     pass
 
 
 def get_value(denomination, number_of_bills):
-    '''
+    """
 
     :param denomination: int - the value of a bill.
     :param number_of_bills: int amount of bills you received.
     :return:
-    '''
+    """
 
     pass
 
 
 def get_number_of_bills(budget, denomination):
-    '''
+    """
 
     :param budget: float - the amount of money you are planning to exchange.
     :param denomination: int - the value of a single bill.
     :return:
-    '''
+    """
 
     pass
 
 
 def exchangeable_value(budget, exchange_rate, spread, denomination):
-    '''
+    """
 
     :param budget: float - the amount of your money you are planning to exchange.
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
     :return:
-    '''
+    """
+
+    pass
+
+
+def unexchangeable_value(budget, exchange_rate, spread, denomination):
+    """
+
+    :param budget: float - the amount of your money you are planning to exchange.
+    :param exchange_rate: float - the unit value of the foreign currency.
+    :param spread: int - percentage that is taken as an exchange fee.
+    :param denomination: int - the value of a single bill.
+    :return:
+    """
 
     pass


### PR DESCRIPTION
Issue #2545 

Added return type and value in docstrings for `exchange.py` and `exemplar.py` files

Additional: fixed minor typo in `tuples.py`