### PR TITLE
Fixed numbers_to_cube example.

### DIFF
--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -225,12 +225,12 @@ Blue : 3
 # Start with a list of numbers and then loop through and print out their cubes.
 >>> numbers_to_cube = [5, 13, 12, 16]
 >>> for number in numbers_to_cube:
-...     print(number*3)
+...     print(number**3)
 ...
-15
-39
-36
-48
+125
+2197
+1728
+4096
 ```
 
 One common way to compose a list of values is to use `<list>.append()` within a loop:


### PR DESCRIPTION
numbers_to_cube example in "Working with Lists" used "*3" instead of "**3" while the example
description says that numbers are going to be cubed. Due to this typo the example output was
also wrong and had numbers in the list multiplied by three instead of cubes.

This change fixes the operation to be cube as per the description and also fixes the output.