### PR TITLE
[Meltdow Mitigation] Changes to docstrings and exemplar file for PyLinting

### DIFF
--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -1,5 +1,5 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
-    '''
+    """Verify criticality is balanced.
 
     :param temperature: int
     :param neutrons_emitted: int
@@ -9,17 +9,18 @@ def is_criticality_balanced(temperature, neutrons_emitted):
     - The temperature less than 800.
     - The number of neutrons emitted per second greater than 500.
     - The product of temperature and neutrons emitted per second less than 500000.
-    '''
+    """
     output = temperature * neutrons_emitted
+    balanced = False
 
     if (temperature < 800 and neutrons_emitted > 500) and output < 500000:
-        return True
-    else:
-        return False
+        balanced = True
+
+    return balanced
 
 
 def reactor_efficiency(voltage, current, theoretical_max_power):
-    '''
+    """Assess reactor efficiency zone.
 
     :param voltage: int
     :param current: int
@@ -36,21 +37,25 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
     These percentage ranges are calculated as
     (generated power/ theoretical max power)*100
     where generated power = voltage * current
-    '''
+    """
     generated_power = voltage * current
-    percentage_range = (generated_power/theoretical_max_power)*100
+    percentage_range = (generated_power / theoretical_max_power) * 100
+    efficiency_level = 'unknown'
 
     if 80 <= percentage_range <= 100:
-        return  'green'
+        efficiency_level = 'green'
     elif 60 <= percentage_range <= 79:
-        return 'orange'
+        efficiency_level = 'orange'
     elif 30 <= percentage_range <= 59:
-        return 'red'
+        efficiency_level = 'red'
     else:
-        return 'black'
+        efficiency_level = 'black'
+
+    return efficiency_level
+
 
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
-    '''
+    """Assess and return safety range.
 
     :param temperature:
     :param neutrons_produced_per_second:
@@ -60,13 +65,16 @@ def fail_safe(temperature, neutrons_produced_per_second, threshold):
     - `temperature * neutrons per second` < 40% of `threshold` == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'
     - `temperature * neutron per second` is not in the above-stated ranges ==  'DANGER'
-    '''
+    """
     output = temperature * neutrons_produced_per_second
-    operational_percentage = int((output/threshold) * 100)
+    operational_percentage = int((output / threshold) * 100)
+    safety_range = 'UNKNOWN'
 
     if operational_percentage < 40:
-        return 'LOW'
+        safety_range = 'LOW'
     elif 90 <= operational_percentage <= 110:
-        return 'NORMAL'
+        safety_range = 'NORMAL'
     else:
-        return 'DANGER'
+        safety_range = 'DANGER'
+
+    return safety_range

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -1,5 +1,5 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
-    '''
+    """Verify criticality is balanced.
 
     :param temperature: int
     :param neutrons_emitted: int
@@ -9,13 +9,13 @@ def is_criticality_balanced(temperature, neutrons_emitted):
     - The temperature is less than 800.
     - The number of neutrons emitted per second is greater than 500.
     - The product of temperature and neutrons emitted per second is less than 500000.
-    '''
+    """
 
     pass
 
 
 def reactor_efficiency(voltage, current, theoretical_max_power):
-    '''
+    """Assess reactor efficiency zone.
 
     :param voltage: int
     :param current: int
@@ -32,13 +32,13 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
     These percentage ranges are calculated as
     (generated power/ theoretical max power)*100
     where generated power = voltage * current
-    '''
+    """
 
     pass
 
 
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
-    '''
+    """Assess and return safety range.
 
     :param temperature:
     :param neutrons_produced_per_second:
@@ -48,6 +48,6 @@ def fail_safe(temperature, neutrons_produced_per_second, threshold):
     - `temperature * neutrons per second` < 40% of threshold == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'
     - `temperature * neutron per second` is not in the above-stated ranges ==  'DANGER'
-    '''
+    """
 
     pass

--- a/exercises/concept/meltdown-mitigation/conditionals_test.py
+++ b/exercises/concept/meltdown-mitigation/conditionals_test.py
@@ -3,8 +3,7 @@ import unittest
 import pytest
 from conditionals import (is_criticality_balanced,
                           reactor_efficiency,
-                          fail_safe
-                          )
+                          fail_safe)
 
 
 class TestConditionals(unittest.TestCase):
@@ -14,33 +13,32 @@ class TestConditionals(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_is_criticality_balanced_set1(self):
-
         self.assertTrue(is_criticality_balanced(
             temperature=750, neutrons_emitted=650), msg="Expected True but returned False")
 
+
     @pytest.mark.task(taskno=1)
     def test_is_criticality_balanced_set2(self):
-
         self.assertTrue(is_criticality_balanced(
             temperature=799, neutrons_emitted=501), msg="Expected True but returned False")
 
+
     @pytest.mark.task(taskno=1)
     def test_is_criticality_balanced_set3(self):
-
         self.assertTrue(
             is_criticality_balanced(temperature=500, neutrons_emitted=600), msg="Expected True but returned False"
         )
 
+
     @pytest.mark.task(taskno=1)
     def test_is_criticality_balanced_set4(self):
-
         self.assertFalse(
             is_criticality_balanced(temperature=800, neutrons_emitted=500), msg="Expected False but returned True"
         )
 
-# End of first functions testing
+    # End of first functions testing
 
-# Test case for reactor_ efficiency()
+    # Test case for reactor_ efficiency()
     # Checking the second condition using assertEqual
     # The values for arguments is not final and should be considered as placeholders
     # More test-cases  required for full testing
@@ -49,12 +47,12 @@ class TestConditionals(unittest.TestCase):
 
     @pytest.mark.task(taskno=2)
     def test_reactor_efficiency_set1(self):
-
         test_return = reactor_efficiency(
             voltage=100, current=50, theoretical_max_power=5000)
         self.assertEqual(
             test_return, 'green', msg=f"Expected green but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=2)
     def test_reactor_efficiency_set2(self):
@@ -64,6 +62,7 @@ class TestConditionals(unittest.TestCase):
             test_return, 'orange', msg=f"Expected orange but returned {test_return}"
         )
 
+
     @pytest.mark.task(taskno=2)
     def test_reactor_efficiency_set3(self):
         test_return = reactor_efficiency(
@@ -71,6 +70,7 @@ class TestConditionals(unittest.TestCase):
         self.assertEqual(
             test_return, 'red', msg=f"Expected red but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=2)
     def test_reactor_efficiency_set4(self):
@@ -80,10 +80,9 @@ class TestConditionals(unittest.TestCase):
             test_return, 'black', msg=f"Expected black but returned {test_return}"
         )
 
-# End of second function testing
+    # End of second function testing
 
-
-# Test case for fail_safe()
+    # Test case for fail_safe()
     # Checking the third condition using assertEqual
     # The values for arguments is not final and should be considered as placeholders
     # More test-cases  required for full testing
@@ -98,6 +97,7 @@ class TestConditionals(unittest.TestCase):
             test_return, 'LOW', msg=f"Expected LOW but returned {test_return}"
         )
 
+
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set2(self):
         test_return = fail_safe(
@@ -105,6 +105,7 @@ class TestConditionals(unittest.TestCase):
         self.assertEqual(
             test_return, 'LOW', msg=f"Expected LOW but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set3(self):
@@ -114,6 +115,7 @@ class TestConditionals(unittest.TestCase):
             test_return, 'LOW', msg=f"Expected LOW but returned {test_return}"
         )
 
+
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set4(self):
         test_return = fail_safe(
@@ -121,6 +123,7 @@ class TestConditionals(unittest.TestCase):
         self.assertEqual(
             test_return, 'NORMAL', msg=f"Expected NORMAL but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set5(self):
@@ -130,6 +133,7 @@ class TestConditionals(unittest.TestCase):
             test_return, 'NORMAL', msg=f"Expected NORMAL but returned {test_return}"
         )
 
+
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set6(self):
         test_return = fail_safe(
@@ -137,6 +141,7 @@ class TestConditionals(unittest.TestCase):
         self.assertEqual(
             test_return, 'NORMAL', msg=f"Expected NORMAL but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set7(self):
@@ -146,6 +151,7 @@ class TestConditionals(unittest.TestCase):
             test_return, 'DANGER', msg=f"Expected DANGER but returned {test_return}"
         )
 
+
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set8(self):
         test_return = fail_safe(
@@ -153,6 +159,7 @@ class TestConditionals(unittest.TestCase):
         self.assertEqual(
             test_return, 'DANGER', msg=f"Expected DANGER but returned {test_return}"
         )
+
 
     @pytest.mark.task(taskno=3)
     def test_fail_safe_set9(self):


### PR DESCRIPTION
Related to #2537  & #2535

- [x] Changed the single quoted docstrings to double quoted docstrings and added function descriptions per PEP 257.
- [x] Added two lines between functions in `exemplar.py`, per PyLinting
- [x] Changed multiple returns to single returns in `exemplar.py` to conform to PyLint nags and issues brought up in
         #2535.
- [x] Ran stub and `exemplar.py` files through PyLint to make sure the only nag was for the missing module docstring. 