### PR TITLE
[Python (PyTest)] Added PyTest ini File to Register Task Custom Mark

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    task: A concept exercise task.


### PR DESCRIPTION
Partially addresses #2539, although documentation should also be updated.

Added basic `pytest.ini` with registration for task mark so Pytest will no longer throw warnings when run locally outside of the test runner.