### PR TITLE
Add iterator independence test to linked-list exercise.

### DIFF
--- a/exercises/practice/linked-list/linked_list_test.py
+++ b/exercises/practice/linked-list/linked_list_test.py
@@ -65,6 +65,18 @@ class LinkedListTest(unittest.TestCase):
         self.assertEqual(next(iterator), 10)
         self.assertEqual(next(iterator), 20)
 
+    @unittest.skip("extra-credit")
+    def test_iterator_independence(self):
+        lst = LinkedList()
+        lst.push(10)
+        lst.push(20)
+        iterator_a = iter(lst)
+        iterator_b = iter(lst)
+        self.assertEqual(next(iterator_a), 10)
+        self.assertEqual(next(iterator_a), 20)
+        self.assertEqual(next(iterator_b), 10)
+        self.assertEqual(next(iterator_b), 20)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a PR for https://github.com/exercism/python/issues/2572.

This PR adds a test to the linked-list exercise, which checks that different calls to `iter()` on the same `LinkedList` instance return independent iterators, (i.e. which change state independently of each other).

