### PR TITLE
Update ci-workflow.yml to use ubuntu-latest

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,7 +49,7 @@ jobs:
         ./bin/template_status.py -v -p .problem-specifications
 
   canonical_sync:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: housekeeping
     strategy:
       matrix:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   housekeeping:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
 


### PR DESCRIPTION
Per notice and instructions listed in [3287](https://github.com/actions/virtual-environments/issues/3287), `ubuntu-16.04` is being deprecated.  Updated this workflow to use `ubuntu-latest`