### PR TITLE
Improve tests of `card-games` exercise

### DIFF
--- a/exercises/concept/card-games/.meta/exemplar.py
+++ b/exercises/concept/card-games/.meta/exemplar.py
@@ -52,7 +52,14 @@ def approx_average_is_average(hand):
     :return: bool - is approximate average the same as true average?
     """
 
-    return card_average([hand[0], hand[-1]]) == card_average(hand)
+    real_average = card_average(hand)
+    if card_average([hand[0], hand[-1]]) == real_average:
+        is_same = True
+    elif hand[len(hand) // 2] == real_average:
+        is_same = True
+    else:
+        is_same = False
+    return is_same
 
 
 def average_even_is_average_odd(hand):

--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -60,9 +60,9 @@ class TestConcatenateRounds(unittest.TestCase):
         want = []
 
         self.assertEqual(concatenate_rounds(rounds_1, rounds_2),
-            want,
-            msg=f'Expected {want} but got an incorrect result.'
-            )
+                         want,
+                         msg=f'Expected {want} but got an incorrect result.'
+                         )
 
     @pytest.mark.task(taskno=2)
     def test_other(self):
@@ -201,6 +201,18 @@ class TestApproxAverageIsAverage(unittest.TestCase):
     def test_instructions_example_3(self):
         hand = [1, 2, 3, 5, 9]
         want = False
+        got = approx_average_is_average(hand)
+
+        self.assertEqual(
+            want,
+            got,
+            msg=f'Expected {want} but got an incorrect result: {got!r}'
+        )
+
+    @pytest.mark.task(taskno=5)
+    def test_median_true(self):
+        hand = [1, 2, 4, 5, 8]
+        want = True
         got = approx_average_is_average(hand)
 
         self.assertEqual(


### PR DESCRIPTION
- Fix unmatched visual indentation in `TestConcatenateRounds`
- Add a test case for `TestApproxAverageIsAverage` to also check if median equals average

The latter was also not implemented in the example solution, so added it there as well.