### PR TITLE
Currency Exchange]: Improvements

### DIFF
--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -1,17 +1,17 @@
 # Instructions
 
-Your friend Chandler plans to visit exotic countries all around the world. Sadly, Chandler's math skills aren't good. He's pretty worried about being scammed with currency exchange during his trip - and he wants you to make a currency calculator for him. Here's his specification for the app:
+Your friend Chandler plans to visit exotic countries all around the world. Sadly, Chandler's math skills aren't good. He's pretty worried about being scammed by currency exchanges during his trip - and he wants you to make a currency calculator for him. Here are his specifications for the app:
 
 ## 1. Estimate value after exchange
 
 Create the `exchange_money()` function, taking 2 parameters:
 
-1. `budget` : the amount of money you are planning to exchange.
-2. `exchange_rate` : unit value of the foreign currency.
+1. `budget` : The amount of money you are planning to exchange.
+2. `exchange_rate` : Unit value of the foreign currency.
 
-This function should return the estimated value of the foreign currency you can receive.
+This function should return the value of the exchanged currency.
 
-**Note:** If your currency is USD and you want to exchange USD for EUR with an exchange rate of `1.20`, then `1.20 USD` == `1 EUR`.
+**Note:** If your currency is USD and you want to exchange USD for EUR with an exchange rate of `1.20`, then `1.20 USD == 1 EUR`.
 
 ```python
 >>> exchange_money(127.5, 1.2)
@@ -22,10 +22,10 @@ This function should return the estimated value of the foreign currency you can 
 
 Create the `get_change()` function, taking 2 parameters:
 
-1. `budget` : amount of money you own.
-2. `exchanging_value` : amount of your money you want to exchange now.
+1. `budget` : Amount of money before exchange.
+2. `exchanging_value` : Amount of money that is *taken* from the budget to be exchanged.
 
-This function should return the amount left of your starting currency after exchanging `exchanging_value`.
+This function should return the amount of money that *is left* from the budget.
 
 ```python
 >>> get_change(127.5, 120)
@@ -36,10 +36,10 @@ This function should return the amount left of your starting currency after exch
 
 Create the `get_value_of_bills()` function, taking 2 parameters:
 
-1. `denomination` : the value of a single bill.
-2. `number_of_bills` : amount of bills you received.
+1. `denomination` : The value of a single bill.
+2. `number_of_bills` : Amount of bills you received.
 
-This function should return the total value of bills you now have.
+This function should return the total value of the given *bills*.
 
 ```python
 >>> get_value_of_bills(5, 128)
@@ -48,12 +48,9 @@ This function should return the total value of bills you now have.
 
 ## 4. Calculate number of bills
 
-Create the `get_number_of_bills()` function, taking 2 parameters:
+Create the `get_number_of_bills()` function, taking `budget` and `denomination`.
 
-1. `budget` : amount of money you are planning to exchange.
-2. `denomination` : the value of a single bill.
-
-This function should return the number of bills after exchanging all your money.
+This function should return the *number of bills* that you can get using the *budget*.
 
 ```python
 >>> get_number_of_bills(127.5, 5)
@@ -62,16 +59,13 @@ This function should return the number of bills after exchanging all your money.
 
 ## 5. Calculate value after exchange
 
-Create the `exchangeable_value()` function, taking 4 parameters:
+Create the `exchangeable_value()` function, taking `budget`, `exchange_rate`, `spread`, and `denomination`.
 
-1. `budget` : amount of your money you are planning to exchange.
-2. `exchange_rate` : unit value of the foreign currency.
-3. `spread` : percentage taken as exchange fee.
-4. `denomination` : the value of a single bill.
+Parameter `spread` is the *percentage taken* as exchange fee. If `1.00 EUR == 1.20 USD` and the *spread* is `10%`, the actual exchange will be: `1.00 EUR == 1.32 USD`.
 
-This function should return the maximum value you can get.
+This function should return the maximum available value after *exchange rate* and the *denomination*.
 
-**Note:** If `1 EUR` == `1.20 USD` and the spread is `10%`, the _actual exchange rate_ becomes `1 EUR` == `1.32 USD`.
+**Note:** Returned value should be `int` type.
 
 ```python
 >>> exchangeable_value(127.25, 1.20, 10, 20)
@@ -82,14 +76,9 @@ This function should return the maximum value you can get.
 
 ## 6. Calculate non-exchangeable value
 
-Create the `non_exchangeable_value()` function, taking 4 parameters:
+Create the `non_exchangeable_value()` function, taking `budget`, `exchange_rate`, `spread`, and `denomination`.
 
-1. `budget` : amount of your money you are planning to exchange.
-2. `exchange_rate` : unit value of the foreign currency.
-3. `spread` : percentage taken as exchange fee.
-4. `denomination` : the value of a single bill.
-
-This function should return the unexchangeable value considering these.
+This function should return the value that is *not* exchangeable due to the *denomination* of the bills.
 
 **Note:** Returned value should be `int` type.
 

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -4,23 +4,23 @@ Your friend Chandler plans to visit exotic countries all around the world. Sadly
 
 ## 1. Estimate value after exchange
 
-Create the `estimate_value()` function, where `budget` & `exchange_rate` are the two required parameters:
+Create the `exchange_money()` function, taking 2 parameters:
 
 1. `budget` : the amount of money you are planning to exchange.
 2. `exchange_rate` : unit value of the foreign currency.
 
-This function should return the estimated value of the foreign currency you can receive based on your `budget` and the current `exchange rate`.
+This function should return the estimated value of the foreign currency you can receive.
 
 **Note:** If your currency is USD and you want to exchange USD for EUR with an exchange rate of `1.20`, then `1.20 USD` == `1 EUR`.
 
 ```python
->>> estimate_value(127.5, 1.2)
+>>> exchange_money(127.5, 1.2)
 106.25
 ```
 
 ## 2. Calculate currency left after an exchange
 
-Create the `get_change()` function, where `budget` & `exchanging_value` are the two required parameters:
+Create the `get_change()` function, taking 2 parameters:
 
 1. `budget` : amount of money you own.
 2. `exchanging_value` : amount of your money you want to exchange now.
@@ -34,7 +34,7 @@ This function should return the amount left of your starting currency after exch
 
 ## 3. Calculate value of bills
 
-Create the `get_value()` function, with parameters `denomination` & `number_of_bills`
+Create the `get_value_of_bills()` function, taking 2 parameters:
 
 1. `denomination` : the value of a single bill.
 2. `number_of_bills` : amount of bills you received.
@@ -42,13 +42,13 @@ Create the `get_value()` function, with parameters `denomination` & `number_of_b
 This function should return the total value of bills you now have.
 
 ```python
->>> get_value(5, 128)
+>>> get_value_of_bills(5, 128)
 640
 ```
 
 ## 4. Calculate number of bills
 
-Create the `get_number_of_bills()` function, with parameters `budget` & `denomination`
+Create the `get_number_of_bills()` function, taking 2 parameters:
 
 1. `budget` : amount of money you are planning to exchange.
 2. `denomination` : the value of a single bill.
@@ -62,14 +62,14 @@ This function should return the number of bills after exchanging all your money.
 
 ## 5. Calculate value after exchange
 
-Create the `exchangeable_value()` function, with parameter `budget`, `exchange_rate`, `spread`, & `denomination`.
+Create the `exchangeable_value()` function, taking 4 parameters:
 
 1. `budget` : amount of your money you are planning to exchange.
 2. `exchange_rate` : unit value of the foreign currency.
 3. `spread` : percentage taken as exchange fee.
 4. `denomination` : the value of a single bill.
 
-This function should return the maximum value you can get considering the `budget`, `exchange_rate`, `spread`, & `denomination`.
+This function should return the maximum value you can get.
 
 **Note:** If `1 EUR` == `1.20 USD` and the spread is `10%`, the _actual exchange rate_ becomes `1 EUR` == `1.32 USD`.
 
@@ -80,22 +80,22 @@ This function should return the maximum value you can get considering the `budge
 95
 ```
 
-## 6. Calculate unexchangeable value
+## 6. Calculate non-exchangeable value
 
-Create the `unexchangeable_value()` function, with parameter `budget`, `exchange_rate`, `spread`, & `denomination`.
+Create the `non_exchangeable_value()` function, taking 4 parameters:
 
 1. `budget` : amount of your money you are planning to exchange.
 2. `exchange_rate` : unit value of the foreign currency.
 3. `spread` : percentage taken as exchange fee.
 4. `denomination` : the value of a single bill.
 
-This function should return the unexchangeable value considering the `budget`, `exchange_rate`, `spread`, & `denomination`.
+This function should return the unexchangeable value considering these.
 
 **Note:** Returned value should be `int` type.
 
 ```python
->>> unexchangeable_value(127.25, 1.20, 10, 20)
+>>> non_exchangeable_value(127.25, 1.20, 10, 20)
 16
->>> unexchangeable_value(127.25, 1.20, 10, 5)
+>>> non_exchangeable_value(127.25, 1.20, 10, 5)
 1
 ```

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -61,7 +61,8 @@ This function should return the *number of bills* that you can get using the *bu
 
 Create the `exchangeable_value()` function, taking `budget`, `exchange_rate`, `spread`, and `denomination`.
 
-Parameter `spread` is the *percentage taken* as exchange fee. If `1.00 EUR == 1.20 USD` and the *spread* is `10%`, the actual exchange will be: `1.00 EUR == 1.32 USD`.
+Parameter `spread` is the *percentage taken* as an exchange fee.
+If `1.00 EUR == 1.20 USD` and the *spread* is `10`, the actual exchange will be: `1.00 EUR == 1.32 USD`.
 
 This function should return the maximum available value after *exchange rate* and the *denomination*.
 

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -51,7 +51,7 @@ This function should return the total value of the given *bills*.
 Create the `get_number_of_bills()` function, taking `budget` and `denomination`.
 
 This function should return the *number of bills* that you can get using the *budget*.
-
+**Note: ** You can only receive _whole bills_, not fractions of bills,  so remember to divide accordingly.
 ```python
 >>> get_number_of_bills(127.5, 5)
 25

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -64,7 +64,8 @@ Create the `exchangeable_value()` function, taking `budget`, `exchange_rate`, `s
 Parameter `spread` is the *percentage taken* as an exchange fee.
 If `1.00 EUR == 1.20 USD` and the *spread* is `10`, the actual exchange will be: `1.00 EUR == 1.32 USD`.
 
-This function should return the maximum available value after *exchange rate* and the *denomination*.
+This function should return the maximum value of the new currency after calculating the *exchange rate* plus the *spread*.
+Remember that the currency *denomination* is a whole number, and cannot be sub-divided.
 
 **Note:** Returned value should be `int` type.
 

--- a/exercises/concept/currency-exchange/.meta/config.json
+++ b/exercises/concept/currency-exchange/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Learn about numbers by solving Chandler's currency exchange conundrums.",
   "icon": "hyperia-forex",
-  "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007"],
+  "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007", "J08K"],
   "files": {
     "solution": ["exchange.py"],
     "test": ["exchange_test.py"],

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -1,9 +1,9 @@
-def estimate_value(budget, exchange_rate):
+def exchange_money(budget, exchange_rate):
     """
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
-    :return: float - estimated value of the foreign currency you can receive
+    :return: float - exchanged value of the foreign currency you can receive.
     """
 
     return budget / exchange_rate
@@ -14,18 +14,18 @@ def get_change(budget, exchanging_value):
 
     :param budget: float - amount of money you own.
     :param exchanging_value: int - amount of your money you want to exchange now.
-    :return: float - amount left of your starting currency after exchanging
+    :return: float - amount left of your starting currency after exchanging.
     """
 
     return budget - exchanging_value
 
 
-def get_value(denomination, number_of_bills):
+def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
     :param number_of_bills: int amount of bills you received.
-    :return: int - total value of bills you now have
+    :return: int - total value of bills you now have.
     """
 
     return number_of_bills * denomination
@@ -36,7 +36,7 @@ def get_number_of_bills(budget, denomination):
 
     :param budget: float - the amount of money you are planning to exchange.
     :param denomination: int - the value of a single bill.
-    :return: int - number of bills after exchanging all your money
+    :return: int - number of bills after exchanging all your money.
     """
 
     return int(budget / denomination)
@@ -49,7 +49,7 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
-    :return: int - maximum value you can get
+    :return: int - maximum value you can get.
     """
 
     exchange_fee = (exchange_rate / 100) * spread
@@ -58,17 +58,17 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     return exchangeable_amount * denomination
 
 
-def unexchangeable_value(budget, exchange_rate, spread, denomination):
+def non_exchangeable_value(budget, exchange_rate, spread, denomination):
     """
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
     :param spread: int - the percentage taken as an exchange fee.
     :param denomination:  int - the value of a single bill.
-    :return: int - unexchangeable value
+    :return: int - non_exchangeable value.
     """
 
     exchange_fee = (exchange_rate / 100) * spread
     actual_rate = exchange_rate + exchange_fee
-    unexchangeable_amount = int((budget / actual_rate) % denomination)
-    return unexchangeable_amount
+    non_exchangeable_amount = int((budget / actual_rate) % denomination)
+    return non_exchangeable_amount

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -65,7 +65,7 @@ def non_exchangeable_value(budget, exchange_rate, spread, denomination):
     :param exchange_rate: float - unit value of the foreign currency.
     :param spread: int - the percentage taken as an exchange fee.
     :param denomination:  int - the value of a single bill.
-    :return: int - non_exchangeable value.
+    :return: int - the value that cannot be exchanged, due to the denomination.
     """
 
     exchange_fee = (exchange_rate / 100) * spread

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -1,9 +1,9 @@
-def estimate_value(budget, exchange_rate):
+def exchange_money(budget, exchange_rate):
     """
 
     :param budget: float - amount of money you are planning to exchange.
     :param exchange_rate: float - unit value of the foreign currency.
-    :return: float - estimated value of the foreign currency you can receive
+    :return: float - exchanged value of the foreign currency you can receive.
     """
 
     pass
@@ -14,18 +14,18 @@ def get_change(budget, exchanging_value):
 
     :param budget: float - amount of money you own.
     :param exchanging_value: int - amount of your money you want to exchange now.
-    :return: float - amount left of your starting currency after exchanging
+    :return: float - amount left of your starting currency after exchanging.
     """
 
     pass
 
 
-def get_value(denomination, number_of_bills):
+def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
     :param number_of_bills: int - amount of bills you received.
-    :return: int - total value of bills you now have
+    :return: int - total value of bills you now have.
     """
 
     pass
@@ -36,7 +36,7 @@ def get_number_of_bills(budget, denomination):
 
     :param budget: float - the amount of money you are planning to exchange.
     :param denomination: int - the value of a single bill.
-    :return: int - number of bills after exchanging all your money
+    :return: int - number of bills after exchanging all your money.
     """
 
     pass
@@ -49,20 +49,20 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
-    :return: int - maximum value you can get
+    :return: int - maximum value you can get.
     """
 
     pass
 
 
-def unexchangeable_value(budget, exchange_rate, spread, denomination):
+def non_exchangeable_value(budget, exchange_rate, spread, denomination):
     """
 
     :param budget: float - the amount of your money you are planning to exchange.
     :param exchange_rate: float - the unit value of the foreign currency.
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
-    :return: int - unexchangeable value
+    :return: int non-exchangeable value.
     """
 
     pass

--- a/exercises/concept/currency-exchange/exchange_test.py
+++ b/exercises/concept/currency-exchange/exchange_test.py
@@ -1,26 +1,26 @@
 import unittest
 import pytest
 from exchange import (
-    estimate_value,
+    exchange_money,
     get_change,
-    get_value,
+    get_value_of_bills,
     get_number_of_bills,
     exchangeable_value,
-    unexchangeable_value
+    non_exchangeable_value
 )
 
 
 class TestNumbers(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
-    def test_estimate_value(self):
+    def test_exchange_money(self):
         input_data = [(100000, 0.84), (700000, 10.1)]
         output_data = [119047, 69306]
         number_of_variants = range(1, len(input_data) + 1)
 
         for variant, input, output in zip(number_of_variants, input_data, output_data):
             with self.subTest(f"variation #{variant}", input=input, output=output):
-                self.assertEqual(int(estimate_value(input[0], input[1])), output)
+                self.assertEqual(int(exchange_money(input[0], input[1])), output)
 
     @pytest.mark.task(taskno=2)
     def test_get_change(self):
@@ -33,14 +33,14 @@ class TestNumbers(unittest.TestCase):
                 self.assertEqual(get_change(input[0], input[1]), output)
 
     @pytest.mark.task(taskno=3)
-    def test_get_value(self):
+    def test_get_value_of_bills(self):
         input_data = [(10000, 128), (50, 360), (200, 200)]
         output_data = [1280000, 18000, 40000]
         number_of_variants = range(1, len(input_data) + 1)
 
         for variant, input, output in zip(number_of_variants, input_data, output_data):
             with self.subTest(f"variation #{variant}", input=input, output=output):
-                self.assertEqual(get_value(input[0], input[1]), output)
+                self.assertEqual(get_value_of_bills(input[0], input[1]), output)
 
     @pytest.mark.task(taskno=4)
     def test_get_number_of_bills(self):
@@ -69,7 +69,7 @@ class TestNumbers(unittest.TestCase):
                 self.assertEqual(exchangeable_value(input[0], input[1], input[2], input[3]), output)
 
     @pytest.mark.task(taskno=6)
-    def test_unexchangeable_value(self):
+    def test_non_exchangeable_value(self):
         input_data = [
             (100000, 10.61, 10, 1),
             (1500, 0.84, 25, 40),
@@ -81,4 +81,5 @@ class TestNumbers(unittest.TestCase):
 
         for variant, input, output in zip(number_of_variants, input_data, output_data):
             with self.subTest(f"variation #{variant}", input=input, output=output):
-                self.assertEqual(unexchangeable_value(input[0], input[1], input[2], input[3]), output)
+                self.assertEqual(non_exchangeable_value(input[0], input[1], input[2],
+                                                      input[3]), output)


### PR DESCRIPTION
Heya, here are the improvements to the [currency exchange](https://exercism.org/tracks/python/exercises/currency-exchange) concept exercise. This was discussed over at issues #2591 and #2594. I already reviewed the readability of the instructions, but I'd like to get a second opinion on that as that was the main point of the first issue.

The exercise passes the tests as normal. Most of the improvements are grammar and language-related, for example `unexchangable_value()` was technically correct, but it has been changed to `non_exchangeable_value()` for extra clarity. The points of interest were clarified in issue #2594.

Thank you!

