### PR TITLE
Refactor tests of `card-games`

### DIFF
--- a/exercises/concept/card-games/.meta/config.json
+++ b/exercises/concept/card-games/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Learn about lists by tracking hands in card games.",
   "icon": "poker",
-  "contributors": ["valentin-p"],
+  "contributors": ["valentin-p", "pranasziaukas"],
   "authors": ["itamargal", "isaacg", "bethanyg"],
   "files": {
     "solution": ["lists.py"],

--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -1,6 +1,5 @@
 import unittest
 import pytest
-import random
 from lists import (
     get_rounds,
     concatenate_rounds,
@@ -15,150 +14,130 @@ from lists import (
 class CardGamesTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
-    def test_round_number_zero(self):
-        round_number = 0
-        want = [0, 1, 2]
+    def test_get_rounds(self):
+        data = [
+            (0, [0, 1, 2]),
+            (1, [1, 2, 3]),
+            (10, [10, 11, 12]),
+            (27, [27, 28, 29]),
+            (99, [99, 100, 101]),
+            (666, [666, 667, 668]),
+        ]
 
-        self.assertEqual(want, get_rounds(round_number),
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=1)
-    def test_random_int_for_round_number(self):
-        round_number = random.randint(0, 100)
-        want = [round_number + i for i in range(3)]
-
-        self.assertEqual(get_rounds(round_number), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=2)
-    def test_concatenate_empty_rounds(self):
-        rounds_1 = []
-        rounds_2 = []
-        want = []
-
-        self.assertEqual(concatenate_rounds(rounds_1, rounds_2), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, (number, rounds) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=number, output=rounds):
+                self.assertEqual(
+                    rounds,
+                    get_rounds(number),
+                    msg=f'Expected rounds {rounds} given the current round {number}.'
+                )
 
     @pytest.mark.task(taskno=2)
-    def test_concatenate_other_rounds(self):
-        rounds_1 = [1, 2, 3]
-        rounds_2 = [4, 5, 6]
-        want = [1, 2, 3, 4, 5, 6]
+    def test_concatenate_rounds(self):
+        data = [
+            (([], []), []),
+            (([0, 1], []), [0, 1]),
+            (([], [1, 2]), [1, 2]),
+            (([1], [2]), [1, 2]),
+            (([27, 28, 29], [35, 36]), [27, 28, 29, 35, 36]),
+            (([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6]),
+        ]
 
-        self.assertEqual(concatenate_rounds(rounds_1, rounds_2), want,
-            msg=f'Expected {want} but got an incorrect result.'
-            )
-
-    @pytest.mark.task(taskno=3)
-    def test_contains_empty_rounds(self):
-        rounds = []
-        round_number = 1
-        want = False
-
-        self.assertEqual(list_contains_round(rounds, round_number), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=3)
-    def test_contains_other_rounds_true(self):
-        rounds = [1, 2, 3]
-        round_number = 2
-        want = True
-
-        self.assertEqual(list_contains_round(rounds, round_number), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, ((rounds_1, rounds_2), rounds) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=(rounds_1, rounds_2), output=rounds):
+                self.assertEqual(
+                    rounds,
+                    concatenate_rounds(rounds_1, rounds_2),
+                    msg=f'Expected {rounds} as the concatenation of {rounds_1} and {rounds_2}.'
+                )
 
     @pytest.mark.task(taskno=3)
-    def test_contains_other_rounds_false(self):
-        rounds = [1, 2, 3]
-        round_number = 0
-        want = False
+    def test_list_contains_round(self):
+        data = [
+            (([], 1), False),
+            (([1, 2, 3], 0), False),
+            (([27, 28, 29, 35, 36], 30), False),
+            (([1], 1), True),
+            (([1, 2, 3], 1), True),
+            (([27, 28, 29, 35, 36], 29), True),
+        ]
 
-        self.assertEqual(list_contains_round(rounds, round_number), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, ((rounds, round_number), contains) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=(rounds, round_number), output=contains):
+                self.assertEqual(
+                    contains,
+                    list_contains_round(rounds, round_number),
+                    msg=f'Round {round_number} {"is" if contains else "is not"} in {rounds}.'
+                )
 
     @pytest.mark.task(taskno=4)
-    def test_card_average_other(self):
-        hand = [1, 2, 3, 4]
-        want = 2.5
+    def test_card_average(self):
+        data = [
+            ([1], 1.0),
+            ([5, 6, 7], 6.0),
+            ([1, 2, 3, 4], 2.5),
+            ([1, 10, 100], 37.0),
+        ]
 
-        self.assertEqual(card_average(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=5)
-    def test_instructions_example_3(self):
-        hand = [1, 2, 3, 5, 9]
-        want = False
-
-        self.assertEqual(approx_average_is_average(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=5)
-    def test_approx_average_median_true(self):
-        hand = [1, 2, 4, 5, 8]
-        want = True
-
-        self.assertEqual(approx_average_is_average(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, (hand, average) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=hand, output=average):
+                self.assertEqual(
+                    average,
+                    card_average(hand),
+                    msg=f'Expected {average} as the average of {hand}.'
+                )
 
     @pytest.mark.task(taskno=5)
-    def test_approx_average_other_true(self):
-        hand = [2, 3, 4]
-        want = True
+    def test_approx_average_is_average(self):
+        data = [
+            ([0, 1, 5], False),
+            ([3, 6, 9, 12, 150], False),
+            ([1, 2, 3, 5, 9], False),
+            ([2, 3, 4, 7, 8], False),
+            ([1, 2, 3], True),
+            ([2, 3, 4], True),
+            ([2, 3, 4, 8, 8], True),
+            ([1, 2, 4, 5, 8], True),
+        ]
 
-        self.assertEqual(approx_average_is_average(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=5)
-    def test_approx_average_other_false(self):
-        hand = [2, 3, 4, 7, 8]
-        want= False
-
-        self.assertEqual(approx_average_is_average(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, (hand, same) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=hand, output=same):
+                self.assertEqual(
+                    same,
+                    approx_average_is_average(hand),
+                    msg=f'Hand {hand} {"does" if same else "does not"} yield the same approximate average.'
+                )
 
     @pytest.mark.task(taskno=6)
-    def test_avg_even_odd_other_true(self):
-        hand = [5, 6, 7]
-        want= True
+    def test_average_even_is_average_odd(self):
+        data = [
+            ([5, 6, 8], False),
+            ([1, 2, 3, 4], False),
+            ([1, 2, 3], True),
+            ([5, 6, 7], True),
+        ]
 
-        self.assertEqual(average_even_is_average_odd(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=6)
-    def test_avg_even_odd_other_false(self):
-        hand = [5, 6, 8]
-        want = False
-
-        self.assertEqual(average_even_is_average_odd(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
-
-    @pytest.mark.task(taskno=7)
-    def test_maybe_double_last_other_doubles(self):
-        hand = [1, 2, 11]
-        want = [1, 2, 22]
-
-        self.assertEqual(maybe_double_last(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, (hand, same) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=hand, output=same):
+                self.assertEqual(
+                    same,
+                    average_even_is_average_odd(hand),
+                    msg=f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'
+                )
 
     @pytest.mark.task(taskno=7)
-    def test_maybe_double_last_other_no_change(self):
-        hand = [1, 2, 3]
-        want = [1, 2, 3]
+    def test_maybe_double_last(self):
+        data = [
+            ([1, 2, 11], [1, 2, 22]),
+            ([5, 9, 11], [5, 9, 22]),
+            ([5, 9, 10], [5, 9, 10]),
+            ([1, 2, 3], [1, 2, 3]),
+        ]
 
-        self.assertEqual(maybe_double_last(hand), want,
-            msg=f'Expected {want} but got an incorrect result.'
-        )
+        for variant, (hand, doubled_hand) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=hand, output=doubled_hand):
+                self.assertEqual(
+                    doubled_hand,
+                    maybe_double_last(hand),
+                    msg=f'Expected {doubled_hand} as the maybe-doubled version of {hand}.'
+                )


### PR DESCRIPTION
Tests of `card-games` are refactored to cover more cases, utilize `subTest` and (hopefully) are now more readable and maintainable.

The promised follow-up to #2590.
Partially addresses #2605.