### PR TITLE
cater-waiter: Minor code example fixes

### DIFF
--- a/exercises/concept/guidos-gorgeous-lasagna/.docs/instructions.md
+++ b/exercises/concept/guidos-gorgeous-lasagna/.docs/instructions.md
@@ -48,7 +48,7 @@ This function should return the total number of minutes you've been cooking, or 
 Go back through the recipe, adding notes and documentation.
 
 ```python
-def total_time_in_minutes(number_of_layers, actual_bake_time):
+def elapsed_time_in_minutes(number_of_layers, actual_bake_time):
     """
     Return elapsed cooking time.
 


### PR DESCRIPTION
The example code for instruction 3 has a tuple as input but per the test cases and pre-fab docstring it should take a "str, list" (as opposed to "tuple(str, list)"). In short there are extra parenthesis.

In instruction 4 the second code example returns `{'blue cheese', 'pinenuts', 'pork tenderloin'}` but with the current data in sets_categories_data.py should return `{'pork tenderloin', 'blue cheese', 'pine nuts', 'onions'}` after correcting the missing space in pine nuts in the input. I'm guessing onions were maybe added later and pine nuts was spaced after the instruction was written.