### PR TITLE
Removed WIP and TBD exercises from prereqs for locked exercises.

### DIFF
--- a/config.json
+++ b/config.json
@@ -204,10 +204,8 @@
           "loops",
           "strings",
           "string-methods",
-          "string-formatting",
           "numbers",
           "conditionals",
-          "comparisons",
           "bools"
         ],
         "difficulty": 2
@@ -372,7 +370,6 @@
           "loops",
           "strings",
           "string-methods",
-          "string-formatting",
           "numbers"
         ],
         "difficulty": 4
@@ -386,13 +383,7 @@
           "rich-comparisons",
           "string-formatting"
         ],
-        "prerequisites": [
-          "basics",
-          "comparisons",
-          "numbers",
-          "strings",
-          "string-formatting"
-        ],
+        "prerequisites": ["basics", "numbers", "strings", "string-formatting"],
         "difficulty": 4
       },
       {
@@ -547,7 +538,6 @@
         ],
         "prerequisites": [
           "basics",
-          "comparisons",
           "lists",
           "loops",
           "numbers",
@@ -842,7 +832,6 @@
           "list-methods",
           "loops",
           "numbers",
-          "sequences",
           "sets"
         ],
         "difficulty": 2
@@ -1075,7 +1064,6 @@
           "loops",
           "strings",
           "string-methods",
-          "string-methods-splitting",
           "numbers"
         ],
         "difficulty": 1
@@ -1329,7 +1317,6 @@
           "basics",
           "conditionals",
           "dicts",
-          "dict-methods",
           "lists",
           "loops",
           "numbers",
@@ -2127,8 +2114,7 @@
           "bools",
           "lists",
           "list-methods",
-          "numbers",
-          "sequences"
+          "numbers"
         ],
         "difficulty": 1
       },


### PR DESCRIPTION
Edited `config.json` to remove WIP and TBD exercises from the prerequisites of the following Practice exercises:

- `Raindrops `--  string-formatting (`Pretty-leaflet`)  & comparisons(`Black-jack`) both **WIP** 
- `Robot-Simulator`-- dict-methods concept (no exercise yet )
- `Luhn` -- string-formatting (`Pretty-leaflet`)` is **WIP**
- `Phone-number` - comparisons(`Black-jack`) is **WIP**
- `Clock` - comparisons(`Black-jack`) is **WIP**
- `Sieve` -- sequences  concept (no exercise yet)
- `Wordry` -- string-methods-splitting (no longer a concept)
- `Risistor Color Duo` -- sequences concept (not exercise yet)