### PR TITLE
Add prickle and smolder labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -319,3 +319,11 @@
 - name: "❔question❔"
   description: "I have a proposal or question about things, but nothing is broken."
   color: "293028"
+
+- name: "prickle💢"
+  description: "This issue should be skipped by the auto-responder."
+  color: "FFFFFF"
+
+- name: "smolder🍲"
+  description: "Lower-priority and/or future idea"
+  color: "8B0000"


### PR DESCRIPTION
These are some new labels:
- prickle💢 - Label for issues that should be skipped by the auto-responder (to be added, _almost done_)
- smolder🍲 - Label for issues or PRs that are a long-term idea, or lower priority for the track.

Discussed with: @BethanyG 