### PR TITLE
[palindrome-products]: Reducing test length to avoid timeouts

### DIFF
--- a/exercises/practice/palindrome-products/palindrome_products_test.py
+++ b/exercises/practice/palindrome-products/palindrome_products_test.py
@@ -39,13 +39,15 @@ class PalindromeProductsTest(unittest.TestCase):
         self.assertEqual(value, 906609)
         self.assertFactorsEqual(factors, [[913, 993]])
 
+    #testing only the first thousand numbers, to improve test performances
     def test_find_smallest_palindrome_from_four_digit_factors(self):
-        value, factors = smallest(min_factor=1000, max_factor=9999)
+        value, factors = smallest(min_factor=1000, max_factor=1999)
         self.assertEqual(value, 1002001)
         self.assertFactorsEqual(factors, [[1001, 1001]])
 
+    #testing only the last thousand numbers, to improve test performances
     def test_find_the_largest_palindrome_from_four_digit_factors(self):
-        value, factors = largest(min_factor=1000, max_factor=9999)
+        value, factors = largest(min_factor=9000, max_factor=9999)
         self.assertEqual(value, 99000099)
         self.assertFactorsEqual(factors, [[9901, 9999]])
 


### PR DESCRIPTION
Hello,
I was doing this palindrome exercise and there is an issue of tests timeout online, even if locally everything works.

There are 2 tests which are testing the largest and smallest palindrome couples made by multiplying all the four-digits numbers.
This two tests are the main responsibles to make the system go in timeout. 

The reason is that if you make the classic nested for loop
```
for x in range(1k,10k)
    for y in range(1k,10k)
            if is_palindrome(x,y):
                    do something
```
It makes 9k * 9k iterations ~ 100M 
Things can be optimized of course, but after all it is a tutorial on numbers and strings.

This proposed solution is an easy fix for the website, and give a better experience.

It tests only the first 1K numbers for the smallest palyndrome, and the last 1k numbers for the largest one, reducing the iteration from ~100M to ~1M
The tests will give the same result and more or less mantain a similar meaning

On my machine the test time goes down from 15/20 seconds to 0.5/1 sec. It seems also a bit of a resource waste, because also it doesn't represent any particular edge case

Let me know if you are interested and need some other edits, or I'm missing something