### PR TITLE
Fix the code sample in the instructions to use the same var name as other references

### DIFF
--- a/exercises/concept/guidos-gorgeous-lasagna/.docs/instructions.md
+++ b/exercises/concept/guidos-gorgeous-lasagna/.docs/instructions.md
@@ -48,7 +48,7 @@ This function should return the total number of minutes you've been cooking, or 
 Go back through the recipe, adding notes and documentation.
 
 ```python
-def elapsed_time_in_minutes(number_of_layers, actual_bake_time):
+def elapsed_time_in_minutes(number_of_layers, elapsed_bake_time):
     """
     Return elapsed cooking time.
 


### PR DESCRIPTION
https://github.com/exercism/python/issues/2647

The sample snippet in the instructions references `actual_bake_time` while all the other references to this parameter call it `elapsed_bake_time`. 