### PR TITLE
Improve test spacing in `chaitanas-colossal-coaster`

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
+++ b/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Learn useful list methods helping Chaitana manage the lines for her colossal roller coaster.",
   "icon": "spiral-matrix",
-  "contributors": ["valentin-p"],
+  "contributors": ["valentin-p", "pranasziaukas"],
   "authors": ["mohanrajanr", "BethanyG"],
   "files": {
     "solution": ["list_methods.py"],

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -13,163 +13,109 @@ from list_methods import (
 
 
 class ListMethodsTest(unittest.TestCase):
-
     @pytest.mark.task(taskno=1)
-    def test_add_me_to_the_queue_set_normal_queue(self):
-        params = (["Tony", "Bruce"], ["RobotGuy", "WW"], 0, "HawkEye")
-        result = ["RobotGuy", "WW", "HawkEye"]
+    def test_add_me_to_the_queue(self):
+        data = [
+            ((['Tony', 'Bruce'], ['RobotGuy', 'WW'], 0, 'HawkEye'), ['RobotGuy', 'WW', 'HawkEye']),
+            ((['Tony', 'Bruce'], ['RobotGuy', 'WW'], 1, 'RichieRich'), ['Tony', 'Bruce', 'RichieRich']),
+        ]
 
-        self.assertListEqual(
-            add_me_to_the_queue(*params), result,
-            msg="The person was not added to the queue correctly"
-        )
-
-    @pytest.mark.task(taskno=1)
-    def test_add_me_to_the_queue_express_queue(self):
-        params = (["Tony", "Bruce"], ["RobotGuy", "WW"], 1, "RichieRich")
-        result = ["Tony", "Bruce", "RichieRich"]
-
-        self.assertListEqual(
-            add_me_to_the_queue(*params), result,
-            msg="The person was not added to the queue correctly"
-        )
+        error_message = 'The person was not added to the queue correctly.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertListEqual(add_me_to_the_queue(*params), result, msg=error_message)
 
     @pytest.mark.task(taskno=2)
-    def test_find_my_friend_start_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], "Natasha")
-        result = 0
+    def test_find_my_friend(self):
+        data = [
+            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Natasha'), 0),
+            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Steve'), 1),
+            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Rocket'), 4),
+        ]
 
-        self.assertEqual(
-            find_my_friend(*params), result,
-            msg="The index of the friend to find is incorrect."
-        )
-
-    @pytest.mark.task(taskno=2)
-    def test_find_my_friend_middle_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], "Steve")
-        result = 1
-
-        self.assertIs(
-            find_my_friend(*params), result,
-            msg="The index of the friend to find is incorrect"
-        )
-
-    @pytest.mark.task(taskno=2)
-    def test_find_my_friend_end_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], "Rocket")
-        result = 4
-
-        self.assertIs(
-            find_my_friend(*params), result,
-            msg="The index of the friend to find is incorrect"
-        )
+        error_message = 'The index of the friend to find is incorrect.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertIs(find_my_friend(*params), result, msg=error_message)
 
     @pytest.mark.task(taskno=3)
-    def test_add_me_with_my_friends_start_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], 0, "Bucky")
-        result = ["Bucky", "Natasha", "Steve", "Tchalla", "Wanda", "Rocket"]
+    def test_add_me_with_my_friends(self):
+        data = [
+            (
+                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 0, 'Bucky'),
+                ['Bucky', 'Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket']
+            ),
+            (
+                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 1, 'Bucky'),
+                ['Natasha', 'Bucky', 'Steve', 'Tchalla', 'Wanda', 'Rocket']
+            ),
+            (
+                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 5, 'Bucky'),
+                ['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket', 'Bucky']
+            ),
+        ]
 
-        self.assertListEqual(
-            add_me_with_my_friends(*params), result,
-            msg="The person was added to the wrong location in the queue or was not added at all",
-        )
-
-    @pytest.mark.task(taskno=3)
-    def test_add_me_with_my_friends_middle_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], 1, "Bucky")
-        result = ["Natasha", "Bucky", "Steve", "Tchalla", "Wanda", "Rocket"]
-
-        self.assertListEqual(
-            add_me_with_my_friends(*params), result,
-            msg="The person was added to the wrong location in the queue or was not added at all"
-        )
-
-    @pytest.mark.task(taskno=3)
-    def test_add_me_with_my_friends_end_of_queue(self):
-        params = (["Natasha", "Steve", "Tchalla", "Wanda", "Rocket"], 5, "Bucky")
-        result = ["Natasha", "Steve", "Tchalla", "Wanda", "Rocket", "Bucky"]
-
-        self.assertListEqual(
-            add_me_with_my_friends(*params), result,
-            msg="The person was added to the wrong location in the queue or was not added at all"
-        )
+        error_message = 'The person was added to the wrong location in the queue or was not added at all.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertListEqual(add_me_with_my_friends(*params), result, error_message)
 
     @pytest.mark.task(taskno=4)
-    def test_remove_the_mean_person_middle_of_queue(self):
-        params = (["Natasha", "Steve", "Ultron", "Wanda", "Rocket"], "Ultron")
-        result = ["Natasha", "Steve", "Wanda", "Rocket"]
+    def test_remove_the_mean_person(self):
+        data = [
+            (
+                (['Natasha', 'Steve', 'Ultron', 'Wanda', 'Rocket'], 'Ultron'),
+                ['Natasha', 'Steve', 'Wanda', 'Rocket']
+            ),
+            (
+                (['Natasha', 'Steve', 'Wanda', 'Rocket', 'Ultron'], 'Ultron'),
+                ['Natasha', 'Steve', 'Wanda', 'Rocket']
+            ),
+            (
+                (['Ultron', 'Natasha', 'Steve', 'Wanda', 'Rocket'], 'Ultron'),
+                ['Natasha', 'Steve', 'Wanda', 'Rocket']
+            ),
+        ]
 
-        self.assertListEqual(
-            remove_the_mean_person(*params), result,
-            msg="The mean person was not removed properly"
-        )
-
-    @pytest.mark.task(taskno=4)
-    def test_remove_the_mean_person_end_of_queue(self):
-        params = (["Natasha", "Steve", "Wanda", "Rocket", "Ultron"], "Ultron")
-        result = ["Natasha", "Steve", "Wanda", "Rocket"]
-
-        self.assertListEqual(
-            remove_the_mean_person(*params), result,
-            msg="The mean person was not removed properly"
-        )
-
-    @pytest.mark.task(taskno=4)
-    def test_remove_the_mean_person_start_of_queue(self):
-        params = (["Ultron", "Natasha", "Steve", "Wanda", "Rocket"], "Ultron")
-        result = ["Natasha", "Steve", "Wanda", "Rocket"]
-
-        self.assertListEqual(
-            remove_the_mean_person(*params), result,
-            msg="The mean person was not removed properly"
-        )
+        error_message = 'The mean person was not removed properly.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertListEqual(remove_the_mean_person(*params), result, msg=error_message)
 
     @pytest.mark.task(taskno=5)
-    def test_how_many_namefellows_person_not_in_queue(self):
-        params = (["Natasha", "Steve", "Ultron", "Natasha", "Rocket"], "Bucky")
-        result = 0
+    def test_how_many_namefellows(self):
+        data = [
+            ((['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Bucky'), 0),
+            ((['Natasha', 'Steve', 'Ultron', 'Rocket'], 'Natasha'), 1),
+            ((['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Natasha'), 2),
+        ]
 
-        self.assertIs(
-            how_many_namefellows(*params), result,
-            msg="The namefellow count is incorrect"
-        )
-
-    @pytest.mark.task(taskno=5)
-    def test_how_many_namefellows_only_one(self):
-        params = (["Natasha", "Steve", "Ultron", "Rocket"], "Natasha")
-        result = 1
-
-        self.assertIs(
-            how_many_namefellows(*params), result,
-            msg="The namefellow count is incorrect"
-        )
-
-    @pytest.mark.task(taskno=5)
-    def test_how_many_namefellows_more_than_one(self):
-        params = (["Natasha", "Steve", "Ultron", "Natasha", "Rocket"], "Natasha")
-        result = 2
-
-        self.assertIs(
-            how_many_namefellows(*params), result,
-            msg="The namefellow count is incorrect"
-        )
+        error_message = 'The namefellow count is incorrect.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertIs(how_many_namefellows(*params), result, msg=error_message)
 
     @pytest.mark.task(taskno=6)
     def test_remove_the_last_person(self):
-        params = ["Natasha", "Steve", "Ultron", "Natasha", "Rocket"]
-        result = "Rocket"
+        data = [
+            (['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Rocket'),
+        ]
 
-        self.assertIs(
-            remove_the_last_person(params), result,
-            msg="The last person was not removed properly"
-        )
+        error_message = 'The last person was not removed properly.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertIs(remove_the_last_person(params), result, msg=error_message)
 
     @pytest.mark.task(taskno=7)
     def test_sorted_names(self):
-        params = ["Steve", "Ultron", "Natasha", "Rocket"]
-        result = ["Natasha", "Rocket", "Steve", "Ultron"]
+        data = [
+            (
+                ['Steve', 'Ultron', 'Natasha', 'Rocket'],
+                ['Natasha', 'Rocket', 'Steve', 'Ultron']
+            ),
+        ]
 
-        self.assertListEqual(
-            sorted_names(params), result,
-            msg="The queue was not properly sorted"
-        )
+        error_message = 'The queue was not properly sorted.'
+        for variant, (params, result) in enumerate(data, start=1):
+            with self.subTest(f'variation #{variant}', input=params, output=result):
+                self.assertListEqual(sorted_names(params), result, msg=error_message)


### PR DESCRIPTION
Addressing the following:

- Spacing in tests for `chaitanas-colossal-coaster` is inconsistent.
- Indentation trips some pyton linters (e.g. [Flake8 E128](https://www.flake8rules.com/rules/E128.html)).