### PR TITLE
Update matching_brackets_test.py

### DIFF
--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -59,7 +59,7 @@ class MatchingBracketsTest(unittest.TestCase):
     def test_complex_latex_expression(self):
         self.assertEqual(
             is_paired(
-                "\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)"
+                r"\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)"
             ),
             True,
         )


### PR DESCRIPTION
`"\r"` was interpreted as carriage return, not as `"\\r"`