### PR TITLE
[Matching Brackets]: Change JinJa2 Template to Correctly Escape LaTex Code & Regenerate Test File

### DIFF
--- a/exercises/practice/matching-brackets/.meta/template.j2
+++ b/exercises/practice/matching-brackets/.meta/template.j2
@@ -6,7 +6,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     def test_{{ case["description"] | to_snake }}(self):
         {%- set value = case["input"]["value"] %}
         {%- set expected = case["expected"] %}
-        self.assertEqual({{ case["property"] | to_snake }}("{{ value }}"), {{ expected }})
+        self.assertEqual({{ case["property"] | to_snake }}({{ "{!r}".format(value) }}), {{ expected }})
     {% endfor %}
 
 {{ macros.footer() }}

--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -59,7 +59,7 @@ class MatchingBracketsTest(unittest.TestCase):
     def test_complex_latex_expression(self):
         self.assertEqual(
             is_paired(
-                "\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)"
+                "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)"
             ),
             True,
         )


### PR DESCRIPTION
Before there were issues with `"\r"` versus `"\\right"` in a test case.

Fixes the problem described in #2663 at its root.