### PR TITLE
[Tisbury Treasure Hunt]:Potential fix for bug 2644.

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
@@ -28,7 +28,7 @@
 - Remember that tuples support all [common sequence operations](https://docs.python.org/3/library/stdtypes.html#common-sequence-operations).
 - Could you re-use your `compare_records()` function here?
 
-## 5. "Clean up" & format a report of all records
+## 5. "Clean up" and format a report of all records
 
 - Remember: tuples are _immutable_, but the contents can be accessed via _index_ using _bracket notation_.
 - Tuples don't have to use parentheses unless there is _ambiguity_.


### PR DESCRIPTION
This is a very small thing and may not work.  Hints for Task 5 are not displaying on the website UI for this exercise.  Noticed that it was the only header with an `&`.  Removed the `&` in hopes that that was the issue with the hints not displaying.  

**Note** -- this may not work, and it may be something else.