### PR TITLE
meetup: Align tests with the exercise description

### DIFF
--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -74,172 +74,172 @@ class MeetupTest(unittest.TestCase):
         self.assertEqual(meetup(2013, 10, "teenth", "Sunday"), date(2013, 10, 13))
 
     def test_first_monday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "1st", "Monday"), date(2013, 3, 4))
+        self.assertEqual(meetup(2013, 3, "first", "Monday"), date(2013, 3, 4))
 
     def test_first_monday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "1st", "Monday"), date(2013, 4, 1))
+        self.assertEqual(meetup(2013, 4, "first", "Monday"), date(2013, 4, 1))
 
     def test_first_tuesday_of_may_2013(self):
-        self.assertEqual(meetup(2013, 5, "1st", "Tuesday"), date(2013, 5, 7))
+        self.assertEqual(meetup(2013, 5, "first", "Tuesday"), date(2013, 5, 7))
 
     def test_first_tuesday_of_june_2013(self):
-        self.assertEqual(meetup(2013, 6, "1st", "Tuesday"), date(2013, 6, 4))
+        self.assertEqual(meetup(2013, 6, "first", "Tuesday"), date(2013, 6, 4))
 
     def test_first_wednesday_of_july_2013(self):
-        self.assertEqual(meetup(2013, 7, "1st", "Wednesday"), date(2013, 7, 3))
+        self.assertEqual(meetup(2013, 7, "first", "Wednesday"), date(2013, 7, 3))
 
     def test_first_wednesday_of_august_2013(self):
-        self.assertEqual(meetup(2013, 8, "1st", "Wednesday"), date(2013, 8, 7))
+        self.assertEqual(meetup(2013, 8, "first", "Wednesday"), date(2013, 8, 7))
 
     def test_first_thursday_of_september_2013(self):
-        self.assertEqual(meetup(2013, 9, "1st", "Thursday"), date(2013, 9, 5))
+        self.assertEqual(meetup(2013, 9, "first", "Thursday"), date(2013, 9, 5))
 
     def test_first_thursday_of_october_2013(self):
-        self.assertEqual(meetup(2013, 10, "1st", "Thursday"), date(2013, 10, 3))
+        self.assertEqual(meetup(2013, 10, "first", "Thursday"), date(2013, 10, 3))
 
     def test_first_friday_of_november_2013(self):
-        self.assertEqual(meetup(2013, 11, "1st", "Friday"), date(2013, 11, 1))
+        self.assertEqual(meetup(2013, 11, "first", "Friday"), date(2013, 11, 1))
 
     def test_first_friday_of_december_2013(self):
-        self.assertEqual(meetup(2013, 12, "1st", "Friday"), date(2013, 12, 6))
+        self.assertEqual(meetup(2013, 12, "first", "Friday"), date(2013, 12, 6))
 
     def test_first_saturday_of_january_2013(self):
-        self.assertEqual(meetup(2013, 1, "1st", "Saturday"), date(2013, 1, 5))
+        self.assertEqual(meetup(2013, 1, "first", "Saturday"), date(2013, 1, 5))
 
     def test_first_saturday_of_february_2013(self):
-        self.assertEqual(meetup(2013, 2, "1st", "Saturday"), date(2013, 2, 2))
+        self.assertEqual(meetup(2013, 2, "first", "Saturday"), date(2013, 2, 2))
 
     def test_first_sunday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "1st", "Sunday"), date(2013, 3, 3))
+        self.assertEqual(meetup(2013, 3, "first", "Sunday"), date(2013, 3, 3))
 
     def test_first_sunday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "1st", "Sunday"), date(2013, 4, 7))
+        self.assertEqual(meetup(2013, 4, "first", "Sunday"), date(2013, 4, 7))
 
     def test_second_monday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "2nd", "Monday"), date(2013, 3, 11))
+        self.assertEqual(meetup(2013, 3, "second", "Monday"), date(2013, 3, 11))
 
     def test_second_monday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "2nd", "Monday"), date(2013, 4, 8))
+        self.assertEqual(meetup(2013, 4, "second", "Monday"), date(2013, 4, 8))
 
     def test_second_tuesday_of_may_2013(self):
-        self.assertEqual(meetup(2013, 5, "2nd", "Tuesday"), date(2013, 5, 14))
+        self.assertEqual(meetup(2013, 5, "second", "Tuesday"), date(2013, 5, 14))
 
     def test_second_tuesday_of_june_2013(self):
-        self.assertEqual(meetup(2013, 6, "2nd", "Tuesday"), date(2013, 6, 11))
+        self.assertEqual(meetup(2013, 6, "second", "Tuesday"), date(2013, 6, 11))
 
     def test_second_wednesday_of_july_2013(self):
-        self.assertEqual(meetup(2013, 7, "2nd", "Wednesday"), date(2013, 7, 10))
+        self.assertEqual(meetup(2013, 7, "second", "Wednesday"), date(2013, 7, 10))
 
     def test_second_wednesday_of_august_2013(self):
-        self.assertEqual(meetup(2013, 8, "2nd", "Wednesday"), date(2013, 8, 14))
+        self.assertEqual(meetup(2013, 8, "second", "Wednesday"), date(2013, 8, 14))
 
     def test_second_thursday_of_september_2013(self):
-        self.assertEqual(meetup(2013, 9, "2nd", "Thursday"), date(2013, 9, 12))
+        self.assertEqual(meetup(2013, 9, "second", "Thursday"), date(2013, 9, 12))
 
     def test_second_thursday_of_october_2013(self):
-        self.assertEqual(meetup(2013, 10, "2nd", "Thursday"), date(2013, 10, 10))
+        self.assertEqual(meetup(2013, 10, "second", "Thursday"), date(2013, 10, 10))
 
     def test_second_friday_of_november_2013(self):
-        self.assertEqual(meetup(2013, 11, "2nd", "Friday"), date(2013, 11, 8))
+        self.assertEqual(meetup(2013, 11, "second", "Friday"), date(2013, 11, 8))
 
     def test_second_friday_of_december_2013(self):
-        self.assertEqual(meetup(2013, 12, "2nd", "Friday"), date(2013, 12, 13))
+        self.assertEqual(meetup(2013, 12, "second", "Friday"), date(2013, 12, 13))
 
     def test_second_saturday_of_january_2013(self):
-        self.assertEqual(meetup(2013, 1, "2nd", "Saturday"), date(2013, 1, 12))
+        self.assertEqual(meetup(2013, 1, "second", "Saturday"), date(2013, 1, 12))
 
     def test_second_saturday_of_february_2013(self):
-        self.assertEqual(meetup(2013, 2, "2nd", "Saturday"), date(2013, 2, 9))
+        self.assertEqual(meetup(2013, 2, "second", "Saturday"), date(2013, 2, 9))
 
     def test_second_sunday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "2nd", "Sunday"), date(2013, 3, 10))
+        self.assertEqual(meetup(2013, 3, "second", "Sunday"), date(2013, 3, 10))
 
     def test_second_sunday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "2nd", "Sunday"), date(2013, 4, 14))
+        self.assertEqual(meetup(2013, 4, "second", "Sunday"), date(2013, 4, 14))
 
     def test_third_monday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "3rd", "Monday"), date(2013, 3, 18))
+        self.assertEqual(meetup(2013, 3, "third", "Monday"), date(2013, 3, 18))
 
     def test_third_monday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "3rd", "Monday"), date(2013, 4, 15))
+        self.assertEqual(meetup(2013, 4, "third", "Monday"), date(2013, 4, 15))
 
     def test_third_tuesday_of_may_2013(self):
-        self.assertEqual(meetup(2013, 5, "3rd", "Tuesday"), date(2013, 5, 21))
+        self.assertEqual(meetup(2013, 5, "third", "Tuesday"), date(2013, 5, 21))
 
     def test_third_tuesday_of_june_2013(self):
-        self.assertEqual(meetup(2013, 6, "3rd", "Tuesday"), date(2013, 6, 18))
+        self.assertEqual(meetup(2013, 6, "third", "Tuesday"), date(2013, 6, 18))
 
     def test_third_wednesday_of_july_2013(self):
-        self.assertEqual(meetup(2013, 7, "3rd", "Wednesday"), date(2013, 7, 17))
+        self.assertEqual(meetup(2013, 7, "third", "Wednesday"), date(2013, 7, 17))
 
     def test_third_wednesday_of_august_2013(self):
-        self.assertEqual(meetup(2013, 8, "3rd", "Wednesday"), date(2013, 8, 21))
+        self.assertEqual(meetup(2013, 8, "third", "Wednesday"), date(2013, 8, 21))
 
     def test_third_thursday_of_september_2013(self):
-        self.assertEqual(meetup(2013, 9, "3rd", "Thursday"), date(2013, 9, 19))
+        self.assertEqual(meetup(2013, 9, "third", "Thursday"), date(2013, 9, 19))
 
     def test_third_thursday_of_october_2013(self):
-        self.assertEqual(meetup(2013, 10, "3rd", "Thursday"), date(2013, 10, 17))
+        self.assertEqual(meetup(2013, 10, "third", "Thursday"), date(2013, 10, 17))
 
     def test_third_friday_of_november_2013(self):
-        self.assertEqual(meetup(2013, 11, "3rd", "Friday"), date(2013, 11, 15))
+        self.assertEqual(meetup(2013, 11, "third", "Friday"), date(2013, 11, 15))
 
     def test_third_friday_of_december_2013(self):
-        self.assertEqual(meetup(2013, 12, "3rd", "Friday"), date(2013, 12, 20))
+        self.assertEqual(meetup(2013, 12, "third", "Friday"), date(2013, 12, 20))
 
     def test_third_saturday_of_january_2013(self):
-        self.assertEqual(meetup(2013, 1, "3rd", "Saturday"), date(2013, 1, 19))
+        self.assertEqual(meetup(2013, 1, "third", "Saturday"), date(2013, 1, 19))
 
     def test_third_saturday_of_february_2013(self):
-        self.assertEqual(meetup(2013, 2, "3rd", "Saturday"), date(2013, 2, 16))
+        self.assertEqual(meetup(2013, 2, "third", "Saturday"), date(2013, 2, 16))
 
     def test_third_sunday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "3rd", "Sunday"), date(2013, 3, 17))
+        self.assertEqual(meetup(2013, 3, "third", "Sunday"), date(2013, 3, 17))
 
     def test_third_sunday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "3rd", "Sunday"), date(2013, 4, 21))
+        self.assertEqual(meetup(2013, 4, "third", "Sunday"), date(2013, 4, 21))
 
     def test_fourth_monday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "4th", "Monday"), date(2013, 3, 25))
+        self.assertEqual(meetup(2013, 3, "fourth", "Monday"), date(2013, 3, 25))
 
     def test_fourth_monday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "4th", "Monday"), date(2013, 4, 22))
+        self.assertEqual(meetup(2013, 4, "fourth", "Monday"), date(2013, 4, 22))
 
     def test_fourth_tuesday_of_may_2013(self):
-        self.assertEqual(meetup(2013, 5, "4th", "Tuesday"), date(2013, 5, 28))
+        self.assertEqual(meetup(2013, 5, "fourth", "Tuesday"), date(2013, 5, 28))
 
     def test_fourth_tuesday_of_june_2013(self):
-        self.assertEqual(meetup(2013, 6, "4th", "Tuesday"), date(2013, 6, 25))
+        self.assertEqual(meetup(2013, 6, "fourth", "Tuesday"), date(2013, 6, 25))
 
     def test_fourth_wednesday_of_july_2013(self):
-        self.assertEqual(meetup(2013, 7, "4th", "Wednesday"), date(2013, 7, 24))
+        self.assertEqual(meetup(2013, 7, "fourth", "Wednesday"), date(2013, 7, 24))
 
     def test_fourth_wednesday_of_august_2013(self):
-        self.assertEqual(meetup(2013, 8, "4th", "Wednesday"), date(2013, 8, 28))
+        self.assertEqual(meetup(2013, 8, "fourth", "Wednesday"), date(2013, 8, 28))
 
     def test_fourth_thursday_of_september_2013(self):
-        self.assertEqual(meetup(2013, 9, "4th", "Thursday"), date(2013, 9, 26))
+        self.assertEqual(meetup(2013, 9, "fourth", "Thursday"), date(2013, 9, 26))
 
     def test_fourth_thursday_of_october_2013(self):
-        self.assertEqual(meetup(2013, 10, "4th", "Thursday"), date(2013, 10, 24))
+        self.assertEqual(meetup(2013, 10, "fourth", "Thursday"), date(2013, 10, 24))
 
     def test_fourth_friday_of_november_2013(self):
-        self.assertEqual(meetup(2013, 11, "4th", "Friday"), date(2013, 11, 22))
+        self.assertEqual(meetup(2013, 11, "fourth", "Friday"), date(2013, 11, 22))
 
     def test_fourth_friday_of_december_2013(self):
-        self.assertEqual(meetup(2013, 12, "4th", "Friday"), date(2013, 12, 27))
+        self.assertEqual(meetup(2013, 12, "fourth", "Friday"), date(2013, 12, 27))
 
     def test_fourth_saturday_of_january_2013(self):
-        self.assertEqual(meetup(2013, 1, "4th", "Saturday"), date(2013, 1, 26))
+        self.assertEqual(meetup(2013, 1, "fourth", "Saturday"), date(2013, 1, 26))
 
     def test_fourth_saturday_of_february_2013(self):
-        self.assertEqual(meetup(2013, 2, "4th", "Saturday"), date(2013, 2, 23))
+        self.assertEqual(meetup(2013, 2, "fourth", "Saturday"), date(2013, 2, 23))
 
     def test_fourth_sunday_of_march_2013(self):
-        self.assertEqual(meetup(2013, 3, "4th", "Sunday"), date(2013, 3, 24))
+        self.assertEqual(meetup(2013, 3, "fourth", "Sunday"), date(2013, 3, 24))
 
     def test_fourth_sunday_of_april_2013(self):
-        self.assertEqual(meetup(2013, 4, "4th", "Sunday"), date(2013, 4, 28))
+        self.assertEqual(meetup(2013, 4, "fourth", "Sunday"), date(2013, 4, 28))
 
     def test_last_monday_of_march_2013(self):
         self.assertEqual(meetup(2013, 3, "last", "Monday"), date(2013, 3, 25))
@@ -293,16 +293,16 @@ class MeetupTest(unittest.TestCase):
         self.assertEqual(meetup(2015, 2, "last", "Sunday"), date(2015, 2, 22))
 
     def test_first_friday_of_december_2012(self):
-        self.assertEqual(meetup(2012, 12, "1st", "Friday"), date(2012, 12, 7))
+        self.assertEqual(meetup(2012, 12, "first", "Friday"), date(2012, 12, 7))
 
     # Additional tests for this track
 
     def test_fifth_monday_of_march_2015(self):
-        self.assertEqual(meetup(2015, 3, "5th", "Monday"), date(2015, 3, 30))
+        self.assertEqual(meetup(2015, 3, "fifth", "Monday"), date(2015, 3, 30))
 
     def test_nonexistent_fifth_monday_of_february_2015(self):
         with self.assertRaisesWithMessage(MeetupDayException):
-            meetup(2015, 2, "5th", "Monday")
+            meetup(2015, 2, "fifth", "Monday")
 
     # Utility functions
     def assertRaisesWithMessage(self, exception):


### PR DESCRIPTION
This is a very optional PR based on two observations:

- The test code is not really consistent with the exercise description ("first" instead of "1st, etc)
- Python version seems to be inconsistent with other languages (I checked F#, C#, Ruby)

Thanks for your time reviewing this PR!