### PR TITLE
[Practice Exercises]: Error Handling Fixes for Tests That Check Error Raising Messages

### DIFF
--- a/exercises/practice/affine-cipher/.meta/template.j2
+++ b/exercises/practice/affine-cipher/.meta/template.j2
@@ -18,8 +18,8 @@ def test_{{ case["description"] | to_snake }}(self):
     {% if case is error_case -%}
     with self.assertRaises(ValueError) as err:
         {{ function }}("{{ phrase }}", {{ a }}, {{ b }})
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "{{ exp_error }}")
+    self.assertEqual(type(err.exception), ValueError)
+    self.assertEqual(err.exception.args[0], "{{ exp_error }}")
     {% else -%}
     self.assertEqual({{ function }}("{{ phrase }}", {{ a }}, {{ b }}), "{{ expected }}")
     {% endif -%}

--- a/exercises/practice/affine-cipher/affine_cipher_test.py
+++ b/exercises/practice/affine-cipher/affine_cipher_test.py
@@ -41,8 +41,8 @@ class AffineCipherTest(unittest.TestCase):
     def test_encode_with_a_not_coprime_to_m(self):
         with self.assertRaises(ValueError) as err:
             encode("This is a test.", 6, 17)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "a and m must be coprime.")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "a and m must be coprime.")
 
     def test_decode_exercism(self):
         self.assertEqual(decode("tytgn fjr", 3, 7), "exercism")
@@ -76,5 +76,5 @@ class AffineCipherTest(unittest.TestCase):
     def test_decode_with_a_not_coprime_to_m(self):
         with self.assertRaises(ValueError) as err:
             decode("Test", 13, 5)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "a and m must be coprime.")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "a and m must be coprime.")

--- a/exercises/practice/bank-account/bank_account_test.py
+++ b/exercises/practice/bank-account/bank_account_test.py
@@ -50,8 +50,8 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.get_balance()
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "account not open")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "account not open")
 
     def test_deposit_into_closed_account(self):
         account = BankAccount()
@@ -60,8 +60,8 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.deposit(50)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "account not open")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "account not open")
 
 
     def test_withdraw_from_closed_account(self):
@@ -71,23 +71,23 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.withdraw(50)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "account not open")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "account not open")
 
     def test_close_already_closed_account(self):
         account = BankAccount()
         with self.assertRaises(ValueError) as err:
             account.close()
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "account not open")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "account not open")
 
     def test_open_already_opened_account(self):
         account = BankAccount()
         account.open()
         with self.assertRaises(ValueError) as err:
             account.open()
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "account already open")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "account already open")
 
     def test_reopened_account_does_not_retain_balance(self):
         account = BankAccount()
@@ -104,8 +104,8 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.withdraw(50)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "amount must be less than balance")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "amount must be less than balance")
 
     def test_cannot_withdraw_negative(self):
         account = BankAccount()
@@ -114,8 +114,8 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.withdraw(-50)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "amount must be greater than 0")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "amount must be greater than 0")
 
     def test_cannot_deposit_negative(self):
         account = BankAccount()
@@ -123,8 +123,8 @@ class BankAccountTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             account.deposit(-50)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "amount must be greater than 0")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "amount must be greater than 0")
 
     def test_can_handle_concurrent_transactions(self):
         account = BankAccount()

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -17,8 +17,8 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- if case is error_case %}
         with self.assertRaises(ValueError) as err:
             {{- test_call(case) }}
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "{{ exp_error }}")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ exp_error }}")
         {%- else %}
         self.assertEqual({{- test_call(case) }}, {{ expected }})
         {%- endif %}

--- a/exercises/practice/binary-search/binary_search_test.py
+++ b/exercises/practice/binary-search/binary_search_test.py
@@ -39,37 +39,37 @@ class BinarySearchTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             find([1, 3, 4, 6, 8, 9, 11], 7)
 
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "value not in array")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "value not in array")
 
     def test_a_value_smaller_than_the_array_s_smallest_value_is_not_found(self):
 
         with self.assertRaises(ValueError) as err:
             find([1, 3, 4, 6, 8, 9, 11], 0)
 
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "value not in array")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "value not in array")
 
     def test_a_value_larger_than_the_array_s_largest_value_is_not_found(self):
 
         with self.assertRaises(ValueError) as err:
             find([1, 3, 4, 6, 8, 9, 11], 13)
 
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "value not in array")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "value not in array")
 
     def test_nothing_is_found_in_an_empty_array(self):
 
         with self.assertRaises(ValueError) as err:
             find([], 1)
 
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "value not in array")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "value not in array")
 
     def test_nothing_is_found_when_the_left_and_right_bounds_cross(self):
 
         with self.assertRaises(ValueError) as err:
             find([1, 2], 0)
 
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "value not in array")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "value not in array")

--- a/exercises/practice/binary/binary_test.py
+++ b/exercises/practice/binary/binary_test.py
@@ -34,26 +34,26 @@ class BinaryTest(unittest.TestCase):
     def test_invalid_binary_text_only(self):
         with self.assertRaises(ValueError) as err:
             parse_binary("carrot")
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Invalid binary literal: 'carrot'")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Invalid binary literal: carrot")
 
     def test_invalid_binary_number_not_base2(self):
         with self.assertRaises(ValueError) as err:
             parse_binary("102011")
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Invalid binary literal: '102011'")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Invalid binary literal: 102011")
 
     def test_invalid_binary_numbers_with_text(self):
         with self.assertRaises(ValueError) as err:
             parse_binary("10nope")
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Invalid binary literal: '10nope'")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Invalid binary literal: 10nope")
 
     def test_invalid_binary_text_with_numbers(self):
         with self.assertRaises(ValueError) as err:
             parse_binary("nope10")
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Invalid binary literal: '10nope'")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Invalid binary literal: nope10")
 
 if __name__ == '__main__':
     unittest.main()

--- a/exercises/practice/change/.meta/example.py
+++ b/exercises/practice/change/.meta/example.py
@@ -1,6 +1,6 @@
 def find_fewest_coins(coins, target):
     if target < 0:
-        raise ValueError("cannot find negative change values")
+        raise ValueError("target can't be negative")
     min_coins_required = [1e9] * (target + 1)
     last_coin = [0]*(target + 1)
     min_coins_required[0] = 0
@@ -15,7 +15,7 @@ def find_fewest_coins(coins, target):
                     last_coin[change] = change - coin
         min_coins_required[change] = final_result
     if min_coins_required[target] == 1e9:
-        raise ValueError("no combination can add up to target")
+        raise ValueError("can't make target with given coins")
     else:
         last_coin_value = target
         array = []

--- a/exercises/practice/change/.meta/template.j2
+++ b/exercises/practice/change/.meta/template.j2
@@ -11,8 +11,8 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- if case is error_case %}
         with self.assertRaises(ValueError) as err:
             {{case["property"] |to_snake }}({{coins}}, {{target}})
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "{{ exp_error }}")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ exp_error }}")
         {% else %}
         self.assertEqual({{ case["property"] |to_snake }}({{coins}}, {{target}}), {{expected}})
         {% endif %}

--- a/exercises/practice/change/change_test.py
+++ b/exercises/practice/change/change_test.py
@@ -38,21 +38,17 @@ class ChangeTest(unittest.TestCase):
     def test_error_testing_for_change_smaller_than_the_smallest_of_coins(self):
         with self.assertRaises(ValueError) as err:
             find_fewest_coins([5, 10], 3)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(
-                err.exception.args[0], "can't make target with given coins"
-            )
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "can't make target with given coins")
 
     def test_error_if_no_combination_can_add_up_to_target(self):
         with self.assertRaises(ValueError) as err:
             find_fewest_coins([5, 10], 94)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(
-                err.exception.args[0], "can't make target with given coins"
-            )
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "can't make target with given coins")
 
     def test_cannot_find_negative_change_values(self):
         with self.assertRaises(ValueError) as err:
             find_fewest_coins([1, 2, 5], -5)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "target can't be negative")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "target can't be negative")

--- a/exercises/practice/circular-buffer/.meta/template.j2
+++ b/exercises/practice/circular-buffer/.meta/template.j2
@@ -24,8 +24,13 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {% else -%}
         with self.assertRaises(BufferError) as err:
             {{ call_op(op) }}
-            self.assertEqual(type(err.exception), (BufferEmptyException, BufferFullException))
-            self.assertEqual(err.exception.args[0], ("Circular buffer is empty", "Circular buffer is full"))
+        {% if op.get("operation") == "read"  %}
+        self.assertEqual(type(err.exception), BufferEmptyException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is empty")
+        {% else %}
+        self.assertEqual(type(err.exception), BufferFullException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is full")
+        {% endif -%}
         {% endif -%}
         {% endfor %}
     {% endfor %}

--- a/exercises/practice/circular-buffer/circular_buffer_test.py
+++ b/exercises/practice/circular-buffer/circular_buffer_test.py
@@ -14,13 +14,9 @@ class CircularBufferTest(unittest.TestCase):
         buf = CircularBuffer(1)
         with self.assertRaises(BufferError) as err:
             buf.read()
-            self.assertEqual(
-                type(err.exception), (BufferEmptyException, BufferFullException)
-            )
-            self.assertEqual(
-                err.exception.args[0],
-                ("Circular buffer is empty", "Circular buffer is full"),
-            )
+
+        self.assertEqual(type(err.exception), BufferEmptyException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is empty")
 
     def test_can_read_an_item_just_written(self):
         buf = CircularBuffer(1)
@@ -33,13 +29,9 @@ class CircularBufferTest(unittest.TestCase):
         self.assertEqual(buf.read(), "1")
         with self.assertRaises(BufferError) as err:
             buf.read()
-            self.assertEqual(
-                type(err.exception), (BufferEmptyException, BufferFullException)
-            )
-            self.assertEqual(
-                err.exception.args[0],
-                ("Circular buffer is empty", "Circular buffer is full"),
-            )
+
+        self.assertEqual(type(err.exception), BufferEmptyException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is empty")
 
     def test_items_are_read_in_the_order_they_are_written(self):
         buf = CircularBuffer(2)
@@ -53,13 +45,9 @@ class CircularBufferTest(unittest.TestCase):
         buf.write("1")
         with self.assertRaises(BufferError) as err:
             buf.write("2")
-            self.assertEqual(
-                type(err.exception), (BufferEmptyException, BufferFullException)
-            )
-            self.assertEqual(
-                err.exception.args[0],
-                ("Circular buffer is empty", "Circular buffer is full"),
-            )
+
+        self.assertEqual(type(err.exception), BufferFullException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is full")
 
     def test_a_read_frees_up_capacity_for_another_write(self):
         buf = CircularBuffer(1)
@@ -83,13 +71,9 @@ class CircularBufferTest(unittest.TestCase):
         buf.clear()
         with self.assertRaises(BufferError) as err:
             buf.read()
-            self.assertEqual(
-                type(err.exception), (BufferEmptyException, BufferFullException)
-            )
-            self.assertEqual(
-                err.exception.args[0],
-                ("Circular buffer is empty", "Circular buffer is full"),
-            )
+
+        self.assertEqual(type(err.exception), BufferEmptyException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is empty")
 
     def test_clear_frees_up_capacity_for_another_write(self):
         buf = CircularBuffer(1)
@@ -144,10 +128,6 @@ class CircularBufferTest(unittest.TestCase):
         self.assertEqual(buf.read(), "4")
         with self.assertRaises(BufferError) as err:
             buf.read()
-            self.assertEqual(
-                type(err.exception), (BufferEmptyException, BufferFullException)
-            )
-            self.assertEqual(
-                err.exception.args[0],
-                ("Circular buffer is empty", "Circular buffer is full"),
-            )
+
+        self.assertEqual(type(err.exception), BufferEmptyException)
+        self.assertEqual(err.exception.args[0], "Circular buffer is empty")

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -6,8 +6,8 @@
         {%- if case is error_case %}
         with self.assertRaises(ValueError) as err:
             {{ case["property"] }}({{ case["input"]["number"] }})
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "{{ exp_error }}")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ exp_error }}")
         {% else %}
         self.assertEqual(
             {{ case["property"] }}({{ case["input"]["number"] }}),
@@ -21,4 +21,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
         {{ test_case(case) }}
     {% endfor %}
-{{ macros.footer() }}

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -28,20 +28,12 @@ class CollatzConjectureTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as err:
             steps(0)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Only positive numbers are allowed")
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Only positive numbers are allowed")
 
     def test_negative_value_is_an_error(self):
 
         with self.assertRaises(ValueError) as err:
             steps(-15)
-            self.assertEqual(type(err.exception), ValueError)
-            self.assertEqual(err.exception.args[0], "Only positive numbers are allowed")
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Only positive numbers are allowed")


### PR DESCRIPTION
Caught an indentation error that was circumventing the error messages check for raised errors.  Regenerated the test files and tested to make sure that the messages were indeed being now being checked.