### PR TITLE
[Practice Exercises]: Add Better Error Handling Instructions & Tests for Error Raising Messages (# 4 of 8)

### DIFF
--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,3 +1,19 @@
-# Hints
+# Instructions append
 
-Please ignore the part regarding FRP library, a third party library is not required for this exercise.
+## Python Special Instructions
+
+A third party library **is not required** for this exercise.  Please ignore the instructions regarding **FRP library**.
+
+
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError` when the game has ended but the player tries to continue playing. The tests will only pass if you both `raise` the `exception` and include a message with it.
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+# when player tries to play, but the game is already over.
+raise ValueError("The game has already ended.")
+```

--- a/exercises/practice/hangman/.meta/example.py
+++ b/exercises/practice/hangman/.meta/example.py
@@ -15,7 +15,7 @@ class Hangman:
 
     def guess(self, char):
         if self.status != STATUS_ONGOING:
-            raise ValueError("Game already ended, you " + self.status)
+            raise ValueError("The game has already ended.")
 
         self.update_remaining_guesses(char)
         self.update_masked_word()

--- a/exercises/practice/hangman/hangman_test.py
+++ b/exercises/practice/hangman/hangman_test.py
@@ -24,8 +24,10 @@ class HangmanTests(unittest.TestCase):
             game.guess('x')
 
         self.assertEqual(game.get_status(), hangman.STATUS_LOSE)
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             game.guess('x')
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "The game has already ended.")
 
     def test_feeding_a_correct_letter_removes_underscores(self):
         game = Hangman('foobar')
@@ -80,8 +82,10 @@ class HangmanTests(unittest.TestCase):
         self.assertEqual(game.get_status(), hangman.STATUS_WIN)
         self.assertEqual(game.get_masked_word(), 'hello')
 
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             game.guess('x')
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "The game has already ended.")
 
     def test_winning_on_last_guess_still_counts_as_a_win(self):
         game = Hangman('aaa')
@@ -91,11 +95,3 @@ class HangmanTests(unittest.TestCase):
         self.assertEqual(game.remaining_guesses, 0)
         self.assertEqual(game.get_status(), hangman.STATUS_WIN)
         self.assertEqual(game.get_masked_word(), 'aaa')
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/exercises/practice/largest-series-product/.docs/instructions.append.md
+++ b/exercises/practice/largest-series-product/.docs/instructions.append.md
@@ -1,6 +1,20 @@
 # Instructions append
 
-Implementation note:
-In case of invalid inputs to the 'largest_product' function
-your program should raise a ValueError with a meaningful error message.
-Feel free to reuse your code from the 'series' exercise!
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError` when your `largest_product()` function receives invalid input. The tests will only pass if you both `raise` the `exception` and include a message with it.  Feel free to reuse your code from the `series` exercise!
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+# span of numbers is longer than number series
+raise ValueError("span must be smaller than string length")
+
+# span of number is zero or negative
+raise ValueError("span must be greater than zero")
+
+# series includes non-number input
+raise ValueError("digits input must only contain digits")
+```

--- a/exercises/practice/largest-series-product/.meta/example.py
+++ b/exercises/practice/largest-series-product/.meta/example.py
@@ -3,10 +3,16 @@ from operator import mul
 
 
 def slices(series, length):
+
+    if not length <= len(series):
+        raise ValueError("span must be smaller than string length")
+    elif not 0 < length:
+        raise ValueError("span must be greater than zero")
+    elif not all(item.isdigit() for item in series):
+        raise ValueError("digits input must only contain digits")
+
     numbers = [int(digit) for digit in series]
-    if not 1 <= length <= len(numbers):
-        raise ValueError("Invalid slice length for this series: " +
-                         str(length))
+
     return [numbers[i:i + length]
             for i in range(len(numbers) - length + 1)]
 

--- a/exercises/practice/largest-series-product/.meta/template.j2
+++ b/exercises/practice/largest-series-product/.meta/template.j2
@@ -9,8 +9,10 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
         {%- if case is error_case %}
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             {{ test_call(case) }}
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ case["expected"]["error"] }}")
         {%- else %}
         self.assertEqual({{ test_call(case) }}, {{ case["expected"] }})
         {%- endif %}
@@ -26,5 +28,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         self.assertEqual({{ test_call(case) }}, {{ case["expected"] }})
         {%- endif %}
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/largest-series-product/largest_series_product_test.py
+++ b/exercises/practice/largest-series-product/largest_series_product_test.py
@@ -39,8 +39,12 @@ class LargestSeriesProductTest(unittest.TestCase):
         self.assertEqual(largest_product("99099", 3), 0)
 
     def test_rejects_span_longer_than_string_length(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             largest_product("123", 4)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(
+            err.exception.args[0], "span must be smaller than string length"
+        )
 
     def test_reports_1_for_empty_string_and_empty_product_0_span(self):
         self.assertEqual(largest_product("", 0), 1)
@@ -49,16 +53,24 @@ class LargestSeriesProductTest(unittest.TestCase):
         self.assertEqual(largest_product("123", 0), 1)
 
     def test_rejects_empty_string_and_nonzero_span(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             largest_product("", 1)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(
+            err.exception.args[0], "span must be smaller than string length"
+        )
 
     def test_rejects_invalid_character_in_digits(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             largest_product("1234a5", 2)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "digits input must only contain digits")
 
     def test_rejects_negative_span(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             largest_product("12345", -1)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "span must be greater than zero")
 
     # Additional tests for this track
     def test_euler_big_number(self):
@@ -69,11 +81,3 @@ class LargestSeriesProductTest(unittest.TestCase):
             ),
             23514624000,
         )
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,0 +1,29 @@
+# Instructions append
+
+## Customizing and Raising Exceptions
+
+Sometimes it is necessary to both [customize](https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions) and [`raise`](https://docs.python.org/3/tutorial/errors.html#raising-exceptions) exceptions in your code. When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging.
+
+Custom exceptions can be created through new exception classes (see [`classes`](https://docs.python.org/3/tutorial/classes.html#tut-classes) for more detail.) that are typically subclasses of [`Exception`](https://docs.python.org/3/library/exceptions.html#Exception).
+
+For situations where you know the error source will be a derivative of a certain exception type, you can choose to inherit from one of the [`built in error types`](https://docs.python.org/3/library/exceptions.html#base-classes) under the _Exception_ class. When raising the error, you should still include a meaningful message.
+
+This particular exercise requires that you create a _custom exception_ to be [raised](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement)/"thrown" when your `meetup()` function is given a weekday name and number combination that is invalid. The tests will only pass if you customize appropriate exceptions, `raise` those exceptions, and include appropriate error messages.
+
+To customize a `built-in exception`, create a `class` that inherits from that exception. When raising the custom exception with a message, write the message as an argument to the `exception` type:
+
+```python
+# subclassing the built-in ValueError to create MeetupDayException
+class MeetupDayException(ValueError):
+    """Exception raised when the Meetup weekday and count do not result in a valid date.
+
+    message: explanation of the error.
+
+    """
+    def __init__(self, message):
+        self.message = message
+
+        
+# raising a MeetupDayException
+raise MeetupDayException("That day does not exist.")
+```

--- a/exercises/practice/meetup/.meta/additional_tests.json
+++ b/exercises/practice/meetup/.meta/additional_tests.json
@@ -12,15 +12,81 @@
       "expected": "2015-03-30"
     },
     {
-      "description": "nonexistent fifth Monday of February 2015",
+      "description": "fifth Thursday of February 2024",
       "property": "meetup",
       "input": {
-        "year": 2015,
+        "year": 2024,
+        "month": 2,
+        "week": "5th",
+        "dayofweek": "Thursday"
+      },
+      "expected": "2024-02-29"
+    },
+    {
+      "description": "fifth Saturday of February 2020",
+      "property": "meetup",
+      "input": {
+        "year": 2020,
+        "month": 2,
+        "week": "5th",
+        "dayofweek": "Saturday"
+      },
+      "expected": "2020-02-29"
+    },
+    {
+      "description": "last Sunday of June 2024",
+      "property": "meetup",
+      "input": {
+        "year": 2024,
+        "month": 6,
+        "week": "last",
+        "dayofweek": "Sunday"
+      },
+      "expected": "2024-06-30"
+    },
+    {
+      "description": "teenth Friday of May 2022",
+      "property": "meetup",
+      "input": {
+        "year": 2022,
+        "month": 5,
+        "week": "teenth",
+        "dayofweek": "Friday"
+      },
+      "expected": "2022-05-13"
+    },
+    {
+      "description": "nonexistent fifth Monday of February 2022",
+      "property": "meetup",
+      "input": {
+        "year": 2022,
         "month": 2,
         "week": "5th",
         "dayofweek": "Monday"
       },
-      "expected": {"error": "day does not exist"}
+      "expected": {"error": "That day does not exist."}
+    },
+    {
+      "description": "nonexistent fifth Friday of August 2022",
+      "property": "meetup",
+      "input": {
+        "year": 2022,
+        "month": 8,
+        "week": "5th",
+        "dayofweek": "Friday"
+      },
+      "expected": {"error": "That day does not exist."}
+    },
+    {
+      "description": "nonexistent fifth Thursday of May 2023",
+      "property": "meetup",
+      "input": {
+        "year": 2023,
+        "month": 5,
+        "week": "5th",
+        "dayofweek": "Thursday"
+      },
+      "expected": {"error": "That day does not exist."}
     }
   ]
 }

--- a/exercises/practice/meetup/.meta/example.py
+++ b/exercises/practice/meetup/.meta/example.py
@@ -19,9 +19,15 @@ def _choice(week):
     def _func(dates):
         if day < len(dates):
             return dates[day]
-        raise MeetupDayException('day does not exist')
+        raise MeetupDayException('That day does not exist.')
     return _func
 
 
-class MeetupDayException(Exception):
-    pass
+class MeetupDayException(ValueError):
+    """Exception raised when the Meetup weekday and count do not result in a valid date.
+
+    message: explanation of the error.
+
+    """
+    def __init__(self, message):
+        self.message = message

--- a/exercises/practice/meetup/.meta/template.j2
+++ b/exercises/practice/meetup/.meta/template.j2
@@ -6,12 +6,14 @@
         {%- set input.month = case["input"]["month"] %}
         {%- set input.week = case["input"]["week"] %}
         {%- set input.dayofweek = case["input"]["dayofweek"] %}
-        {%- for (k, v) in {"first":"1st", "second":"2nd", "third":"3rd", "fourth":"4th", "fifth":"5th"}.items() %}
+        {%- for (k, v) in {"first":"1st", "second":"2nd", "third":"3rd", "fourth":"4th", "fifth":"5th", "sixth":"6th"}.items() %}
               {%- set input.week = input.week.replace(k, v) %}
         {%- endfor %}
         {%- if case is error_case %}
-        with self.assertRaisesWithMessage(MeetupDayException):
+        with self.assertRaises(MeetupDayException) as err:
             {{ case["property"] }}({{ input.year }}, {{ input.month }}, "{{ input.week }}", "{{ input.dayofweek }}")
+        self.assertEqual(type(err.exception), MeetupDayException)
+        self.assertEqual(err.exception.args[0], "{{ case["expected"]["error"] }}")
         {%- else %}
         {%- set (year, month, day) = case["expected"].replace("-0", "-").split("-") %}
         self.assertEqual({{ case["property"] }}(
@@ -34,6 +36,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case(case) }}
     {% endfor %}
     {%- endif %}
-
-
-{{ macros.footer(True) }}

--- a/exercises/practice/meetup/meetup.py
+++ b/exercises/practice/meetup/meetup.py
@@ -1,2 +1,13 @@
+# subclassing the built-in ValueError to create MeetupDayException
+class MeetupDayException(ValueError):
+    """Exception raised when the Meetup weekday and count do not result in a valid date.
+
+    message: explanation of the error.
+
+    """
+    def __init__(self):
+        pass
+
+
 def meetup(year, month, week, day_of_week):
     pass

--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -300,14 +300,32 @@ class MeetupTest(unittest.TestCase):
     def test_fifth_monday_of_march_2015(self):
         self.assertEqual(meetup(2015, 3, "5th", "Monday"), date(2015, 3, 30))
 
-    def test_nonexistent_fifth_monday_of_february_2015(self):
-        with self.assertRaisesWithMessage(MeetupDayException):
-            meetup(2015, 2, "5th", "Monday")
+    def test_fifth_thursday_of_february_2024(self):
+        self.assertEqual(meetup(2024, 2, "5th", "Thursday"), date(2024, 2, 29))
 
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
+    def test_fifth_saturday_of_february_2020(self):
+        self.assertEqual(meetup(2020, 2, "5th", "Saturday"), date(2020, 2, 29))
 
+    def test_last_sunday_of_june_2024(self):
+        self.assertEqual(meetup(2024, 6, "last", "Sunday"), date(2024, 6, 30))
 
-if __name__ == "__main__":
-    unittest.main()
+    def test_teenth_friday_of_may_2022(self):
+        self.assertEqual(meetup(2022, 5, "teenth", "Friday"), date(2022, 5, 13))
+
+    def test_nonexistent_fifth_monday_of_february_2022(self):
+        with self.assertRaises(MeetupDayException) as err:
+            meetup(2022, 2, "5th", "Monday")
+        self.assertEqual(type(err.exception), MeetupDayException)
+        self.assertEqual(err.exception.args[0], "That day does not exist.")
+
+    def test_nonexistent_fifth_friday_of_august_2022(self):
+        with self.assertRaises(MeetupDayException) as err:
+            meetup(2022, 8, "5th", "Friday")
+        self.assertEqual(type(err.exception), MeetupDayException)
+        self.assertEqual(err.exception.args[0], "That day does not exist.")
+
+    def test_nonexistent_fifth_thursday_of_may_2023(self):
+        with self.assertRaises(MeetupDayException) as err:
+            meetup(2023, 5, "5th", "Thursday")
+        self.assertEqual(type(err.exception), MeetupDayException)
+        self.assertEqual(err.exception.args[0], "That day does not exist.")

--- a/exercises/practice/minesweeper/.docs/instructions.append.md
+++ b/exercises/practice/minesweeper/.docs/instructions.append.md
@@ -1,4 +1,14 @@
-# Implementation Notes
-The board function must validate its input and raise a
-ValueError with a *meaningful* error message if the
-input turns out to be malformed.
+# Instructions append
+
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError` when the `board()` function receives malformed input. The tests will only pass if you both `raise` the `exception` and include a message with it.
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+# when the board receives malformed input
+raise ValueError("The board is invalid with current input.")
+```

--- a/exercises/practice/minesweeper/.meta/additional_tests.json
+++ b/exercises/practice/minesweeper/.meta/additional_tests.json
@@ -38,7 +38,7 @@
           "  "
 	      ]
       },
-      "expected": {"error": "The minefield must have a consistent length"}
+      "expected": {"error": "The board is invalid with current input."}
     },
     {
       "description": "invalid char",
@@ -46,7 +46,7 @@
       "input": {
         "minefield": ["X  * "]
       },
-      "expected": {"error": "The minefield contains an invalid character"}
+      "expected": {"error": "The board is invalid with current input."}
 
     }
   ]

--- a/exercises/practice/minesweeper/.meta/example.py
+++ b/exercises/practice/minesweeper/.meta/example.py
@@ -1,5 +1,5 @@
 def annotate(minefield):
-    if(minefield == []):
+    if not minefield:
         return []
     verify_board(minefield)
     row_len = len(minefield[0])
@@ -30,11 +30,11 @@ def verify_board(minefield):
     # Rows with different lengths
     row_len = len(minefield[0])
     if not all(len(row) == row_len for row in minefield):
-        raise ValueError("Invalid board")
+        raise ValueError("The board is invalid with current input.")
 
     # Unknown character in board
     character_set = set()
     for row in minefield:
         character_set.update(row)
     if character_set - set(' *'):
-        raise ValueError("Invalid board")
+        raise ValueError("The board is invalid with current input.")

--- a/exercises/practice/minesweeper/.meta/template.j2
+++ b/exercises/practice/minesweeper/.meta/template.j2
@@ -14,10 +14,11 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in additional_cases -%}
     def test_{{ case["description"] | to_snake }}(self):
         {%- if case is error_case %}
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             {{ test_call(case) }}
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ case["expected"]["error"] }}")
         {%- else %}
         self.assertEqual({{- test_call(case) }}, {{ case["expected"] }})
         {%- endif %}
     {% endfor %}
-{{ macros.footer(True) }}

--- a/exercises/practice/minesweeper/minesweeper_test.py
+++ b/exercises/practice/minesweeper/minesweeper_test.py
@@ -58,17 +58,17 @@ class MinesweeperTest(unittest.TestCase):
         )
 
     def test_different_len(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             annotate([" ", "*  ", "  "])
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(
+            err.exception.args[0], "The board is invalid with current input."
+        )
 
     def test_invalid_char(self):
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             annotate(["X  * "])
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(
+            err.exception.args[0], "The board is invalid with current input."
+        )


### PR DESCRIPTION
Forth set from [Issue #2563](https://github.com/exercism/python/issues/2563)

- [x] [hangman](https://github.com/exercism/python/tree/main/exercises/practice/hangman/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/hangman/hangman_test.py)
- [x] [largest-series-product](https://github.com/exercism/python/tree/main/exercises/practice/largest-series-product/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/largest-series-product/largest_series_product_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/largest-series-product/.meta/template.j2)
- [x] [meetup](https://github.com/exercism/python/tree/main/exercises/practice/meetup/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/meetup/meetup_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/meetup/.meta/template.j2)
- [x] [minesweeper](https://github.com/exercism/python/tree/main/exercises/practice/minesweeper/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/minesweeper/minesweeper_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/minesweeper/.meta/template.j2)