### PR TITLE
[Practice Exercises]: Add Better Error Handling Instructions & Tests for Error Raising Messages (# 7 of 8)

### DIFF
--- a/exercises/practice/rational-numbers/.meta/template.j2
+++ b/exercises/practice/rational-numbers/.meta/template.j2
@@ -94,4 +94,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
             {{ render_other_cases(mathtypescases) }}
         {% endif %}
     {% endfor %}
-{{ macros.footer(True) }}

--- a/exercises/practice/rational-numbers/rational_numbers_test.py
+++ b/exercises/practice/rational-numbers/rational_numbers_test.py
@@ -145,11 +145,3 @@ class RationalNumbersTest(unittest.TestCase):
 
     def test_reduce_one_to_lowest_terms(self):
         self.assertEqual(Rational(13, 13), Rational(1, 1))
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/robot-simulator/.meta/template.j2
+++ b/exercises/practice/robot-simulator/.meta/template.j2
@@ -23,6 +23,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in supercase["cases"] -%}
     {{ test_case(case) }}
     {% endfor %}{% endfor %}
-
-
-{{ macros.footer(True) }}

--- a/exercises/practice/robot-simulator/robot_simulator_test.py
+++ b/exercises/practice/robot-simulator/robot_simulator_test.py
@@ -141,11 +141,3 @@ class RobotSimulatorTest(unittest.TestCase):
 
         self.assertEqual(robot.coordinates, (11, 5))
         self.assertEqual(robot.direction, NORTH)
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/roman-numerals/.meta/template.j2
+++ b/exercises/practice/roman-numerals/.meta/template.j2
@@ -5,5 +5,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     def test_{{ case["description"] | to_snake }}(self):
         self.assertEqual({{ case["property"] }}({{ case["input"]["number"] }}), "{{ case["expected"] }}")
     {% endfor %}
-
-{{ macros.footer(True) }}

--- a/exercises/practice/roman-numerals/roman_numerals_test.py
+++ b/exercises/practice/roman-numerals/roman_numerals_test.py
@@ -62,11 +62,3 @@ class RomanNumeralsTest(unittest.TestCase):
 
     def test_3000_is_mmm(self):
         self.assertEqual(roman(3000), "MMM")
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/run-length-encoding/.meta/template.j2
+++ b/exercises/practice/run-length-encoding/.meta/template.j2
@@ -31,6 +31,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case(case, title_modifier) }}
     {% endfor %}
     {% endfor %}
-
-
-{{ macros.footer(True) }}

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.py
@@ -53,11 +53,3 @@ class RunLengthEncodingTest(unittest.TestCase):
 
     def test_encode_followed_by_decode_gives_original_string(self):
         self.assertMultiLineEqual(decode(encode("zzz ZZ  zZ")), "zzz ZZ  zZ")
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/saddle-points/.docs/instructions.append.md
+++ b/exercises/practice/saddle-points/.docs/instructions.append.md
@@ -1,0 +1,14 @@
+# Instructions append
+
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError` if the `matrix` is irregular. The tests will only pass if you both `raise` the `exception` and include a message with it.
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+# if the matrix is irregular
+raise ValueError("irregular matrix")
+```

--- a/exercises/practice/saddle-points/.meta/template.j2
+++ b/exercises/practice/saddle-points/.meta/template.j2
@@ -17,8 +17,10 @@ irregular.
         matrix = []
         {% endif -%}
         {% if case is error_case -%}
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             {{- case["property"] | to_snake }}(matrix)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ case["expected"]["error"] }}")
         {% else -%}
         self.assertEqual(
         sorted_points({{ case["property"] | to_snake }}(matrix)),
@@ -44,6 +46,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case(case) }}
     {% endfor %}
     {%- endif %}
-
-
-{{ macros.footer(True) }}

--- a/exercises/practice/saddle-points/saddle_points_test.py
+++ b/exercises/practice/saddle-points/saddle_points_test.py
@@ -96,13 +96,7 @@ class SaddlePointsTest(unittest.TestCase):
 
     def test_irregular_matrix(self):
         matrix = [[3, 2, 1], [0, 1], [2, 1, 0]]
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             saddle_points(matrix)
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "irregular matrix")

--- a/exercises/practice/satellite/.docs/instructions.append.md
+++ b/exercises/practice/satellite/.docs/instructions.append.md
@@ -1,0 +1,20 @@
+# Instructions append
+
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError` if the `preorder` and `inorder` arguments are mis-matched length-wise, element-wise, or the elements are not unique. The tests will only pass if you both `raise` the `exception` and include a message with it.
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+# if preorder and inorder are not the same length
+raise ValueError("traversals must have the same length")
+
+# if preorder and inorder do not share the same elements
+raise ValueError("traversals must have the same elements")
+    
+# if element repeat (are not unique)    
+raise ValueError("traversals must contain unique items")
+```

--- a/exercises/practice/satellite/.meta/template.j2
+++ b/exercises/practice/satellite/.meta/template.j2
@@ -7,12 +7,12 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         preorder = {{ case["input"]["preorder"] }}
         inorder = {{ case["input"]["inorder"] }}
         {% if "Reject" in case["description"] %}
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             {{ case["property"] | to_snake }}(preorder, inorder)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "{{ case["expected"]["error"] }}")
         {% else %}
         expected = {{ case["expected"] }}
         self.assertEqual({{ case["property"] | to_snake }}(preorder, inorder), expected)
         {% endif %}
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/satellite/satellite_test.py
+++ b/exercises/practice/satellite/satellite_test.py
@@ -41,27 +41,27 @@ class SatelliteTest(unittest.TestCase):
         preorder = ["a", "b"]
         inorder = ["b", "a", "r"]
 
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             tree_from_traversals(preorder, inorder)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "traversals must have the same length")
 
     def test_reject_inconsistent_traversals_of_same_length(self):
         preorder = ["x", "y", "z"]
         inorder = ["a", "b", "c"]
 
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             tree_from_traversals(preorder, inorder)
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(
+            err.exception.args[0], "traversals must have the same elements"
+        )
 
     def test_reject_traversals_with_repeated_items(self):
         preorder = ["a", "b", "a"]
         inorder = ["b", "a", "a"]
 
-        with self.assertRaisesWithMessage(ValueError):
+        with self.assertRaises(ValueError) as err:
             tree_from_traversals(preorder, inorder)
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "traversals must contain unique items")


### PR DESCRIPTION
Seventh set from [Issue #2563](https://github.com/exercism/python/issues/2563)

**`Note:`** For the exercises that did not have error cases, the generic "error handling" macro was removed from the JinJa2 templates, and the test files were re-generated.

- [x] ~~[rational-numbers](https://github.com/exercism/python/tree/main/exercises/practice/rational-numbers/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/rational-numbers/rational_numbers_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/rational-numbers/.meta/template.j2)~~ actually, no error cases here.
- [x] ~~[robot-simulator](https://github.com/exercism/python/tree/main/exercises/practice/robot-simulator/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/robot-simulator/robot_simulator_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/robot-simulator/.meta/template.j2)~~ No error cases currently.  Consider adding some later.
- [x] ~~[roman-numerals](https://github.com/exercism/python/tree/main/exercises/practice/roman-numerals/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/roman-numerals/roman_numerals_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/roman-numerals/.meta/template.j2)~~ Doesn't have error cases either.  Maybe we should consider adding some.
- [x] ~~[run-length-encoding](https://github.com/exercism/python/tree/main/exercises/practice/run-length-encoding/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/run-length-encoding/run_length_encoding_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/run-length-encoding/.meta/template.j2)~~ No error cases.



- [x] [saddle-points](https://github.com/exercism/python/tree/main/exercises/practice/saddle-points/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/saddle-points/saddle_points_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/saddle-points/.meta/template.j2)
- [x] [satellite](https://github.com/exercism/python/tree/main/exercises/practice/satellite/) \| [test file](https://github.com/exercism/python/tree/main/exercises/practice/satellite/satellite_test.py) \| [template file](https://github.com/exercism/python/tree/main/exercises/practice/satellite/.meta/template.j2)