### PR TITLE
Fix-Python-Card-Game-Introduction-Typo

### DIFF
--- a/exercises/concept/card-games/.docs/introduction.md
+++ b/exercises/concept/card-games/.docs/introduction.md
@@ -7,7 +7,7 @@ Lists can be copied in whole or in part via [slice notation][slice notation] or 
 
 Lists support both [common][common sequence operations] and [mutable][mutable sequence operations] sequence operations such as `min()`/`max()`, `<list>.index()`, `<list>.append()` and `<list>.reverse()`.
 List elements can be iterated over using the `for item in <list>` construct.
- `for index, item in enumerate(<list)` can be used when both the element index and the element value are needed.
+ `for index, item in enumerate(<list>)` can be used when both the element index and the element value are needed.
 
 Under the hood, `lists` are implemented as [dynamic arrays][dynamic array] -- similar to Java's [`Arraylist`][arraylist] type, and are most often used to store groups of similar data (_strings, numbers, sets etc._) of unknown length.
 Lists are an extremely flexible and useful data structure and many built-in methods and operations in Python produce lists as their output.


### PR DESCRIPTION
a > was missing in the code example