### PR TITLE
Add doc-strings to stub file and exemplar.py

### DIFF
--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 class LogLevel(Enum):
-    """Represents different logging levels by their verbose codes"""
+    """Represent different log levels by their verbose codes."""
 
     TRACE = 'TRC'
     DEBUG = 'DBG'

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 
 class LogLevel(Enum):
+    """Represents different logging levels by their verbose codes"""
+
     TRACE = 'TRC'
     DEBUG = 'DBG'
     INFO = 'INF'
@@ -13,6 +15,8 @@ class LogLevel(Enum):
 
 
 class LogLevelInt(Enum):
+    """Represents different logging levels by their short codes"""
+
     TRACE = 0
     DEBUG = 1
     INFO = 4
@@ -24,6 +28,17 @@ class LogLevelInt(Enum):
 
 
 def parse_log_level(message):
+    """Takes a log message and returns the enum member of its level
+    Returns a LogLevel.Unknown incase an unknown severity is found
+
+    :param message: log message (string)
+    :return: <enum 'LogLevel'>
+
+    Ex:
+    - parse_log_level("[INF]: File deleted") #=> LogLevel.Info
+    - parse_log_level("[XYZ]: Out of context message") #=> LogLevel.Unknown
+    """
+
     str_split = message.split(':')
     lvl = str_split[0][1:-1]
     if lvl in [level.value for level in LogLevel]:
@@ -32,14 +47,35 @@ def parse_log_level(message):
 
 
 def convert_to_short_log(log_level, message):
+    """Converts a log message to a shorter format optimized for storage.
+
+    :param log_level: The Log level of the log sent. ex: LogLevel.Error.
+    :param message: log message (string)
+    :return: <enum 'LogLevelInt'>
+
+    Ex:
+    - convert_to_short_log(LogLevel.Error, "Stack overflow") #=> "6:Stack overflow"
+    """
+
     return f'{LogLevelInt[log_level.name].value}:{message}'
 
 
 def get_warn_alias():
+    """Returns the enum for LogLevel Warning
+
+    :return: <enum 'LogLevel'>
+    """
+
     return LogLevel('WRN')
 
 
 def get_members():
+    """Returns a list of tuples (name, value) containing all the members
+    of the enum LogLevel.
+
+    :return: List of tuples [(name1, value1), (name2, value2)]
+    """
+
     out_list = []
     for member in LogLevel:
         out_list.append((member.name, member.value))

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -15,7 +15,7 @@ class LogLevel(Enum):
 
 
 class LogLevelInt(Enum):
-    """Represents different logging levels by their short codes."""
+    """Represent different log levels by their short codes."""
 
     TRACE = 0
     DEBUG = 1

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -42,14 +42,11 @@ def parse_log_level(message):
 
 
 def convert_to_short_log(log_level, message):
-    """Converts a log message to a shorter format optimized for storage.
+    """Converts a log message to its shorter format.
 
-    :param log_level: The Log level of the log sent. ex: LogLevel.Error.
-    :param message: log message (string)
-    :return: <enum 'LogLevelInt'>
-
-    Ex:
-    - convert_to_short_log(LogLevel.Error, "Stack overflow") #=> "6:Stack overflow"
+    :param log_level: enum - 'LogLevel.<level>'  e.g.  'LogLevel.Error'
+    :param message: str - log message
+    :return: enum -  'LogLevelInt.<value>` e.g. 'LogLevelInt.5'
     """
 
     return f'{LogLevelInt[log_level.name].value}:{message}'

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -15,7 +15,7 @@ class LogLevel(Enum):
 
 
 class LogLevelInt(Enum):
-    """Represents different logging levels by their short codes"""
+    """Represents different logging levels by their short codes."""
 
     TRACE = 0
     DEBUG = 1

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -28,7 +28,7 @@ class LogLevelInt(Enum):
 
 
 def parse_log_level(message):
-    """Returns level enum for log message.
+    """Return level enum for log message.
    
     :param message: log message (string)
     :return: enum - 'LogLevel.<level>'.  Return 'LogLevel.Unknown' if an unknown severity is passed.
@@ -42,7 +42,7 @@ def parse_log_level(message):
 
 
 def convert_to_short_log(log_level, message):
-    """Converts a log message to its shorter format.
+    """Convert a log message to its shorter format.
 
     :param log_level: enum - 'LogLevel.<level>'  e.g.  'LogLevel.Error'
     :param message: str - log message

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -28,15 +28,10 @@ class LogLevelInt(Enum):
 
 
 def parse_log_level(message):
-    """Takes a log message and returns the enum member of its level
-    Returns a LogLevel.Unknown incase an unknown severity is found
-
+    """Returns level enum for log message.
+   
     :param message: log message (string)
-    :return: <enum 'LogLevel'>
-
-    Ex:
-    - parse_log_level("[INF]: File deleted") #=> LogLevel.Info
-    - parse_log_level("[XYZ]: Out of context message") #=> LogLevel.Unknown
+    :return: enum - 'LogLevel.<level>'.  Return 'LogLevel.Unknown' if an unknown severity is passed.
     """
 
     str_split = message.split(':')

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -53,9 +53,9 @@ def convert_to_short_log(log_level, message):
 
 
 def get_warn_alias():
-    """Returns the enum for LogLevel Warning
+    """Returns the enum for LogLevel.Warning.
 
-    :return: <enum 'LogLevel'>
+    :return: enum - 'LogLevel'.<alias>'
     """
 
     return LogLevel('WRN')

--- a/exercises/concept/log-levels/.meta/exemplar.py
+++ b/exercises/concept/log-levels/.meta/exemplar.py
@@ -62,10 +62,9 @@ def get_warn_alias():
 
 
 def get_members():
-    """Returns a list of tuples (name, value) containing all the members
-    of the enum LogLevel.
+    """Return all members of the enum.
 
-    :return: List of tuples [(name1, value1), (name2, value2)]
+    :return: list of tuples -  [(name1, value1), (name2, value2)]
     """
 
     out_list = []

--- a/exercises/concept/log-levels/enums.py
+++ b/exercises/concept/log-levels/enums.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 class LogLevel(Enum):
-    """Represents different logging levels by their verbose codes"""
+    """Represent different log levels by their verbose codes."""
 
     pass
 

--- a/exercises/concept/log-levels/enums.py
+++ b/exercises/concept/log-levels/enums.py
@@ -2,20 +2,54 @@ from enum import Enum
 
 
 class LogLevel(Enum):
+    """Represents different logging levels by their verbose codes"""
+
     pass
 
 
 def parse_log_level(message):
+    """Takes a log message and returns the enum member of its level
+    Returns a LogLevel.Unknown incase an unknown severity is found
+
+    :param message: log message (string)
+    :return: <enum 'LogLevel'>
+
+    Ex:
+    - parse_log_level("[INF]: File deleted") #=> LogLevel.Info
+    - parse_log_level("[XYZ]: Out of context message") #=> LogLevel.Unknown
+    """
+
     pass
 
 
 def convert_to_short_log(log_level, message):
+    """Converts a log message to a shorter format optimized for storage.
+
+    :param log_level: The Log level of the log sent. ex: LogLevel.Error.
+    :param message: log message (string)
+    :return: <enum 'LogLevelInt'>
+
+    Ex:
+    - convert_to_short_log(LogLevel.Error, "Stack overflow") #=> "6:Stack overflow"
+    """
+
     pass
 
 
 def get_warn_alias():
+    """Returns the enum for LogLevel Warning
+
+    :return: <enum 'LogLevel'>
+    """
+
     pass
 
 
 def get_members():
+    """Returns a list of tuples (name, value) containing all the members
+    of the enum LogLevel.
+
+    :return: List of tuples [(name1, value1), (name2, value2)]
+    """
+
     pass

--- a/exercises/concept/log-levels/enums.py
+++ b/exercises/concept/log-levels/enums.py
@@ -18,7 +18,7 @@ def parse_log_level(message):
 
 
 def convert_to_short_log(log_level, message):
-    """Converts a log message to its shorter format.
+    """Convert a log message to its shorter format.
 
     :param log_level: enum - 'LogLevel.<level>'  e.g.  'LogLevel.Error'
     :param message: str - log message
@@ -29,7 +29,7 @@ def convert_to_short_log(log_level, message):
 
 
 def get_warn_alias():
-    """Returns the enum for LogLevel.Warning.
+    """Return the enum for LogLevel.Warning.
 
     :return: enum - 'LogLevel'.<alias>'
     """

--- a/exercises/concept/log-levels/enums.py
+++ b/exercises/concept/log-levels/enums.py
@@ -8,48 +8,39 @@ class LogLevel(Enum):
 
 
 def parse_log_level(message):
-    """Takes a log message and returns the enum member of its level
-    Returns a LogLevel.Unknown incase an unknown severity is found
-
+    """Returns level enum for log message.
+   
     :param message: log message (string)
-    :return: <enum 'LogLevel'>
-
-    Ex:
-    - parse_log_level("[INF]: File deleted") #=> LogLevel.Info
-    - parse_log_level("[XYZ]: Out of context message") #=> LogLevel.Unknown
+    :return: enum - 'LogLevel.<level>'.  Return 'LogLevel.Unknown' if an unknown severity is passed.
     """
 
     pass
 
 
 def convert_to_short_log(log_level, message):
-    """Converts a log message to a shorter format optimized for storage.
+    """Converts a log message to its shorter format.
 
-    :param log_level: The Log level of the log sent. ex: LogLevel.Error.
-    :param message: log message (string)
-    :return: <enum 'LogLevelInt'>
-
-    Ex:
-    - convert_to_short_log(LogLevel.Error, "Stack overflow") #=> "6:Stack overflow"
+    :param log_level: enum - 'LogLevel.<level>'  e.g.  'LogLevel.Error'
+    :param message: str - log message
+    :return: enum -  'LogLevelInt.<value>` e.g. 'LogLevelInt.5'
     """
 
     pass
 
 
 def get_warn_alias():
-    """Returns the enum for LogLevel Warning
+    """Returns the enum for LogLevel.Warning.
 
-    :return: <enum 'LogLevel'>
+    :return: enum - 'LogLevel'.<alias>'
     """
 
     pass
 
 
 def get_members():
-    """Returns a list of tuples (name, value) containing all the members
-    of the enum LogLevel.
+    """Return all members of the enum.
 
-    :return: List of tuples [(name1, value1), (name2, value2)]
+    :return: list of tuples -  [(name1, value1), (name2, value2)]
     """
 
     pass


### PR DESCRIPTION
For log-levels `(Enums concept)`, proper docstrings  are added to stub file `(enums.py)` and `exemplar.py`.
Example docstrings were referenced and denoted with triple """.