### PR TITLE
Make instructions of task #3 more clear

### DIFF
--- a/exercises/concept/little-sisters-vocab/.docs/instructions.md
+++ b/exercises/concept/little-sisters-vocab/.docs/instructions.md
@@ -61,7 +61,7 @@ Implement the `make_word_groups(<vocab_words>)` function that takes a `vocab_wor
 `ness` is a common suffix that means _'state of being'_.
  In this activity, your sister needs to find the original root word by removing the `ness` suffix.
   But of course there are pesky spelling rules: If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to to 'i'.
- Removing 'ness' needs to restore the 'y' in those root words. e.g. `happiness` --> `happi` --> `happy`.
+ Removing 'ness' needs to restore the 'y' in those root words. e.g. `happiness` --> `happi` --> `happy`. In this exercise, you can ignore the second last letter point, though - just replace last letter 'i' with 'y' when removing the suffix.
 
 Implement the `remove_suffix_ness(<word>)` function that takes in a word `str`, and returns the root word without the `ness` suffix.
 


### PR DESCRIPTION
When I was doing this exercise, I had a doubt about the spelling rule: "If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to to 'i'.". Does that mean I have to check that the second last letter (without the "ness") is a consonant before replacing the "i" with a "y"? 

No, said my mentor (and the tests pass when I don't check the second last letter), which is why I've added an instruction not to care about the second last letter. If we do need to consider that, we need to both add a new test and clarify this instruction page. Also, the spelling rule seems to have a repetition

This is my first contribution to any open source project... so my apologies if my edits to the doc is not up to standard. Please edit them for more clarity.