### PR TITLE
Remove duplicate instructions header

### DIFF
--- a/exercises/concept/card-games/.docs/instructions.md
+++ b/exercises/concept/card-games/.docs/instructions.md
@@ -1,7 +1,5 @@
 # Instructions
 
-## Instructions
-
 Elyse is really looking forward to playing some poker (and other card games) during her upcoming trip to Vegas.
  Being a big fan of "self-tracking" she wants to put together some small functions that will help her with tracking tasks and has asked for your help thinking them through.
 


### PR DESCRIPTION
There is both a first level and a second-level header with the text "Instructions". This is not a big problem in the exercise description, but in the editor, the first task is shown as "Instructions", which is not right. I've removed the duplicate header so that Task 1 will be shown correctly as "Tracking Poker Rounds".