### PR TITLE
Remove duplicate "to"

### DIFF
--- a/exercises/concept/little-sisters-vocab/.docs/instructions.md
+++ b/exercises/concept/little-sisters-vocab/.docs/instructions.md
@@ -60,7 +60,7 @@ Implement the `make_word_groups(<vocab_words>)` function that takes a `vocab_wor
 
 `ness` is a common suffix that means _'state of being'_.
  In this activity, your sister needs to find the original root word by removing the `ness` suffix.
-  But of course there are pesky spelling rules: If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to to 'i'.
+  But of course there are pesky spelling rules: If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to 'i'.
  Removing 'ness' needs to restore the 'y' in those root words. e.g. `happiness` --> `happi` --> `happy`.
 
 Implement the `remove_suffix_ness(<word>)` function that takes in a word `str`, and returns the root word without the `ness` suffix.


### PR DESCRIPTION
Remove the secocnd "to" from the sentence `If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to to 'i'.`