### PR TITLE
[Anagram, Grade-School, Hamming and Markdown ]:  Corrected Bad Test files and Templates

### DIFF
--- a/bin/data.py
+++ b/bin/data.py
@@ -356,7 +356,10 @@ class TestsTOML:
     def load(cls, toml_path: Path):
         with toml_path.open() as f:
             data = toml.load(f)
-        return cls({uuid: TestCaseTOML(uuid, *opts) for uuid, opts in data.items()})
+        return cls({uuid: TestCaseTOML(uuid, *opts) for
+                    uuid, opts in
+                    data.items() if
+                    opts.get('include', None) is not False})
 
 
 if __name__ == "__main__":

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -12,5 +12,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         )
 
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/anagram/anagram_test.py
+++ b/exercises/practice/anagram/anagram_test.py
@@ -14,11 +14,6 @@ class AnagramTest(unittest.TestCase):
         self.assertCountEqual(find_anagrams("diaper", candidates), expected)
 
     def test_detects_two_anagrams(self):
-        candidates = ["stream", "pigeon", "maters"]
-        expected = ["stream", "maters"]
-        self.assertCountEqual(find_anagrams("master", candidates), expected)
-
-    def test_detects_two_anagrams(self):
         candidates = ["lemons", "cherry", "melons"]
         expected = ["lemons", "melons"]
         self.assertCountEqual(find_anagrams("solemn", candidates), expected)
@@ -82,7 +77,3 @@ class AnagramTest(unittest.TestCase):
         candidates = ["Listen", "Silent", "LISTEN"]
         expected = ["Silent"]
         self.assertCountEqual(find_anagrams("LISTEN", candidates), expected)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/grade-school/.meta/example.py
+++ b/exercises/practice/grade-school/.meta/example.py
@@ -16,10 +16,6 @@ class School:
         if not self.db.get(name, 0):
             self.db[name] = grade
             self.add.append(True)
-
-        elif self.db[name] > grade:
-            self.db[name] = grade
-
         else:
             self.add.append(False)
 

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -29,9 +29,11 @@ description = "Cannot add student to same grade in the roster more than once"
 
 [c125dab7-2a53-492f-a99a-56ad511940d8]
 description = "A student can't be in two different grades"
+include = false
 
 [a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
 description = "A student can only be added to the same grade in the roster once"
+include = false
 reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
 
 [d7982c4f-1602-49f6-a651-620f2614243a]
@@ -49,6 +51,7 @@ description = "Cannot add same student to multiple grades in the roster"
 
 [6a03b61e-1211-4783-a3cc-fc7f773fba3f]
 description = "A student cannot be added to more than one grade in the sorted roster"
+include = false
 reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
 
 [c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5]

--- a/exercises/practice/grade-school/grade_school_test.py
+++ b/exercises/practice/grade-school/grade_school_test.py
@@ -53,21 +53,6 @@ class GradeSchoolTest(unittest.TestCase):
         expected = [True, True, False, True]
         self.assertEqual(school.added(), expected)
 
-    def test_a_student_can_t_be_in_two_different_grades(self):
-        school = School()
-        school.add_student(name="Aimee", grade=2)
-        school.add_student(name="Aimee", grade=1)
-        expected = []
-        self.assertEqual(school.roster(2), expected)
-
-    def test_a_student_can_only_be_added_to_the_same_grade_in_the_roster_once(self):
-        school = School()
-        school.add_student(name="Aimee", grade=2)
-        school.add_student(name="Aimee", grade=2)
-        expected = ["Aimee"]
-
-        self.assertEqual(school.roster(), expected)
-
     def test_student_not_added_to_same_grade_in_the_roster_more_than_once(self):
         school = School()
         school.add_student(name="Blair", grade=2)
@@ -101,16 +86,6 @@ class GradeSchoolTest(unittest.TestCase):
         school.add_student(name="Paul", grade=3)
         expected = [True, True, False, True]
         self.assertEqual(school.added(), expected)
-
-    def test_a_student_cannot_be_added_to_more_than_one_grade_in_the_sorted_roster(
-        self,
-    ):
-        school = School()
-        school.add_student(name="Aimee", grade=2)
-        school.add_student(name="Aimee", grade=1)
-        expected = ["Aimee"]
-
-        self.assertEqual(school.roster(), expected)
 
     def test_student_not_added_to_multiple_grades_in_the_roster(self):
         school = School()

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -60,7 +60,6 @@ include = false
 [920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
 description = "disallow right empty strand"
 reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
-include = false
 
 [9ab9262f-3521-4191-81f5-0ed184a5aa89]
 description = "disallow empty second strand"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -26,6 +26,7 @@ description = "long different strands"
 
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
+include = false
 
 [b9228bb1-465f-4141-b40f-1f99812de5a8]
 description = "disallow first strand longer"
@@ -33,6 +34,7 @@ reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
 
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
+include = false
 
 [dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
 description = "disallow second strand longer"
@@ -40,10 +42,12 @@ reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
+include = false
 
 [db92e77e-7c72-499d-8fe6-9354d2bfd504]
 description = "disallow left empty strand"
 reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+include = false
 
 [b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
 description = "disallow empty first strand"
@@ -51,10 +55,12 @@ reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
 
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
+include = false
 
 [920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
 description = "disallow right empty strand"
 reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+include = false
 
 [9ab9262f-3521-4191-81f5-0ed184a5aa89]
 description = "disallow empty second strand"

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -44,6 +44,13 @@ class HammingTest(unittest.TestCase):
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
 
+    def test_disallow_right_empty_strand(self):
+        with self.assertRaises(ValueError) as err:
+            distance("G", "")
+
+        self.assertEqual(type(err.exception), ValueError)
+        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
+
     def test_disallow_empty_second_strand(self):
         with self.assertRaises(ValueError) as err:
             distance("G", "")

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -30,37 +30,9 @@ class HammingTest(unittest.TestCase):
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
 
-    def test_disallow_first_strand_longer(self):
-        with self.assertRaises(ValueError) as err:
-            distance("AATG", "AAA")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
     def test_disallow_second_strand_longer(self):
         with self.assertRaises(ValueError) as err:
             distance("ATA", "AGTG")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
-    def test_disallow_second_strand_longer(self):
-        with self.assertRaises(ValueError) as err:
-            distance("ATA", "AGTG")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
-    def test_disallow_left_empty_strand(self):
-        with self.assertRaises(ValueError) as err:
-            distance("", "G")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
-    def test_disallow_left_empty_strand(self):
-        with self.assertRaises(ValueError) as err:
-            distance("", "G")
 
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
@@ -68,20 +40,6 @@ class HammingTest(unittest.TestCase):
     def test_disallow_empty_first_strand(self):
         with self.assertRaises(ValueError) as err:
             distance("", "G")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
-    def test_disallow_right_empty_strand(self):
-        with self.assertRaises(ValueError) as err:
-            distance("G", "")
-
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Strands must be of equal length.")
-
-    def test_disallow_right_empty_strand(self):
-        with self.assertRaises(ValueError) as err:
-            distance("G", "")
 
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "Strands must be of equal length.")

--- a/exercises/practice/markdown/.meta/template.j2
+++ b/exercises/practice/markdown/.meta/template.j2
@@ -3,8 +3,6 @@
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
-    {% if case["description"] == "with h7 header level" %}
-    {% else %}
     def test_{{ case["description"] | to_snake }}(self):
         self.assertEqual(
             {{ case["property"] | to_snake }}(
@@ -12,5 +10,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
             ),
             "{{ case["expected"] }}"
         )
-    {% endif %}
     {% endfor %}


### PR DESCRIPTION
Due to a bug in `bin/data.py`, automated test generation was including test cases flagged `include=false` in the exercise `tests.toml` files.  

This PR:

1. Corrects `TestsTOML` `load()` classmethod in `bin/data.py` to only include test cases where `include != false`
2. Updates the `tests.toml` files for affected exercises
2. Corrects the JinJa templates for affected exercises
3. Includes regenerated test files for the 4 exercises in question.