### PR TITLE
[Wordy]: Changed Expected Error Messages for Python-Specific Test Cases

### DIFF
--- a/exercises/practice/wordy/.meta/additional_tests.json
+++ b/exercises/practice/wordy/.meta/additional_tests.json
@@ -6,7 +6,7 @@
       "input": {
         "question": "What is 2 2 minus 3?"
       },
-      "expected": {"error": "unknown operation"}
+      "expected": {"error": "syntax error"}
     },
     {
       "description": "Missing number",
@@ -14,7 +14,7 @@
       "input": {
         "question": "What is 7 plus multiplied by -2?"
       },
-      "expected": {"error": "unknown operation"}
+      "expected": {"error": "syntax error"}
     }
   ]
 }

--- a/exercises/practice/wordy/.meta/example.py
+++ b/exercises/practice/wordy/.meta/example.py
@@ -45,6 +45,6 @@ def answer(question):
         try:
             main_value = VALID_OPERATIONS[operation](main_value, second_value)
         except KeyError:
-            raise ValueError("unknown operation")
+            raise ValueError("syntax error")
 
     return main_value

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -107,10 +107,10 @@ class WordyTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             answer("What is 2 2 minus 3?")
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "unknown operation")
+        self.assertEqual(err.exception.args[0], "syntax error")
 
     def test_missing_number(self):
         with self.assertRaises(ValueError) as err:
             answer("What is 7 plus multiplied by -2?")
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "unknown operation")
+        self.assertEqual(err.exception.args[0], "syntax error")


### PR DESCRIPTION
See [Issue #2799](https://github.com/exercism/python/issues/2799) for discussion.  Changed the following:

1.  Changed error message in `additional_tests.json` to `syntax error`
2.  Regenerated `wordy_test.py` from JinJa2 template
3.  Updated `example.py` to pass re-generated tests.