### PR TITLE
[High Scores]: Skipped "scores after personal top" Test Cases

### DIFF
--- a/exercises/practice/high-scores/.meta/example.py
+++ b/exercises/practice/high-scores/.meta/example.py
@@ -1,3 +1,4 @@
+
 def latest(scores):
     return scores[-1]
 
@@ -8,11 +9,3 @@ def personal_best(scores):
 
 def personal_top_three(scores):
     return sorted(scores, reverse=True)[:3]
-
-
-def latest_after_top_three(scores):
-    return latest(scores)
-
-
-def scores_after_top_three(scores):
-    return scores

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -35,6 +35,8 @@ description = "Top 3 scores -> Personal top when there is only one"
 
 [2df075f9-fec9-4756-8f40-98c52a11504f]
 description = "Top 3 scores -> Latest score after personal top scores"
+include = false
 
 [809c4058-7eb1-4206-b01e-79238b9b71bc]
 description = "Top 3 scores -> Scores after personal top scores"
+include = false

--- a/exercises/practice/high-scores/high_scores.py
+++ b/exercises/practice/high-scores/high_scores.py
@@ -8,11 +8,3 @@ def personal_best(scores):
 
 def personal_top_three(scores):
     pass
-
-
-def latest_after_top_three(scores):
-    pass
-
-
-def scores_after_top_three(scores):
-    pass

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -2,10 +2,8 @@ import unittest
 
 from high_scores import (
     latest,
-    latest_after_top_three,
     personal_best,
     personal_top_three,
-    scores_after_top_three,
 )
 
 # Tests adapted from `problem-specifications//canonical-data.json`
@@ -46,13 +44,3 @@ class HighScoresTest(unittest.TestCase):
         scores = [40]
         expected = [40]
         self.assertEqual(personal_top_three(scores), expected)
-
-    def test_latest_score_after_personal_top_scores(self):
-        scores = [70, 50, 20, 30]
-        expected = 30
-        self.assertEqual(latest_after_top_three(scores), expected)
-
-    def test_scores_after_personal_top_scores(self):
-        scores = [30, 50, 20, 70]
-        expected = [30, 50, 20, 70]
-        self.assertEqual(scores_after_top_three(scores), expected)


### PR DESCRIPTION
Per discussion in issue #2786, the newly added test cases to get at mutability issues  make no sense for the current Python implementation of this exercise.  

This PR reverts/skips those added test cases in prep for (perhaps) added Python-specific cases for mutability, or re-writing the exercise to be class-based or in a format that better sets up mutability discussions.

1.  Set `Top 3 scores -> Latest score after personal top scores` & `Top 3 scores -> Scores after personal top scores` to `include= false` in `tests.toml.
2. Regenerated test file from JinJa template
3. Edited `example.py` to match and pass tests.