### PR TITLE
Fixed dictation error in basic concepts links, Closes #2818

### DIFF
--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -73,7 +73,7 @@
   },
   {
     "url": "https://docs.python.org/3/reference/expressions.html#calls",
-    "description": "called"
+    "description": "calls"
   },
   {
     "url": "https://docs.python.org/3/tutorial/controlflow.html#default-argument-values",


### PR DESCRIPTION
Well after clarifications I did fix it my self and here is the PR :rocket:

This PR resolves the following problem(s):
- There was a link to `https://docs.python.org/3/reference/expressions.html#calls` on this page which held the description `called` that is miss typed, It must follow the link and be typed **_calls_**.