### PR TITLE
Clock: adding support for `repr` and `str` functionality

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -2,7 +2,8 @@
 
 ## Representing your class
 
-When working with and debugging objects, it's important to have a string representation of that object. For example, if you were to create a `datetime.datetime` object in a REPL environment, you could see its string representation:
+When working with and debugging objects, it's important to have a string representation of that object.
+For example, if you were to create a `datetime.datetime` object in a REPL environment, you can see its string representation:
 
 ```python
 >>> from datetime import datetime
@@ -10,43 +11,46 @@ When working with and debugging objects, it's important to have a string represe
 datetime.datetime(2022, 5, 4, 0, 0)
 ```
 
-In this excersize, you will create a custom object, `Clock`, that handles times without dates. To do this in python, you would create a `class` to define its data and behavior.
+In this excersise, you will create a custom object, `Clock`, that handles times without dates.
+To do this in Python, you would create a `class` to to implement the desired behavior.
 
-One aspect of a class' behavior is this string prepresentation. By default, a class' string representation is not very helpful:
+One aspect of a class's behavior is how it is represented as a string.
+By default, a class's string representation is not very helpful.
 
 ```python
 >>> Clock(12, 34)
 <Clock object st 0x... >
 ```
 
-To create a more helpful representation, you will need to define a `__repr__` method on your class that returns a string.
+To create a more helpful representation, you need to define a `__repr__` method on your class that returns a string.
 
-According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return a string that could be used to recreate the object, if you were to copy and paste it into a new environment. 
+According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return valid Python code that could be used to recreate the object.
+That allows you to copy-paste the output directly into code or the REPL.
 
 For example, a `Clock` that represents 11:30 AM could look like this: `Clock(11, 30)`.
 
-
-Defining a `__repr__` method is a great thing to do for every class you create. When you do, you should consider:
+Defining a `__repr__` method is good practice for all classes.
+When you do, you should consider:
 
 - The information you're returning from this method will be beneficial when you're debugging issues.
-
-- Ideally, you should return a string that a user could copy, paste into a python environment, and have a copy of the object.
-
-- If that's not practical, return a description between angle brackets, as in `< ...a practical description... >`.
+- Ideally, you should return a string that is valid Python code.
+- If that is not practical, return a description between angle brackets: `< ...a practical description... >`.
 
 
 ### String conversion
 
-As useful as the `__repr__` method is, sometimes you'll want an alternative string representation. For example, let's look at the `datetime.datetime` class again:
+In addition to the `__repr__` method, sometimes you'll want an alternative string representation.
+This might be used to format the object for program output.
+For example, let's look at the `datetime.datetime` class again:
 
 ```python
 >>> str(datetime.datetime(2022, 5, 4))
 '2022-05-04 00:00:00'
 ```
 
-When a `datetime` object is askes to convert itself to a string, it turns into a string formatted according to the ISO 8601 standard, which can be parsed by most datetime libraries.
+When a `datetime` object is askes to convert itself to a string, it returns a string formatted according to the ISO 8601 standard, which can be parsed by most datetime libraries.
 
-This clock exercise will provide you with a similar opportunity. Part of the challenge will be to have an alternate representation like this:
+In this exercise, you will get to write a `__str__` method, too.
 
 ```python
 >>> str(Clock(11, 30))

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -19,11 +19,11 @@ One aspect of a class' behavior is this string prepresentation. By default, a cl
 <Clock object st 0x... >
 ```
 
-To create a more helpful representation, you will need to define a `__repr__` method on your class.
+To create a more helpful representation, you will need to define a `__repr__` method on your class that returns a string.
 
-According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return a string that could be used to recreate the object, is you were to copy the result and paste it in a new environment. 
+According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return a string that could be used to recreate the object, if you were to copy and paste it into a new environment. 
 
-For example, a `Clock` what represents 11:30 AM could look like this: `Clock(11, 30)`.
+For example, a `Clock` that represents 11:30 AM could look like this: `Clock(11, 30)`.
 
 
 Defining a `__repr__` method is a great thing to do for every class you create. When you do, you should consider:
@@ -32,7 +32,7 @@ Defining a `__repr__` method is a great thing to do for every class you create. 
 
 - Ideally, you should return a string that a user could copy, paste into a python environment, and have a copy of the object.
 
-- If that's not possible, return a practical description between angle brackets, as in `< ...a practical description... >`.
+- If that's not practical, return a description between angle brackets, as in `< ...a practical description... >`.
 
 
 ### String conversion

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -23,7 +23,7 @@ To create a more helpful representation, you will need to define a `__repr__` me
 
 According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return a string that could be used to recreate the object, is you were to copy the result and paste it in a new environment. 
 
-For example, a `Clock` what represents 11:30 AM would look like this: `Clock(11, 30)`.
+For example, a `Clock` what represents 11:30 AM could look like this: `Clock(11, 30)`.
 
 
 Defining a `__repr__` method is a great thing to do for every class you create. When you do, you should consider:

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -58,7 +58,7 @@ In this exercise, you will get a chance to write a `__str__` method, as well as 
 '11:30'
 ```
 
-To support this string conversion, you will need to create a `__str__` method on your class.
+To support this string conversion, you will need to create a `__str__` method on your class that returns a more "human readable" string showing the Clock time.
 
 [repr-docs]: https://docs.python.org/3/reference/datamodel.html#object.__repr__
 [classes in python]: https://docs.python.org/3/tutorial/classes.html

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -19,12 +19,12 @@ By default, a class's string representation is not very helpful.
 
 ```python
 >>> Clock(12, 34)
-<Clock object st 0x... >
+<Clock object st 0x102807b20 >
 ```
 
 To create a more helpful representation, you need to define a `__repr__` method on your class that returns a string.
 
-According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return valid Python code that could be used to recreate the object.
+According to the [specification for a `__repr__` method][repr-docs], you should ideally have the method return valid Python code that could be used to recreate the object.
 That allows you to copy-paste the output directly into code or the REPL.
 
 For example, a `Clock` that represents 11:30 AM could look like this: `Clock(11, 30)`.
@@ -58,3 +58,5 @@ In this exercise, you will get to write a `__str__` method, too.
 ```
 
 To support this string conversion, you will need to create a `__str__` method on your class.
+
+[repr-docs]: https://docs.python.org/3/reference/datamodel.html#object.__repr__

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -41,7 +41,7 @@ Some things to consider:
 ### String conversion
 
 In addition to the `__repr__` method, there might also be a need for an alternative "human-readable" string representation of the `class`.
-This might be used to format the object for program output, or documentation.
+This might be used to format the object for program output or documentation.
 Looking at `datetime.datetime` again:
 
 ```python

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,0 +1,56 @@
+# Instructions append
+
+## Representing your class
+
+When working with and debugging objects, it's important to have a string representation of that object. For example, if you were to create a `datetime.datetime` object in a REPL environment, you could see its string representation:
+
+```python
+>>> from datetime import datetime
+>>> datetime(2022, 5, 4)
+datetime.datetime(2022, 5, 4, 0, 0)
+```
+
+In this excersize, you will create a custom object, `Clock`, that handles times without dates. To do this in python, you would create a `class` to define its data and behavior.
+
+One aspect of a class' behavior is this string prepresentation. By default, a class' string representation is not very helpful:
+
+```python
+>>> Clock(12, 34)
+<Clock object st 0x... >
+```
+
+To create a more helpful representation, you will need to define a `__repr__` method on your class.
+
+According to the [specification for a `__repr__` method](https://docs.python.org/3/reference/datamodel.html#object.__repr__), you should ideally have the method return a string that could be used to recreate the object, is you were to copy the result and paste it in a new environment. 
+
+For example, a `Clock` what represents 11:30 AM would look like this: `Clock(11, 30)`.
+
+
+Defining a `__repr__` method is a great thing to do for every class you create. When you do, you should consider:
+
+- The information you're returning from this method will be beneficial when you're debugging issues.
+
+- Ideally, you should return a string that a user could copy, paste into a python environment, and have a copy of the object.
+
+- If that's not possible, return a practical description between angle brackets, as in `< ...a practical description... >`.
+
+
+### String conversion
+
+As useful as the `__repr__` method is, sometimes you'll want an alternative string representation. For example, let's look at the `datetime.datetime` class again:
+
+```python
+>>> str(datetime.datetime(2022, 5, 4))
+'2022-05-04 00:00:00'
+```
+
+When a `datetime` object is askes to convert itself to a string, it turns into a string formatted according to the ISO 8601 standard, which can be parsed by most datetime libraries.
+
+This clock exercise will provide you with a similar opportunity. Part of the challenge will be to have an alternate representation like this:
+
+```python
+>>> str(Clock(11, 30))
+'11:30'
+```
+
+To support this string conversion, you will need to create a `__str__` method on your class.

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -60,6 +60,8 @@ In this exercise, you will get a chance to write a `__str__` method, as well as 
 
 To support this string conversion, you will need to create a `__str__` method on your class that returns a more "human readable" string showing the Clock time.
 
+If you don't create a `__str__` method and you call `str()` on your class, python will try calling `__repr__` on your class as a fallback. So if you only implement one of the two, it would be better to create a `__repr__` method.
+
 [repr-docs]: https://docs.python.org/3/reference/datamodel.html#object.__repr__
 [classes in python]: https://docs.python.org/3/tutorial/classes.html
 [REPL]: https://pythonprogramminglanguage.com/repl/

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,56 +1,57 @@
 # Instructions append
 
+The tests for this exercise expect your clock will be implemented via a Clock `class` in Python.
+If you are unfamiliar with classes in Python, [classes][classes in python] from the Python docs is a good place to start.
 ## Representing your class
 
 When working with and debugging objects, it's important to have a string representation of that object.
-For example, if you were to create a `datetime.datetime` object in a REPL environment, you can see its string representation:
+For example, if you were to create a new `datetime.datetime` object in the Python [REPL][REPL] environment, you could see its string representation:
 
 ```python
 >>> from datetime import datetime
->>> datetime(2022, 5, 4)
+>>> new_date = datetime(2022, 5, 4)
+>>> new_date
 datetime.datetime(2022, 5, 4, 0, 0)
-```
 
-In this excersise, you will create a custom object, `Clock`, that handles times without dates.
-To do this in Python, you would create a `class` to to implement the desired behavior.
-
-One aspect of a class's behavior is how it is represented as a string.
-By default, a class's string representation is not very helpful.
+Your Clock `class` will create a custom `object` that handles times without dates.
+One important aspect of this `class` will be how it is represented as a _string_.
+Other programmers who use or call Clock `objects` created from the Clock `class` will refer to this string representation for debugging and other activities.  
+However, the default string representation on a `class` is usually not very helpful.
 
 ```python
 >>> Clock(12, 34)
 <Clock object st 0x102807b20 >
 ```
 
-To create a more helpful representation, you need to define a `__repr__` method on your class that returns a string.
+To create a more helpful representation, you can define a `__repr__` method on the `class` that returns a string.
 
-According to the [specification for a `__repr__` method][repr-docs], you should ideally have the method return valid Python code that could be used to recreate the object.
-That allows you to copy-paste the output directly into code or the REPL.
+Ideally, the `__repr__` method returns valid Python code that can be used to recreate the object -- as laid out in the [specification for a `__repr__` method][repr-docs].
+Returning valid Python code allows you to copy-paste the `str` directly into code or the REPL.
 
 For example, a `Clock` that represents 11:30 AM could look like this: `Clock(11, 30)`.
 
 Defining a `__repr__` method is good practice for all classes.
-When you do, you should consider:
+Some things to consider:
 
-- The information you're returning from this method will be beneficial when you're debugging issues.
-- Ideally, you should return a string that is valid Python code.
-- If that is not practical, return a description between angle brackets: `< ...a practical description... >`.
+- The information returned from this method should be beneficial when debugging issues.
+- _Ideally_, the method returns a string that is valid Python code -- although that might not always be possible.
+- If valid Python code is not practical, returning a description between angle brackets: `< ...a practical description... >` is the convention.
 
 
 ### String conversion
 
-In addition to the `__repr__` method, sometimes you'll want an alternative string representation.
-This might be used to format the object for program output.
-For example, let's look at the `datetime.datetime` class again:
+In addition to the `__repr__` method, there might also be a need for an alternative "human-readable" string representation of the `class`.
+This might be used to format the object for program output, or documentation.
+Looking at `datetime.datetime` again:
 
 ```python
 >>> str(datetime.datetime(2022, 5, 4))
 '2022-05-04 00:00:00'
 ```
 
-When a `datetime` object is askes to convert itself to a string, it returns a string formatted according to the ISO 8601 standard, which can be parsed by most datetime libraries.
+When a `datetime` object is asked to convert itself to a string representation, it returns a `str` formatted according to the [ISO 8601 standard][ISO 8601], which can be parsed by most datetime libraries into a human-readable date and time.
 
-In this exercise, you will get to write a `__str__` method, too.
+In this exercise, you will get a chance to write a `__str__` method, as well as a `__repr__`.
 
 ```python
 >>> str(Clock(11, 30))
@@ -60,3 +61,7 @@ In this exercise, you will get to write a `__str__` method, too.
 To support this string conversion, you will need to create a `__str__` method on your class.
 
 [repr-docs]: https://docs.python.org/3/reference/datamodel.html#object.__repr__
+[classes in python]: https://docs.python.org/3/tutorial/classes.html
+[REPL]: https://pythonprogramminglanguage.com/repl/
+[ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+

--- a/exercises/practice/clock/.meta/additional_tests.json
+++ b/exercises/practice/clock/.meta/additional_tests.json
@@ -1,0 +1,39 @@
+{
+  "cases": [
+    {
+      "description": "Create a string representation",
+      "cases": [
+        {
+          "uuid": "d2c8f173-018d-488c-8c4c-009f8c772313",
+          "description": "lunch time",
+          "property": "repr",
+          "input": {
+            "hour": 12,
+            "minute": 0
+          },
+          "expected": "Clock(12, 0)"
+        },
+        {
+          "uuid": "61a68f88-b980-46cd-a9f5-844832618092",
+          "description": "breakfast time",
+          "property": "repr",
+          "input": {
+            "hour": 6,
+            "minute": 45
+          },
+          "expected": "Clock(6, 45)"
+        },
+        {
+          "uuid": "ea93b367-fb03-44e4-a845-51756b8c9f3a",
+          "description": "dinner time",
+          "property": "repr",
+          "input": {
+            "hour": 18,
+            "minute": 30
+          },
+          "expected": "Clock(18, 30)"
+        }
+      ]
+    }
+  ]
+}

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -16,7 +16,8 @@
     "rootulp",
     "smalley",
     "thomasjpfan",
-    "tqa236"
+    "tqa236",
+    "chrismay"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/clock/.meta/example.py
+++ b/exercises/practice/clock/.meta/example.py
@@ -7,6 +7,9 @@ class Clock:
         self.cleanup()
 
     def __repr__(self):
+        return f'Clock({self.hour}, {self.minute})'
+
+    def __str__(self):
         return '{:02d}:{:02d}'.format(self.hour, self.minute)
 
     def __eq__(self, other):

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -19,7 +19,6 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
                 {{- clock(input["clock1"]) }},
                 {{- clock(input["clock2"]) }}
             {% else -%}
-                
                 Equal({{ 'repr' if prop == 'repr' else 'str' }}({{ clock(input) }}
                 {%- if prop == "add" %} + {{ input["value"] }}
                 {%- elif prop == "subtract" %} - {{ input["value"] }}

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -4,6 +4,8 @@ Clock({{ obj["hour"] }}, {{ obj["minute"] }})
 {%- endmacro -%}
 {{ macros.header(["Clock"])}}
 
+{% set cases = additional_cases + cases %}
+
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases -%}
     # {{ casegroup["description"].title() }}
@@ -17,7 +19,8 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
                 {{- clock(input["clock1"]) }},
                 {{- clock(input["clock2"]) }}
             {% else -%}
-                Equal(str({{ clock(input) }}
+                
+                Equal({{ 'repr' if prop == 'repr' else 'str' }}({{ clock(input) }}
                 {%- if prop == "add" %} + {{ input["value"] }}
                 {%- elif prop == "subtract" %} - {{ input["value"] }}
                 {%- endif %}), "
@@ -27,5 +30,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 
     {% endfor %}
     {%- endfor %}
-
 {{ macros.footer() }}

--- a/exercises/practice/clock/clock.py
+++ b/exercises/practice/clock/clock.py
@@ -5,6 +5,9 @@ class Clock:
     def __repr__(self):
         pass
 
+    def __str__(self):
+        pass
+
     def __eq__(self, other):
         pass
 

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -8,6 +8,16 @@ from clock import (
 
 
 class ClockTest(unittest.TestCase):
+    # Create a string representation
+    def test_breakfast_time(self):
+        self.assertEqual(repr(Clock(6, 45)), "Clock(6, 45)")
+
+    def test_lunchtime(self):
+        self.assertEqual(repr(Clock(12, 0)), "Clock(12, 0)")
+
+    def test_dinnertime(self):
+        self.assertEqual(repr(Clock(18, 30)), "Clock(18, 30)")
+
     # Create A New Clock With An Initial Time
     def test_on_the_hour(self):
         self.assertEqual(str(Clock(8, 0)), "08:00")

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -8,14 +8,14 @@ from clock import (
 
 
 class ClockTest(unittest.TestCase):
-    # Create a string representation
+    # Create A String Representation
+    def test_lunch_time(self):
+        self.assertEqual(repr(Clock(12, 0)), "Clock(12, 0)")
+
     def test_breakfast_time(self):
         self.assertEqual(repr(Clock(6, 45)), "Clock(6, 45)")
 
-    def test_lunchtime(self):
-        self.assertEqual(repr(Clock(12, 0)), "Clock(12, 0)")
-
-    def test_dinnertime(self):
+    def test_dinner_time(self):
         self.assertEqual(repr(Clock(18, 30)), "Clock(18, 30)")
 
     # Create A New Clock With An Initial Time


### PR DESCRIPTION
This pull request aims to add helpful instructions about the difference between the `__repr__` and `__str__` methods to the Clock exercise, to address #2813.