### PR TITLE
Update noun_to_verb to adjective_to_verb

### DIFF
--- a/exercises/concept/little-sisters-vocab/.docs/instructions.md
+++ b/exercises/concept/little-sisters-vocab/.docs/instructions.md
@@ -82,16 +82,15 @@ Suffixes are often used to change the part of speech a word has.
 In this task, your sister is going to practice "verbing" words by extracting an adjective from a sentence and turning it into a verb.
  Fortunately, all the words that need to be transformed here are "regular" - they don't need spelling changes to add the suffix.
 
-Implement the `noun_to_verb(<sentence>, <index>)` function that takes two parameters.
+Implement the `adjective_to_verb(<sentence>, <index>)` function that takes two parameters.
  A `sentence` using the vocabulary word, and the `index` of the word, once that sentence is split apart.
  The function should return the extracted adjective as a verb.
 
 
 ```python
->>> noun_to_verb('I need to make that bright.', -1 )
+>>> adjective_to_verb('I need to make that bright.', -1 )
 'brighten'
 
->>> noun_to_verb('It got dark as the sun set.', 2)
+>>> adjective_to_verb('It got dark as the sun set.', 2)
 'darken'
 ```
-

--- a/exercises/concept/little-sisters-vocab/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-vocab/.meta/exemplar.py
@@ -45,7 +45,7 @@ def remove_suffix_ness(word):
     return word
 
 
-def noun_to_verb(sentence, index):
+def adjective_to_verb(sentence, index):
     """
 
     :param sentence: str that uses the word in sentence

--- a/exercises/concept/little-sisters-vocab/strings.py
+++ b/exercises/concept/little-sisters-vocab/strings.py
@@ -38,7 +38,7 @@ def remove_suffix_ness(word):
     pass
 
 
-def noun_to_verb(sentence, index):
+def adjective_to_verb(sentence, index):
     """
 
     :param sentence: str that uses the word in sentence

--- a/exercises/concept/little-sisters-vocab/strings_test.py
+++ b/exercises/concept/little-sisters-vocab/strings_test.py
@@ -3,7 +3,7 @@ import pytest
 from strings import (add_prefix_un,
                      make_word_groups,
                      remove_suffix_ness,
-                     noun_to_verb)
+                     adjective_to_verb)
 
 
 class LittleSistersVocabTest(unittest.TestCase):
@@ -73,22 +73,22 @@ class LittleSistersVocabTest(unittest.TestCase):
                                  msg=f'Expected: {result} but got a different word instead.')
 
     @pytest.mark.task(taskno=4)
-    def test_noun_to_verb(self):
+    def test_adjective_to_verb(self):
         input_data = ['Look at the bright sky.',
                       'His expression went dark.',
                       'The bread got hard after sitting out.',
                       'The butter got soft in the sun.',
-                      'Her face was filled with light.',
+                      'Her eyes were light blue.',
                       'The morning fog made everything damp with mist.',
                       'He cut the fence pickets short by mistake.',
                       'Charles made weak crying noises.',
                       'The black oil got on the white dog.']
-        index_data = [-2, -1, 3, 3, -1, -3, 5, 2, 1]
+        index_data = [-2, -1, 3, 3, -2, -3, 5, 2, 1]
         result_data = ['brighten', 'darken', 'harden', 'soften',
                        'lighten', 'dampen', 'shorten', 'weaken', 'blacken']
         number_of_variants = range(1, len(input_data) + 1)
 
         for variant, sentence, index, result in zip(number_of_variants, input_data, index_data, result_data):
             with self.subTest(f'variation #{variant}', sentence=sentence, index=index, result=result):
-                self.assertEqual(noun_to_verb(sentence, index), result,
+                self.assertEqual(adjective_to_verb(sentence, index), result,
                                  msg=f'Expected: {result} but got a different word instead.')


### PR DESCRIPTION
I noticed that the function actually extracts an adjective, not a noun (The description itself states _The function should return the extracted **adjective** as a verb._).
Also proposed a new sentence (with an adjective) in the test as it was using a noun.