### PR TITLE
gigasecond: Make it clear that we pass a datetime object

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.md
+++ b/exercises/practice/gigasecond/.docs/instructions.md
@@ -1,6 +1,9 @@
 # Instructions
 
-Given a moment, determine the moment that would be after a gigasecond
+Given a `datetime` representing a moment in time, determine the moment that would be after a _gigasecond_
 has passed.
 
-A gigasecond is 10^9 (1,000,000,000) seconds.
+A _gigasecond_ is 10^9 (1,000,000,000) seconds.
+
+For example, `add(datetime.datetime.utcnow())` might return, depending on when it was called
+`datetime.datetime(2053, 9, 10, 22, 44, 38, 704371)`


### PR DESCRIPTION
Simple PR, do let me know if it's inappropriate / need to raise an issue.

I wasn't really sure what the gigasecond problem wanted me to do.  This was because "moment" doesn't have a well-defined meaning.  As such, it was only when I ran the tests that I saw it was receiving a `datetime` object.