### PR TITLE
Fix all entries with wrong output for number_to_the_power_of.__doc__

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -201,9 +201,13 @@ def number_to_the_power_of(number_one, number_two):
     return number_one ** number_two
 
 >>> print(number_to_the_power_of.__doc__)
-Returns float or int.
+Raise a number to an arbitrary power.
 
-       Takes number_one and raises it to the power of number_two, returning the result.
+    :param number_one: int the base number.
+    :param number_two: int the power to raise the base number to.
+    :return: int - number raised to power of second number
+
+    Takes number_one and raises it to the power of number_two, returning the result.
 
 # __doc__() for the built-in type: str.
 >>> print(str.__doc__)

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -179,9 +179,13 @@ def number_to_the_power_of(number_one, number_two):
     return number_one ** number_two
 
 >>> print(number_to_the_power_of.__doc__)
-Returns float or int.
+Raise a number to an arbitrary power.
 
-       Takes number_one and raises it to the power of number_two, returning the result.
+    :param number_one: int the base number.
+    :param number_two: int the power to raise the base number to.
+    :return: int - number raised to power of second number
+
+    Takes number_one and raises it to the power of number_two, returning the result.
 
 # __doc__() for the built-in type: str.
 >>> print(str.__doc__)

--- a/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
+++ b/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
@@ -186,9 +186,13 @@ They are recommended for programs of any size where documentation is needed, and
 ...
 
 >>> print(number_to_the_power_of.__doc__)
-Returns float or int.
+Raise a number to an arbitrary power.
 
-       Takes number_one and raises it to the power of number_two, returning the result.
+    :param number_one: int the base number.
+    :param number_two: int the power to raise the base number to.
+    :return: int - number raised to power of second number
+
+    Takes number_one and raises it to the power of number_two, returning the result.
 
 # __doc__() for the built-in type: str.
 >>> print(str.__doc__)


### PR DESCRIPTION
Hi @BethanyG, I read your comments to the previous PR and checked for all instances of the docstring to `number_to_the_power_of` function. 
I found one more instance, altogether 3 files were changed.

This PR relates to issue: https://github.com/exercism/python/issues/2833

Note 1: Prettier suggests to add one more line after `>>> print(number_to_the_power_of.__doc__)` but I kept the same distance as in the original, because it's supposed to show how the REPL prints output, so I guess not having that blank line is fine?

Note 2: I wanted to update the already created PR (#2834), but some of my changes (updated branch to be in sync with main) must have automatically closed it.