### PR TITLE
Fix error_case test gen to check for 'score' prpty

### DIFF
--- a/exercises/practice/bowling/.meta/template.j2
+++ b/exercises/practice/bowling/.meta/template.j2
@@ -5,8 +5,13 @@
         rolls = {{ input["previousRolls"] }}
         game = self.roll_new_game(rolls)
         {% if case is error_case -%}
+        {% set property = case["property"] -%}
         with self.assertRaisesWithMessage(Exception):
+            {% if property == 'score' -%}
+            game.score()
+            {% else -%}
             game.roll({{ input["roll"] }})
+            {% endif -%}
         {% else -%}
         self.assertEqual(game.score(), {{ case["expected"] }})
         {% endif %}

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -151,13 +151,13 @@ class BowlingTest(unittest.TestCase):
         rolls = []
         game = self.roll_new_game(rolls)
         with self.assertRaisesWithMessage(Exception):
-            game.roll()
+            game.score()
 
     def test_an_incomplete_game_cannot_be_scored(self):
         rolls = [0, 0]
         game = self.roll_new_game(rolls)
         with self.assertRaisesWithMessage(Exception):
-            game.roll()
+            game.score()
 
     def test_cannot_roll_if_game_already_has_ten_frames(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -171,7 +171,7 @@ class BowlingTest(unittest.TestCase):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
         game = self.roll_new_game(rolls)
         with self.assertRaisesWithMessage(Exception):
-            game.roll()
+            game.score()
 
     def test_both_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated(
         self,
@@ -179,7 +179,7 @@ class BowlingTest(unittest.TestCase):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
         game = self.roll_new_game(rolls)
         with self.assertRaisesWithMessage(Exception):
-            game.roll()
+            game.score()
 
     def test_bonus_roll_for_a_spare_in_the_last_frame_must_be_rolled_before_score_can_be_calculated(
         self,
@@ -187,7 +187,7 @@ class BowlingTest(unittest.TestCase):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
         game = self.roll_new_game(rolls)
         with self.assertRaisesWithMessage(Exception):
-            game.roll()
+            game.score()
 
     def test_cannot_roll_after_bonus_roll_for_spare(self):
         rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2]


### PR DESCRIPTION
error_case tests were being generated with code that always raised exceptions regardless of the user's code; this was disguised as 'passing' tests since they were expecting an exception anyway.

This change means the generator now checks the 'property' field from the canonical-data.json file and correctly calls the `score` method instead of `roll` for error tests where that is specified.

**Edit to add: [issue link here](https://github.com/exercism/python/issues/2839)**