### PR TITLE
Update to the test_is_blackjack function

### DIFF
--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -64,7 +64,8 @@ class BlackJackTest(unittest.TestCase):
     def test_is_blackjack(self):
         data = [
                 (('A', 'K'), True), (('10', 'A'), True),
-                (('10', '9'), False), (('A', 'A'), False)]
+                (('10', '9'), False), (('A', 'A'), False),
+                (('4', '7'), False), (('9', '2'), False)]
 
         for variant, (hand, blackjack) in enumerate(data, 1):
             with self.subTest(f'variation #{variant}', input=hand, output=blackjack):


### PR DESCRIPTION
Solution/Modification: Added two extra test cases to the data array in the test_is_blackjack function.

Problem: One can conceivably pass the test_is_blackjack test by calling the value_of_card function for each card, add the results together, and then test if the value was 11 (as an Ace in the value_of_card function is fixed as 1).  However, this alone does not necessarily indicate that blackjack has been achieved, as any two cards that sum to 11 (such as 4 and 7, or 9 and 2) would also pass the test, even though they shouldn't.  For blackjack to occur, one must also check that one of the cards is an Ace (or, alternatively, that one of the cards has a value of 10)