### PR TITLE
[Strings and Loops] Changed Prerequisites for Concept Exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
         "name": "Little Sister's Vocabulary",
         "uuid": "5a9b42fb-ddf4-424b-995d-f9952ea63c37",
         "concepts": ["strings"],
-        "prerequisites": ["basics"],
+        "prerequisites": ["basics", "conditionals"],
         "status": "beta"
       },
       {
@@ -145,7 +145,7 @@
         "concepts": ["loops"],
         "prerequisites": [
           "basics",
-          "conditionals",
+          "comparisons",
           "lists",
           "list-methods",
           "strings"


### PR DESCRIPTION
Closes #2795 
- Added `conditionals` (Meltdown Mitigation) as prerequisite for `strings` (Little Sisters Vocab).
- Added `comparisons` (Black Jack) as prerequisite for `loops` (Making the Grade).
- Removed `conditionals` as prerequisite for `loops` (_`comparisons` has `conditionals` as a prerequisite_.)