### PR TITLE
ghost-gobble-arcade_game: Fixed typos in hints.md

### DIFF
--- a/exercises/concept/ghost-gobble-arcade-game/.docs/hints.md
+++ b/exercises/concept/ghost-gobble-arcade-game/.docs/hints.md
@@ -10,15 +10,15 @@
 
 ## 2. Define if Pac-Man scores
 
-- You can use the [Boolean][boolean] [operator][Boolean-operators] to combine arguments for a result.
+- You can use the [Boolean][boolean] [operators][Boolean-operators] to combine arguments for a result.
 
 ## 3. Define if Pac-Man loses
 
-- You can use the [boolean][Boolean] [operator][Boolean-operators] to combine arguments for a result.
+- You can use the [boolean][Boolean] [operators][Boolean-operators] to combine arguments for a result.
 
 ## 4. Define if Pac-Man wins
 
-- You can use the [Boolean][boolean] [operator][Boolean-operators] to combine arguments for a result.
+- You can use the [Boolean][boolean] [operators][Boolean-operators] to combine arguments for a result.
 
 [boolean]: https://docs.python.org/3/library/stdtypes.html#truth
 [Boolean-operators]: https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not


### PR DESCRIPTION
I was just looking over this and found that only the first sentence had 'operators' (plural) while the other 3 had 'operator' (singular).  Judging by the text in the indirect link, I figured that the latter 3 were incorrect.