### PR TITLE
Fixed the 'dark.en' != 'darken' error

### DIFF
--- a/exercises/concept/little-sisters-vocab/strings_test.py
+++ b/exercises/concept/little-sisters-vocab/strings_test.py
@@ -75,7 +75,7 @@ class LittleSistersVocabTest(unittest.TestCase):
     @pytest.mark.task(taskno=4)
     def test_adjective_to_verb(self):
         input_data = ['Look at the bright sky.',
-                      'His expression went dark.',
+                      'His expression went dark when he saw it.',
                       'The bread got hard after sitting out.',
                       'The butter got soft in the sun.',
                       'Her eyes were light blue.',


### PR DESCRIPTION
As the word dark is at the end of the sentence, when we split the sentence we get "dark." instead of "dark"