### PR TITLE
[Grade School]: Stub out `added` and `add_student` methods that are called in the tests

### DIFF
--- a/exercises/practice/grade-school/grade_school.py
+++ b/exercises/practice/grade-school/grade_school.py
@@ -10,3 +10,6 @@ class School:
 
     def grade(self, grade_number):
         pass
+
+    def added(self):
+        pass


### PR DESCRIPTION
A bunch of tests call an "added()" method, but the method is not stubbed out. At a minimum, it should be stubbed out.