### PR TITLE
fix(concept/black-jack): quotation marks

### DIFF
--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -51,7 +51,7 @@ class BlackJackTest(unittest.TestCase):
                 ('2', '3', 11), ('3', '6', 11), ('5', '2', 11),
                 ('8', '2', 11), ('5', '5', 11), ('Q', 'A', 1),
                 ('10', '2', 1), ('7', '8', 1), ('J', '9', 1),
-                ('K', "K", 1), ('2', 'A', 1)]
+                ('K', 'K', 1), ('2', 'A', 1)]
 
         for variant, (card_one, card_two, ace_value) in enumerate(data, 1):
             with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, ace_value=ace_value):


### PR DESCRIPTION
Single quotation mark seems to be used for strings in black_jack_test.py.
I found one string surrounded by double quotation mark.
And I fixed.