### PR TITLE
refactor: reformat lists_test.py by pylint

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,7 +66,7 @@ jobs:
       run: pip install dataclasses
 
     - name: Install pytest
-      run: pip install pytest
+      run: pip install pytest~=6.2.5
 
     - name: Check exercises
       run: |

--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -18,8 +18,8 @@ class CardGamesTest(unittest.TestCase):
 
         input_vars = [0, 1, 10, 27, 99, 666]
 
-        results = [[0, 1, 2], [1, 2, 3], 
-                   [10, 11, 12], [27, 28, 29], 
+        results = [[0, 1, 2], [1, 2, 3],
+                   [10, 11, 12], [27, 28, 29],
                    [99, 100, 101], [666, 667, 668]]
 
         for variant, (number, rounds) in enumerate(zip(input_vars, results), start=1):
@@ -27,16 +27,15 @@ class CardGamesTest(unittest.TestCase):
             with self.subTest(f'variation #{variant}', input=number, output=rounds):
                 self.assertEqual(rounds, get_rounds(number), msg=error_message)
 
-
     @pytest.mark.task(taskno=2)
     def test_concatenate_rounds(self):
 
-        input_vars = [([], []), ([0, 1], []), ([], [1, 2]), 
-                      ([1], [2]), ([27, 28, 29], [35, 36]), 
+        input_vars = [([], []), ([0, 1], []), ([], [1, 2]),
+                      ([1], [2]), ([27, 28, 29], [35, 36]),
                       ([1, 2, 3], [4, 5, 6])]
 
-        results = [[], [0, 1], [1, 2], [1, 2], 
-                   [27, 28, 29, 35, 36], 
+        results = [[], [0, 1], [1, 2], [1, 2],
+                   [27, 28, 29, 35, 36],
                    [1, 2, 3, 4, 5, 6]]
 
         for variant, ((rounds_1, rounds_2), rounds) in enumerate(zip(input_vars, results), start=1):
@@ -44,11 +43,10 @@ class CardGamesTest(unittest.TestCase):
             with self.subTest(f'variation #{variant}', input=(rounds_1, rounds_2), output=rounds):
                 self.assertEqual(rounds, concatenate_rounds(rounds_1, rounds_2), msg=error_message)
 
-
     @pytest.mark.task(taskno=3)
     def test_list_contains_round(self):
 
-        input_vars = [([], 1), ([1, 2, 3], 0), ([27, 28, 29, 35, 36], 30), 
+        input_vars = [([], 1), ([1, 2, 3], 0), ([27, 28, 29, 35, 36], 30),
                       ([1], 1), ([1, 2, 3], 1), ([27, 28, 29, 35, 36], 29)]
 
         results = [False, False, False, True, True, True]
@@ -58,7 +56,6 @@ class CardGamesTest(unittest.TestCase):
             with self.subTest(f'variation #{variant}', input=(rounds, round_number), output=contains):
                 self.assertEqual(contains, list_contains_round(rounds, round_number), msg=error_message)
 
-
     @pytest.mark.task(taskno=4)
     def test_card_average(self):
 
@@ -67,10 +64,9 @@ class CardGamesTest(unittest.TestCase):
         results = [1.0, 6.0, 2.5, 37.0]
 
         for variant, (hand, average) in enumerate(zip(input_vars, results), start=1):
-            error_message=f'Expected {average} as the average of {hand}.'
+            error_message = f'Expected {average} as the average of {hand}.'
             with self.subTest(f'variation #{variant}', input=hand, output=average):
                 self.assertEqual(average, card_average(hand), msg=error_message)
-
 
     @pytest.mark.task(taskno=5)
     def test_approx_average_is_average(self):
@@ -86,7 +82,6 @@ class CardGamesTest(unittest.TestCase):
             with self.subTest(f'variation #{variant}', input=hand, output=same):
                 self.assertEqual(same, approx_average_is_average(hand), msg=error_message)
 
-
     @pytest.mark.task(taskno=6)
     def test_average_even_is_average_odd(self):
 
@@ -95,19 +90,18 @@ class CardGamesTest(unittest.TestCase):
         results = [False, False, True, True]
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
-            error_message=f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'
+            error_message = f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'
             with self.subTest(f'variation #{variant}', input=hand, output=same):
-                self.assertEqual(same, average_even_is_average_odd(hand),msg=error_message)
-
+                self.assertEqual(same, average_even_is_average_odd(hand), msg=error_message)
 
     @pytest.mark.task(taskno=7)
     def test_maybe_double_last(self):
 
         input_vars = [[1, 2, 11], [5, 9, 11], [5, 9, 10], [1, 2, 3]]
 
-        results = [[1, 2, 22], [5, 9, 22], [5, 9 , 10], [1, 2, 3]]
+        results = [[1, 2, 22], [5, 9, 22], [5, 9, 10], [1, 2, 3]]
 
         for variant, (hand, doubled_hand) in enumerate(zip(input_vars, results), start=1):
-            error_message=f'Expected {doubled_hand} as the maybe-doubled version of {hand}.'
+            error_message = f'Expected {doubled_hand} as the maybe-doubled version of {hand}.'
             with self.subTest(f'variation #{variant}', input=hand, output=doubled_hand):
-                self.assertEqual(doubled_hand,maybe_double_last(hand),msg=error_message)
+                self.assertEqual(doubled_hand, maybe_double_last(hand), msg=error_message)

--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -19,11 +19,12 @@ class CardGamesTest(unittest.TestCase):
         input_vars = [0, 1, 10, 27, 99, 666]
 
         results = [[0, 1, 2], [1, 2, 3],
-                   [10, 11, 12], [27, 28, 29],
+                   [10, 11, 12], [27, 28, 29], 
                    [99, 100, 101], [666, 667, 668]]
 
         for variant, (number, rounds) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected rounds {rounds} given the current round {number}.'
+
             with self.subTest(f'variation #{variant}', input=number, output=rounds):
                 self.assertEqual(rounds, get_rounds(number), msg=error_message)
 
@@ -40,6 +41,7 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, ((rounds_1, rounds_2), rounds) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected {rounds} as the concatenation of {rounds_1} and {rounds_2}.'
+
             with self.subTest(f'variation #{variant}', input=(rounds_1, rounds_2), output=rounds):
                 self.assertEqual(rounds, concatenate_rounds(rounds_1, rounds_2), msg=error_message)
 
@@ -53,6 +55,7 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, ((rounds, round_number), contains) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Round {round_number} {"is" if contains else "is not"} in {rounds}.'
+
             with self.subTest(f'variation #{variant}', input=(rounds, round_number), output=contains):
                 self.assertEqual(contains, list_contains_round(rounds, round_number), msg=error_message)
 
@@ -79,6 +82,7 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Hand {hand} {"does" if same else "does not"} yield the same approximate average.'
+
             with self.subTest(f'variation #{variant}', input=hand, output=same):
                 self.assertEqual(same, approx_average_is_average(hand), msg=error_message)
 
@@ -91,6 +95,7 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'
+
             with self.subTest(f'variation #{variant}', input=hand, output=same):
                 self.assertEqual(same, average_even_is_average_odd(hand), msg=error_message)
 
@@ -103,5 +108,6 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, doubled_hand) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected {doubled_hand} as the maybe-doubled version of {hand}.'
+
             with self.subTest(f'variation #{variant}', input=hand, output=doubled_hand):
                 self.assertEqual(doubled_hand, maybe_double_last(hand), msg=error_message)

--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -19,12 +19,11 @@ class CardGamesTest(unittest.TestCase):
         input_vars = [0, 1, 10, 27, 99, 666]
 
         results = [[0, 1, 2], [1, 2, 3],
-                   [10, 11, 12], [27, 28, 29], 
+                   [10, 11, 12], [27, 28, 29],
                    [99, 100, 101], [666, 667, 668]]
 
         for variant, (number, rounds) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected rounds {rounds} given the current round {number}.'
-
             with self.subTest(f'variation #{variant}', input=number, output=rounds):
                 self.assertEqual(rounds, get_rounds(number), msg=error_message)
 
@@ -41,7 +40,6 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, ((rounds_1, rounds_2), rounds) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected {rounds} as the concatenation of {rounds_1} and {rounds_2}.'
-
             with self.subTest(f'variation #{variant}', input=(rounds_1, rounds_2), output=rounds):
                 self.assertEqual(rounds, concatenate_rounds(rounds_1, rounds_2), msg=error_message)
 
@@ -55,7 +53,6 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, ((rounds, round_number), contains) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Round {round_number} {"is" if contains else "is not"} in {rounds}.'
-
             with self.subTest(f'variation #{variant}', input=(rounds, round_number), output=contains):
                 self.assertEqual(contains, list_contains_round(rounds, round_number), msg=error_message)
 
@@ -82,7 +79,6 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Hand {hand} {"does" if same else "does not"} yield the same approximate average.'
-
             with self.subTest(f'variation #{variant}', input=hand, output=same):
                 self.assertEqual(same, approx_average_is_average(hand), msg=error_message)
 
@@ -95,7 +91,6 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'
-
             with self.subTest(f'variation #{variant}', input=hand, output=same):
                 self.assertEqual(same, average_even_is_average_odd(hand), msg=error_message)
 
@@ -108,6 +103,5 @@ class CardGamesTest(unittest.TestCase):
 
         for variant, (hand, doubled_hand) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Expected {doubled_hand} as the maybe-doubled version of {hand}.'
-
             with self.subTest(f'variation #{variant}', input=hand, output=doubled_hand):
                 self.assertEqual(doubled_hand, maybe_double_last(hand), msg=error_message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ astroid>=2.6.5
 flake8==4.0.1
 pylint>=2.9.2
 yapf>=0.31.0
+toml>=0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ astroid>=2.6.5
 flake8==4.0.1
 pylint>=2.9.2
 yapf>=0.31.0
-toml>=0.10.2


### PR DESCRIPTION
## fixed:

- trim whitespaces in the end of line
- trim blanklines between pytest tasks (PEP 8)