### PR TITLE
[Inventory Management] Correct typo in the introduction

### DIFF
--- a/exercises/concept/inventory-management/.docs/introduction.md
+++ b/exercises/concept/inventory-management/.docs/introduction.md
@@ -54,7 +54,7 @@ You can easily change a value of an item using its _key_.
 
 ## Deleting values using keys
 
-You can delete an item from a dictionary using `dict.pop(<key>)`. This will remove the `(key`, `value`) pair from the dictionary and return the `value` for use. `dict.pop(<key>)` accepts second argument, `default` that is returned if the `key` is not found  (`dict.pop(<key>, <default>)`). Otherwise, a `KeyError` will be raised for any `key` that is missing.
+You can delete an item from a dictionary using `dict.pop(<key>)`. This will remove the (`key`, `value`) pair from the dictionary and return the `value` for use. `dict.pop(<key>)` accepts second argument, `default` that is returned if the `key` is not found  (`dict.pop(<key>, <default>)`). Otherwise, a `KeyError` will be raised for any `key` that is missing.
 
 ```python
 >>> bear.pop("name")


### PR DESCRIPTION
Changed `(key`, `value`) to (`key`, `value`)
#2897