### PR TITLE
[Comparisons] Corrected typo

### DIFF
--- a/concepts/comparisons/.meta/config.json
+++ b/concepts/comparisons/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Comparison operators evaluate two operand values, returning True or False based on whether the comparison condition is met.",
+  "blurb": "Comparison operators evaluate two operand values, returning 'True' or 'False' based on whether the comparison condition is met.",
   "authors": ["gurupratap-matharu", "bethanyg"],
   "contributors": []
 }


### PR DESCRIPTION
changed "True or False" to "'True' or 'False'" as in the other texts #2906