### PR TITLE
Add additional test case to black-jack

### DIFF
--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -65,7 +65,8 @@ class BlackJackTest(unittest.TestCase):
         data = [
                 (('A', 'K'), True), (('10', 'A'), True),
                 (('10', '9'), False), (('A', 'A'), False),
-                (('4', '7'), False), (('9', '2'), False)]
+                (('4', '7'), False), (('9', '2'), False),
+                (('Q', 'K'), False)]
 
         for variant, (hand, blackjack) in enumerate(data, 1):
             with self.subTest(f'variation #{variant}', input=hand, output=blackjack):


### PR DESCRIPTION
I saw this in a submission that passed the test. The incorrect implementation was:

```python
def is_blackjack(card_one, card_two):
    if card_one != card_two:
        if card_one and card_two in ['J','Q',"K",'A']:
            return True 
    return False
```

Not sure if I should have opened an issue for this first and if patches like these are accepted but just thought I would open a PR with a possible fix. Let me know!