### PR TITLE
[Phone Number] Only one problem per test input

### DIFF
--- a/exercises/practice/phone-number/phone_number_test.py
+++ b/exercises/practice/phone-number/phone_number_test.py
@@ -22,7 +22,7 @@ class PhoneNumberTest(unittest.TestCase):
 
     def test_invalid_when_9_digits(self):
         with self.assertRaises(ValueError) as err:
-            PhoneNumber("123456789")
+            PhoneNumber("213456789")
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "incorrect number of digits")
 
@@ -48,13 +48,13 @@ class PhoneNumberTest(unittest.TestCase):
 
     def test_invalid_with_letters(self):
         with self.assertRaises(ValueError) as err:
-            PhoneNumber("123-abc-7890")
+            PhoneNumber("523-abc-7890")
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "letters not permitted")
 
     def test_invalid_with_punctuations(self):
         with self.assertRaises(ValueError) as err:
-            PhoneNumber("123-@:!-7890")
+            PhoneNumber("523-@:!-7890")
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "punctuations not permitted")
 


### PR DESCRIPTION
Because the area code is not allowed to start with 0 or 1, inputs designed to elicit other errors should not use area codes that start with either of those digits.