### PR TITLE
[Cater Waiter] Change Dict to Set in Example of Introduction

### DIFF
--- a/exercises/concept/cater-waiter/.docs/introduction.md
+++ b/exercises/concept/cater-waiter/.docs/introduction.md
@@ -106,7 +106,7 @@ Using operators requires that both inputs be `sets` or `frozensets`, while metho
 True
 
 # A set is always a loose subset of itself
->>> animals <= animals
+>>> birds <= birds
 True
 
 >>> birds <= set(animals)


### PR DESCRIPTION
Replace **dictionary** `animals` by **set** `birds`. This should be done because the example is about sets. See #2920