### PR TITLE
two-bucket: Update test generation template (#2916)

### DIFF
--- a/exercises/practice/two-bucket/.docs/instructions.append.md
+++ b/exercises/practice/two-bucket/.docs/instructions.append.md
@@ -1,0 +1,13 @@
+# Instructions append
+
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" a `ValueError`. The tests will only pass if you both `raise` the `exception` and include a message with it.
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
+
+```python
+raise ValueError("A meaningful error message here.")
+```

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -11,7 +11,8 @@
     "ikhadykin",
     "N-Parsons",
     "tqa236",
-    "yawpitch"
+    "yawpitch",
+    "mhorod"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,19 +1,26 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{%- macro test_call(case) -%}
+{{ case["property"] }}({{ case["input"]["bucketOne"] }},
+                      {{ case["input"]["bucketTwo"] }},
+                      {{ case["input"]["goal"] }},
+                      "{{ case["input"]["startBucket"] }}")
+{%- endmacro -%}
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{ case["property"] }}(
-                {{ case["input"]["bucketOne"] }},
-                    {{ case["input"]["bucketTwo"] }},
-                    {{ case["input"]["goal"] }},
-                    "{{ case["input"]["startBucket"] }}"),
+        {%- if case is error_case %}
+        with self.assertRaisesWithMessage(ValueError):
+          {{ test_call(case) }}
+        {%- else %}
+        self.assertEqual({{ test_call(case) }},
             (
                 {{ case["expected"]["moves"] }},
                 "{{ case["expected"]["goalBucket"] }}",
                 {{ case["expected"]["otherBucket"] }}
             ))
+        {%- endif %}
 
     {% endfor %}
 

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -29,12 +29,9 @@ description = "Measure using bucket one of size 2 and bucket two of size 3 - sta
 
 [449be72d-b10a-4f4b-a959-ca741e333b72]
 description = "Not possible to reach the goal"
-include = false
 
 [aac38b7a-77f4-4d62-9b91-8846d533b054]
 description = "With the same buckets but a different goal, then it is possible"
-include = false
 
 [74633132-0ccf-49de-8450-af4ab2e3b299]
 description = "Goal larger than both buckets is impossible"
-include = false

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -38,6 +38,21 @@ class TwoBucketTest(unittest.TestCase):
     ):
         self.assertEqual(measure(2, 3, 3, "one"), (2, "two", 2))
 
+    def test_not_possible_to_reach_the_goal(self):
+        with self.assertRaisesWithMessage(ValueError):
+            measure(6, 15, 5, "one")
+
+    def test_with_the_same_buckets_but_a_different_goal_then_it_is_possible(self):
+        self.assertEqual(measure(6, 15, 9, "one"), (10, "two", 0))
+
+    def test_goal_larger_than_both_buckets_is_impossible(self):
+        with self.assertRaisesWithMessage(ValueError):
+            measure(5, 7, 8, "one")
+
+    # Utility functions
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixing issue #2916 

Test generator was failing because the new tests contain `error` field which wasn't handled by the old JinJa2 template.
No changes to `example.py` were required.
