### PR TITLE
Add Markupsafe to generator-requirements.txt

### DIFF
--- a/requirements-generator.txt
+++ b/requirements-generator.txt
@@ -2,3 +2,4 @@ black==20.8b1
 flake8==3.7.8
 Jinja2==2.10.1
 python-dateutil==2.8.1
+markupsafe==2.0.1


### PR DESCRIPTION
JinJa2 is complaining that it can't import `soft_unicode` from markupsafe.  Pinning version to see if that helps fix the CI issue.