### PR TITLE
Fix bug in test case for test_value_of_ace

### DIFF
--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -51,7 +51,7 @@ class BlackJackTest(unittest.TestCase):
                 ('2', '3', 11), ('3', '6', 11), ('5', '2', 11),
                 ('8', '2', 11), ('5', '5', 11), ('Q', 'A', 1),
                 ('10', '2', 1), ('7', '8', 1), ('J', '9', 1),
-                ('K', 'K', 1), ('2', 'A', 1)]
+                ('K', 'K', 1), ('2', 'A', 11)]
 
         for variant, (card_one, card_two, ace_value) in enumerate(data, 1):
             with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, ace_value=ace_value):


### PR DESCRIPTION
A variant of the test_value_of_ace test case is incorrect. If you have a '2' and 'A' in your hand, and you receive a third card of an 'A', the value of the 'A' received is 11 not 1.