### PR TITLE
Updating instructions to match test case

### DIFF
--- a/exercises/concept/making-the-grade/.docs/instructions.md
+++ b/exercises/concept/making-the-grade/.docs/instructions.md
@@ -9,7 +9,7 @@ You decide to make things a little more interesting by putting together some fun
 While you can give "partial credit" on exam questions, overall exam scores have to be `int`s.
 So before you can do anything else with the class scores, you need to go through the grades and turn any `float` scores into `int`s. Lucky for you, Python has the built-in [`round()`][round] function you can use.
 
-A score of 75.45 or 75.49 will round to 75. A score of 43.50 or 43.59 will round to 44.
+A score of 75.45 or 75.49 will round to 75. A score of 40.50 will round to 40. A score of 43.59 will round to 44.
 There shouldn't be any scores that have more than two places after the decimal point.
 
 Create the function `round_scores()` that takes a `list` of `student_scores`.

--- a/exercises/concept/making-the-grade/.docs/instructions.md
+++ b/exercises/concept/making-the-grade/.docs/instructions.md
@@ -9,7 +9,7 @@ You decide to make things a little more interesting by putting together some fun
 While you can give "partial credit" on exam questions, overall exam scores have to be `int`s.
 So before you can do anything else with the class scores, you need to go through the grades and turn any `float` scores into `int`s. Lucky for you, Python has the built-in [`round()`][round] function you can use.
 
-A score of 75.45 or 75.49 will round to 75. A score of 40.50 will round to 40. A score of 43.59 will round to 44.
+A score of 75.45 or 75.49 will round to 75. A score of 40.50 will round to 40. A score of 43.50 (_or above_) will round to 44.
 There shouldn't be any scores that have more than two places after the decimal point.
 
 Create the function `round_scores()` that takes a `list` of `student_scores`.


### PR DESCRIPTION
In the very first test case, there is a test case of 40.5, and the expected value is 40. This contradicts the instructions which says values of for example 40.50 should round up to 41. This also contradicts the instructions to use round() which rounds values of .5 down.

Here is the test case which contradicts the instructions:

```
    @pytest.mark.task(taskno=1)
    def test_round_scores(self):
        data = [
            ([], []),
            ([.5], [0]),
            ([1.5], [2]),
            (
                [90.33, 40.5, 55.44, 70.05, 30.55, 25.45, 80.45, 95.3, 38.7, 40.3],
                [90, 40, 55, 70, 31, 25, 80, 95, 39, 40]),
```