### PR TITLE
[Ellens Alien Game] Cleanup Pass for Docs.

### DIFF
--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -85,7 +85,7 @@ Altering the value of class attributes alters the value _**for all objects insta
 # Modifying the value of the "number" class attribute.
 >>> MyClass.number = 27
 
-# Modifying the "number" class attribute changes the "number" attribute for all instantiated objects.
+# Modifying the "number" class attribute changes the "number" attribute for all objects.
 >>> obj_one.number
 27
 

--- a/exercises/concept/ellens-alien-game/.docs/hints.md
+++ b/exercises/concept/ellens-alien-game/.docs/hints.md
@@ -25,7 +25,7 @@
 ## 5. The `collision_detection` Method
 
 - Remember that `object methods` are always passed `self` as the first parameter.
-- This method seems like an excellent place to use some kind of placeholder...
+- This method seems like an excellent place to use some kind of placeholder…
 
 ## 6. Alien Counter
 

--- a/exercises/concept/ellens-alien-game/.docs/hints.md
+++ b/exercises/concept/ellens-alien-game/.docs/hints.md
@@ -2,35 +2,40 @@
 
 ## 1. Create the Alien Class
 
-- Remember that object methods are always passed `self` as the first parameter.
-- Remember the double underscores on _both_ sides of `__init__`.
-- Instance variables are unique to the class instance (object) that possesses them.
-- Class variables are the same across all instances of a class.
+- Remember that `object methods` are always passed `self` as the first parameter.
+- Remember the double underscores on _both_ sides of `__init__()`.
+- Instance variables are unique to the `class` instance (_object_) that possesses them.
+- Class variables are the same across all instances of a `class`.
 
 ## 2. The `hit` Method
 
-- Remember that object methods are always passed `self` as the first parameter.
+- Remember that `object methods` are always passed `self` as the first parameter.
+- You can choose to allow the Alien's health to fall below zero, or require that it does not.
 
 ## 3. The `is_alive` Method
 
-- Remember that object methods are always passed `self` as the first parameter.
-- 0 is not the only 'dead' condition.
+- Remember that `object methods` are always passed `self` as the first parameter.
+- 0 may not be the only 'dead' condition, depending on how `hit()` is implemented.
 
 ## 4. The `teleport` Method
 
-- Remember that object methods are always passed `self` as the first parameter.
+- Remember that `object methods` are always passed `self` as the first parameter.
+- Instance attributes can be updated from a method by using `self.<attribute>` = `<new attribute value>`.
 
 ## 5. The `collision_detection` Method
 
-- Remember that object methods are always passed `self` as the first parameter.
-- This method seems like an excellent place to use some kind of placeholder.
+- Remember that `object methods` are always passed `self` as the first parameter.
+- This method seems like an excellent place to use some kind of placeholder...
 
 ## 6. Alien Counter
 
-- Class variables are the same across all instances of a class.
+- Class attributes are the same across all instances of a `class`.
+- Ideally, this counter would increment whenever someone _made an new Alien_.
+- Class attributes can be changed from an instance method by using the _class name_:  `Alien.<class attribute name>`.
+- `__init__()` is considered an instance method since it _initializes a new object_.
 
 ## 7. Object Creation
 
-- A tuple would be a _single_ parameter.
-- The Alien constructor takes 2 parameters.
-- Unpacking what is _inside_ the tuple might be closer to what you need.
+- A `tuple` would be a _single_ parameter.
+- The Alien constructor takes _2 parameters_.
+- Unpacking what is _inside_ the tuple would yield two parameters.

--- a/exercises/concept/ellens-alien-game/.docs/instructions.md
+++ b/exercises/concept/ellens-alien-game/.docs/instructions.md
@@ -5,6 +5,7 @@ She has just learned about Object Oriented Programming (OOP) and is eager to tak
 
 To Ellen's delight, you have offered to help and she has given you the task of programming the aliens that the player has to fight.
 
+
 ## 1. Create the Alien Class
 
 Define the Alien class with a constructor that accepts two parameters `<x_coordinate>` and `<y_coordinate>`, putting them into `x_coordinate` and `y_coordinate` instance variables.
@@ -20,12 +21,13 @@ Every alien will also start off with a health level of 3, so the `health` variab
 3
 ```
 
-Now, each alien should be able to internally keep track of it's own position and health.
+Now, each alien should be able to internally track its own position and health.
 
 ## 2. The `hit` Method
 
 Ellen would like the Alien `class` to have a `hit` method that decrements the health of an alien object by 1 when called.
 This way, she can simply call `<alien>.hit()` instead of having to manually change an alien's health.
+It is up to you if `hit()` takes healths points _to_ or _below_ zero.
 
 ```python
 >>> alien = Alien(0, 0)
@@ -42,7 +44,7 @@ This way, she can simply call `<alien>.hit()` instead of having to manually chan
 
 ## 3. The `is_alive` Method
 
-You realize that if the health keeps decreasing, at some point it will probably hit 0 (or even less!).
+You realize that if the health keeps decreasing, at some point it will probably hit 0 (_or even less!_).
 It would be a good idea to add an `is_alive` method that Ellen can quickly call to check if the alien is... well... alive. 😉
 `<alien>.is_alive()` should return a boolean.
 

--- a/exercises/concept/ellens-alien-game/.docs/introduction.md
+++ b/exercises/concept/ellens-alien-game/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 If you have been programming in a [functional][functional], [declarative][declarative], or [imperative][imperative] style, shifting focus to [object oriented programming][oop] (OOP) may feel a bit foreign.
 An OOP approach asks the programmer to think about modeling a problem as one or more `objects` that interact with one another, keep state, and act upon data.
-Objects can represent real world entities (_such as Cars or Cats_) - or more abstract concepts (_such as integers, vehicles, or mammals_).
+Objects can represent real world entities (_such as cars or cats_) - or more abstract concepts (_such as integers, vehicles, or mammals_).
 Each object becomes a unique instance in computer memory and represents some part of the overall model.
 
 ## Classes
@@ -88,7 +88,7 @@ Altering the value of class attributes alters the value _**for all objects insta
 # Modifying the value of the "number" class attribute.
 >>> MyClass.number = 27
 
-# Modifying the "number" class attribute changes the "number" attribute for all instantiated objects.
+# Modifying the "number" class attribute changes the "number" attribute for all objects.
 >>> obj_one.number
 27
 
@@ -230,7 +230,7 @@ class MyClass:
 ## Placeholding or Stubbing Implementation with Pass
 
 In previous concept exercises and practice exercise stubs, you will have seen the `pass` keyword used within the body of  functions in place of actual code.
-The `pass` keyword is a syntactically valid placeholder - it prevents Python from throwing a syntax error or `NotImplemented` error for an empty function or class definition.
+The `pass` keyword is a syntactically valid placeholder - it prevents Python from throwing a syntax error for an empty function or class definition.
 Essentially, it is a way to say to the Python interpreter, 'Don't worry! I _will_ put code here eventually, I just haven't done it yet.'
 
 ```python


### PR DESCRIPTION
Originally related to #2954, but also included things I found when re-reviewing the docs.

- Cleaned up a few "leftover" typos and wording issues in both exercise and concept docs.
- Added line for **task two** (`hit()`) instructions hinting at choosing Alien health to remain at zero or go below zero.
- Edited `hints` to add note about being able to take alien health below zero.
- Edited `hints` to add more detail on how to go about changing a class attribute and *where* to do it.