### PR TITLE
[PROBLEM-SOVLING]: Added (very) rough draft of problem solving links

### DIFF
--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -15,12 +15,12 @@ Below are some community-sourced articles, videos, and books that can help you d
 - [Felienne Hermans][felienne-hermans] is more focused on _how_ people learn the art of coding and how that maps to learning in general.
   She has written [The Programmers Brian][programmers-brain-free-online], with strategies for reading code better, thinking about code clearly, writing better code, and becoming a better code collaborator.
   - You can order a physical copy of her book [here][programmers-brain-manning].
-  - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Writing is Programming is Writing][felienne-hermans-programming-is-writing-is-programming].
+  - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Programming is Writing is Programming ][felienne-hermans-programming-is-writing-is-programming].
 - [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover problem-solving when coding.
 - [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking] and [Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
 - [From Computing to Computational Thinking (Paul S. Wang)][wang-computational-thinking] is a bit more generalized and academic, but offers problem-solving strategies and structures that can apply to more than coding, and does not require prior programming knowledge.
 
-Many of the books above can also be read through the Association of Computing Machinery library.
+Some of the books above may also be read through the Association of Computing Machinery library.
 Membership (paid) information is available at [acm(dot)org][association-for-computing-machinery].
 
 

--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -8,6 +8,7 @@ Below are some community-sourced articles, videos, and books that can help you d
 
 
 - Free Code Camp offers a good overview article on [How to Think Like a Programmer - Lessons in Problem-Solving][free-code-camp-think-like-a-programmer].
+- Kurtis Pykes writing for Towards Data Science has a nice [hands-on tutorial for problem-solving][Kurtis Pykes: Hands-on Tutorial - How to Improve Your Problem-Solving Skills as A Programmer].
 - UC Berkeley has a nice PDF summary of [G. Polya's Problem Solving Techniques][g-polya-how-to-solve-it-summary].
 - Originally written in 1945 as guidance for tackling complicated math problems,[G. Polya's How To Solve It][g-polya-how-to-solve-it] (full book) is still _excellent_ advice for problem-solving in general.
 - Mentioned in the Free Code Camp Article, V. Anton Spraul's [Think Like a Programmer: An Introduction to Creative Problem Solving][v-anton-spraul-think-like-a-programmer] is a more modern and programming-focused take on the same general methods Polya outlines for mathematics.
@@ -23,7 +24,9 @@ Many of the books above can also be read through the Association of Computing Ma
 Membership (paid) information is available at [acm(dot)org][association-for-computing-machinery].
 
 
+[Kurtis Pykes: Hands-on Tutorial - How to Improve Your Problem-Solving Skills as A Programmer]: https://towardsdatascience.com/hands-on-tutorial-how-to-improve-your-problem-solving-skills-as-a-programmer-83f0a8d1082f
 [association-for-computing-machinery]: https://www.acm.org/membership/membership-benefits
+[beecher-computational-thinking]: https://www.karlbeecher.com/project/ct
 [daniel-zingaro-algorithmic-thinking]: https://nostarch.com/algorithmic-thinking
 [felienne-hermans-how-to-teach-programming]: https://www.youtube.com/watch?v=g1ib43q3uXQ
 [felienne-hermans-programming-is-writing-is-programming]: https://www.youtube.com/watch?v=uO3a4HIBDU4
@@ -34,7 +37,6 @@ Membership (paid) information is available at [acm(dot)org][association-for-comp
 [paul-vickers-how-to-think-like-a-programmer]: https://www.researchgate.net/publication/236270907_How_to_Think_like_a_Programmer_Problem_Solving_for_the_Bewildered
 [programmers-brain-free-online]: https://www.manning.com/books/the-programmers-brain#toc
 [programmers-brain-manning]: https://www.manning.com/books/the-programmers-brain
-[v-anton-spraul-think-like-a-programmer]: https://archive.org/details/think-like-a-programmer/page/n19/mode/2up
-[beecher-computational-thinking]: https://www.karlbeecher.com/project/ct
 [riley-and-hunt-computational-thinking]: https://www.amazon.com/Computational-Thinking-Problem-Textbooks-Computing-ebook/dp/B00IZL9NQI
+[v-anton-spraul-think-like-a-programmer]: https://archive.org/details/think-like-a-programmer/page/n19/mode/2up
 [wang-computational-thinking]: https://www.amazon.com/Computing-Computational-Thinking-Paul-Wang-dp-1482217651/dp/1482217651/ref=mt_other?_encoding=UTF8&me=&qid=

--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -15,7 +15,9 @@ Below are some community-sourced articles, videos, and books that can help you d
   She has written [The Programmers Brian][programmers-brain-free-online], with strategies for reading code better, thinking about code clearly, writing better code, and becoming a better code collaborator.
   - You can order a physical copy of her book [here][programmers-brain-manning].
   - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Writing is Programming is Writing][felienne-hermans-programming-is-writing-is-programming].
-- [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover similar problem-solving territory when coding.
+- 
+- [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover problem-solving when coding.
+- [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking],[Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking], and [From Computing to Computational Thinking (Paul S. Wang)][wang-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
 
 Many of the books above can also be read through the Association of Computing Machinery library.
 Membership (paid) information is available at [acm(dot)org][association-for-computing-machinery].
@@ -33,3 +35,6 @@ Membership (paid) information is available at [acm(dot)org][association-for-comp
 [programmers-brain-free-online]: https://www.manning.com/books/the-programmers-brain#toc
 [programmers-brain-manning]: https://www.manning.com/books/the-programmers-brain
 [v-anton-spraul-think-like-a-programmer]: https://archive.org/details/think-like-a-programmer/page/n19/mode/2up
+[beecher-computational-thinking]: https://www.karlbeecher.com/project/ct
+[riley-and-hunt-computational-thinking]: https://www.amazon.com/Computational-Thinking-Problem-Textbooks-Computing-ebook/dp/B00IZL9NQI
+[wang-computational-thinking]: https://www.amazon.com/Computing-Computational-Thinking-Paul-Wang-dp-1482217651/dp/1482217651/ref=mt_other?_encoding=UTF8&me=&qid=

--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -9,15 +9,15 @@ Below are some community-sourced articles, videos, and books that can help you d
 
 - Free Code Camp offers a good overview article on [How to Think Like a Programmer - Lessons in Problem-Solving][free-code-camp-think-like-a-programmer].
 - UC Berkeley has a nice PDF summary of [G. Polya's Problem Solving Techniques][g-polya-how-to-solve-it-summary].
-- Originally written in 1945 as guidance for tackling complicated math problems,[G. Polya's [How To Solve It][g-polya-how-to-solve-it] (full book) is still _excellent_ advice for problem-solving in general.
+- Originally written in 1945 as guidance for tackling complicated math problems,[G. Polya's How To Solve It][g-polya-how-to-solve-it] (full book) is still _excellent_ advice for problem-solving in general.
 - Mentioned in the Free Code Camp Article, V. Anton Spraul's [Think Like a Programmer: An Introduction to Creative Problem Solving][v-anton-spraul-think-like-a-programmer] is a more modern and programming-focused take on the same general methods Polya outlines for mathematics.
 - [Felienne Hermans][felienne-hermans] is more focused on _how_ people learn the art of coding and how that maps to learning in general.
   She has written [The Programmers Brian][programmers-brain-free-online], with strategies for reading code better, thinking about code clearly, writing better code, and becoming a better code collaborator.
   - You can order a physical copy of her book [here][programmers-brain-manning].
   - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Writing is Programming is Writing][felienne-hermans-programming-is-writing-is-programming].
-- 
 - [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover problem-solving when coding.
-- [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking],[Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking], and [From Computing to Computational Thinking (Paul S. Wang)][wang-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
+- [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking],[Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
+- [From Computing to Computational Thinking (Paul S. Wang)][wang-computational-thinking] is a bit more generalized and academic, but offers problem-solving strategies and structures that can apply to more than coding, and does not require prior programming knowledge.
 
 Many of the books above can also be read through the Association of Computing Machinery library.
 Membership (paid) information is available at [acm(dot)org][association-for-computing-machinery].

--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -16,7 +16,7 @@ Below are some community-sourced articles, videos, and books that can help you d
   - You can order a physical copy of her book [here][programmers-brain-manning].
   - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Writing is Programming is Writing][felienne-hermans-programming-is-writing-is-programming].
 - [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover problem-solving when coding.
-- [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking],[Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
+- [Computational Thinking: A beginner's guide to problem-solving and programming (Karl Beecher)][beecher-computational-thinking] and [Computational Thinking for the Modern Problem-Solver (Riley and Hunt)][riley-and-hunt-computational-thinking]. Also offer strategies for thinking about problems and breaking them down for coding solutions.
 - [From Computing to Computational Thinking (Paul S. Wang)][wang-computational-thinking] is a bit more generalized and academic, but offers problem-solving strategies and structures that can apply to more than coding, and does not require prior programming knowledge.
 
 Many of the books above can also be read through the Association of Computing Machinery library.

--- a/docs/PROBLEM-SOLVING.md
+++ b/docs/PROBLEM-SOLVING.md
@@ -1,0 +1,35 @@
+# Problem Solving Strategies
+
+
+As the first article here states, `Problem solving is a meta-skill`.
+We find that often, the syntax or structure of a programming language isn't the most difficult part of solving a challenge - figuring out _what to code_ or _where to start_ is.
+Developing strategies and a system to break down problems into code-able steps is a **great** skill to cultivate.
+Below are some community-sourced articles, videos, and books that can help you develop this super-skill.
+
+
+- Free Code Camp offers a good overview article on [How to Think Like a Programmer - Lessons in Problem-Solving][free-code-camp-think-like-a-programmer].
+- UC Berkeley has a nice PDF summary of [G. Polya's Problem Solving Techniques][g-polya-how-to-solve-it-summary].
+- Originally written in 1945 as guidance for tackling complicated math problems,[G. Polya's [How To Solve It][g-polya-how-to-solve-it] (full book) is still _excellent_ advice for problem-solving in general.
+- Mentioned in the Free Code Camp Article, V. Anton Spraul's [Think Like a Programmer: An Introduction to Creative Problem Solving][v-anton-spraul-think-like-a-programmer] is a more modern and programming-focused take on the same general methods Polya outlines for mathematics.
+- [Felienne Hermans][felienne-hermans] is more focused on _how_ people learn the art of coding and how that maps to learning in general.
+  She has written [The Programmers Brian][programmers-brain-free-online], with strategies for reading code better, thinking about code clearly, writing better code, and becoming a better code collaborator.
+  - You can order a physical copy of her book [here][programmers-brain-manning].
+  - She also has two interesting videos on the same topic: [How to Teach Programming (and other things??)][felienne-hermans-how-to-teach-programming] and [Writing is Programming is Writing][felienne-hermans-programming-is-writing-is-programming].
+- [Algorithmic Thinking (Daniel Zingaro)][daniel-zingaro-algorithmic-thinking] from No Starch Press and [How to think like a programmer (Paul Vickers)][paul-vickers-how-to-think-like-a-programmer] also cover similar problem-solving territory when coding.
+
+Many of the books above can also be read through the Association of Computing Machinery library.
+Membership (paid) information is available at [acm(dot)org][association-for-computing-machinery].
+
+
+[association-for-computing-machinery]: https://www.acm.org/membership/membership-benefits
+[daniel-zingaro-algorithmic-thinking]: https://nostarch.com/algorithmic-thinking
+[felienne-hermans-how-to-teach-programming]: https://www.youtube.com/watch?v=g1ib43q3uXQ
+[felienne-hermans-programming-is-writing-is-programming]: https://www.youtube.com/watch?v=uO3a4HIBDU4
+[felienne-hermans]: https://www.felienne.com/
+[free-code-camp-think-like-a-programmer]: https://www.freecodecamp.org/news/how-to-think-like-a-programmer-lessons-in-problem-solving-d1d8bf1de7d2/
+[g-polya-how-to-solve-it-summary]: https://math.berkeley.edu/~gmelvin/polya.pdf
+[g-polya-how-to-solve-it]: https://press.princeton.edu/books/paperback/9780691164076/how-to-solve-it
+[paul-vickers-how-to-think-like-a-programmer]: https://www.researchgate.net/publication/236270907_How_to_Think_like_a_Programmer_Problem_Solving_for_the_Bewildered
+[programmers-brain-free-online]: https://www.manning.com/books/the-programmers-brain#toc
+[programmers-brain-manning]: https://www.manning.com/books/the-programmers-brain
+[v-anton-spraul-think-like-a-programmer]: https://archive.org/details/think-like-a-programmer/page/n19/mode/2up

--- a/docs/config.json
+++ b/docs/config.json
@@ -5,28 +5,35 @@
       "slug": "installation",
       "path": "docs/INSTALLATION.md",
       "title": "Installing Python locally",
-      "blurb": "Learn how to install Python locally to solve Exercism's exercises on your own machine"
+      "blurb": "Learn how to install Python locally to solve Exercism's exercises on your own machine."
     },
     {
       "uuid": "8508154c-70e2-4f98-8262-20190db15c1f",
       "slug": "learning",
       "path": "docs/LEARNING.md",
       "title": "How to learn Python",
-      "blurb": "An overview of how to get started from scratch with Python"
+      "blurb": "An overview of how to get started from scratch with Python."
     },
     {
       "uuid": "8666f259-de7d-4928-ae6f-15ff6fe6bb74",
       "slug": "tests",
       "path": "docs/TESTS.md",
       "title": "Testing on the Python track",
-      "blurb": "Learn how to test your Python exercises on Exercism"
+      "blurb": "Learn how to test your Python exercises on Exercism."
+    },
+    {
+      "uuid": "f18d3af2-fb71-41c6-984a-32b3ba86bf02",
+      "slug": "problem-solving",
+      "path": "docs/PROBLEM-SOLVING.md",
+      "title": "Problem Solving Resources",
+      "blurb": "Learn some general problem-solving techniques to help you with programming."
     },
     {
       "uuid": "73ced51d-76d0-45af-952c-8a6d7b5f3f7a",
       "slug": "resources",
       "path": "docs/RESOURCES.md",
       "title": "Useful Python resources",
-      "blurb": "A collection of useful resources to help you master Python"
+      "blurb": "A collection of useful resources to help you master Python."
     },
     {
       "uuid": "0dbb029b-ec67-4bbe-9ff7-483bf3a96af1",


### PR DESCRIPTION
Per conversation in slack, making a rough-draft doc for general problem solving links and strategies.  Not sure where this will ultimately live, but PR-ing it to the Python track docs for the time being.


