### PR TITLE
[little-sisters-vocab] Minor typo fix in introduction.md

### DIFF
--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -166,7 +166,7 @@ Strings can also be broken into smaller strings via [`<str>.split(<separator>)`]
 >>> cat_words = "feline, four-footed, ferocious, furry"
 >>> cat_words.split(',')
 ...
-['feline', 'four-footed', 'ferocious', 'furry']
+['feline', ' four-footed', ' ferocious', ' furry']
 ```
 
 

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -164,9 +164,9 @@ Strings can also be broken into smaller strings via [`<str>.split(<separator>)`]
 
 
 >>> cat_words = "feline, four-footed, ferocious, furry"
->>> cat_words.split(',')
+>>> cat_words.split(', ')
 ...
-['feline', ' four-footed', ' ferocious', ' furry']
+['feline', 'four-footed', 'ferocious', 'furry']
 ```
 
 


### PR DESCRIPTION
Originally showing:
```python
>>> cat_words.split(',')
...
['feline', 'four-footed', 'ferocious', 'furry']
```
which is missing spaces. Fixed to:
```python
['feline', ' four-footed', ' ferocious', ' furry']
```
Tested on Python 3.8.5 and Python 3.10.4 (not that this project supports 3.10, but I don't have 3.9 handy).