### PR TITLE
Docstring Cleanup 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ Exercism is a platform centered around empathetic conversation. We have a low to
 
 ## Seen or experienced something uncomfortable?
 
-If you see or experience abuse, harassment, discrimination, or feel unsafe or upset, please email abuse@exercism.io. We will take your report seriously.
+If you see or experience abuse, harassment, discrimination, or feel unsafe or upset, please email abuse@exercism.org. We will take your report seriously.
 
 ## Enforcement
 

--- a/exercises/concept/black-jack/.meta/exemplar.py
+++ b/exercises/concept/black-jack/.meta/exemplar.py
@@ -12,7 +12,7 @@ def value_of_card(card):
     :return: int - value of a given card. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
     """
 
-    if card in('JQK'):
+    if card in ('JQK'):
         value = 10
 
     elif card == 'A':
@@ -28,7 +28,7 @@ def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
     :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
-    :return: higher value card - str. Tuple of both cards if they are of equal value.
+    :return: str or (str, str) - resulting Tuple contains both cards if they are of equal value.
     """
 
     card_one_value = value_of_card(card_one)

--- a/exercises/concept/black-jack/.meta/exemplar.py
+++ b/exercises/concept/black-jack/.meta/exemplar.py
@@ -28,7 +28,7 @@ def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
     :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
-    :return: str or (str, str) - resulting Tuple contains both cards if they are of equal value.
+    :return: str or tuple - resulting Tuple contains both cards if they are of equal value.
     """
 
     card_one_value = value_of_card(card_one)

--- a/exercises/concept/black-jack/.meta/exemplar.py
+++ b/exercises/concept/black-jack/.meta/exemplar.py
@@ -9,7 +9,11 @@ def value_of_card(card):
     """Determine the scoring value of a card.
 
     :param card: str - given card.
-    :return: int - value of a given card. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
+    :return: int - value of a given card.  See below for values.
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 1
+    3.  '2' - '10' = numerical value.
     """
 
     if card in ('JQK'):
@@ -27,8 +31,12 @@ def value_of_card(card):
 def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
-    :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
+    :param card_one, card_two: str - cards dealt in hand.  See below for values.
     :return: str or tuple - resulting Tuple contains both cards if they are of equal value.
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 1
+    3.  '2' - '10' = numerical value.
     """
 
     card_one_value = value_of_card(card_one)
@@ -49,10 +57,12 @@ def higher_card(card_one, card_two):
 def value_of_ace(card_one, card_two):
     """Calculate the most advantageous value for the ace card.
 
-    :param card_one, card_two: str - card dealt. 'J', 'Q', 'K' = 10
-           'A' = 11 (if already in hand); numerical value otherwise.
+    :param card_one, card_two: str - card dealt. See below for values.
+    :return: int - either 1 or 11 value of the upcoming ace card.
 
-    :return: int - value of the upcoming ace card (either 1 or 11).
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 11 (if already in hand)
+    3.  '2' - '10' = numerical value.
     """
 
     card_one_value = 11 if card_one == 'A' else value_of_card(card_one)
@@ -66,8 +76,12 @@ def value_of_ace(card_one, card_two):
 def is_blackjack(card_one, card_two):
     """Determine if the hand is a 'natural' or 'blackjack'.
 
-    :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 11; numerical value otherwise.
-    :return: bool - if the hand is a blackjack (two cards worth 21).
+    :param card_one, card_two: str - card dealt. See below for values.
+    :return: bool - is the hand is a blackjack (two cards worth 21).
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 11 (if already in hand)
+    3.  '2' - '10' = numerical value.
     """
 
     return (card_one == 'A' or card_two == 'A') and (value_of_card(card_one) == 10 or value_of_card(card_two) == 10)
@@ -77,7 +91,7 @@ def can_split_pairs(card_one, card_two):
     """Determine if a player can split their hand into two hands.
 
     :param card_one, card_two: str - cards dealt.
-    :return: bool - if the hand can be split into two pairs (i.e. cards are of the same value).
+    :return: bool - can the hand be split into two pairs? (i.e. cards are of the same value).
     """
 
     return value_of_card(card_one) == value_of_card(card_two)
@@ -87,7 +101,7 @@ def can_double_down(card_one, card_two):
     """Determine if a blackjack player can place a double down bet.
 
     :param card_one, card_two: str - first and second cards in hand.
-    :return: bool - if the hand can be doubled down (i.e. totals 9, 10 or 11 points).
+    :return: bool - can the hand can be doubled down? (i.e. totals 9, 10 or 11 points).
     """
 
     return 8 < value_of_card(card_one) + value_of_card(card_two) < 12

--- a/exercises/concept/black-jack/black_jack.py
+++ b/exercises/concept/black-jack/black_jack.py
@@ -19,7 +19,7 @@ def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
     :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
-    :return: str or (str, str) - resulting Tuple contains both cards if they are of equal value.
+    :return: str or tuple - resulting Tuple contains both cards if they are of equal value.
     """
 
     pass

--- a/exercises/concept/black-jack/black_jack.py
+++ b/exercises/concept/black-jack/black_jack.py
@@ -19,7 +19,7 @@ def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
     :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
-    :return: higher value card - str. Tuple of both cards if they are of equal value.
+    :return: str or (str, str) - resulting Tuple contains both cards if they are of equal value.
     """
 
     pass

--- a/exercises/concept/black-jack/black_jack.py
+++ b/exercises/concept/black-jack/black_jack.py
@@ -9,7 +9,11 @@ def value_of_card(card):
     """Determine the scoring value of a card.
 
     :param card: str - given card.
-    :return: int - value of a given card. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
+    :return: int - value of a given card.  See below for values.
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 1
+    3.  '2' - '10' = numerical value.
     """
 
     pass
@@ -18,8 +22,12 @@ def value_of_card(card):
 def higher_card(card_one, card_two):
     """Determine which card has a higher value in the hand.
 
-    :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
+    :param card_one, card_two: str - cards dealt in hand.  See below for values.
     :return: str or tuple - resulting Tuple contains both cards if they are of equal value.
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 1
+    3.  '2' - '10' = numerical value.
     """
 
     pass
@@ -28,10 +36,12 @@ def higher_card(card_one, card_two):
 def value_of_ace(card_one, card_two):
     """Calculate the most advantageous value for the ace card.
 
-    :param card_one, card_two: str - card dealt. 'J', 'Q', 'K' = 10;
-           'A' = 11 (if already in hand); numerical value otherwise.
+    :param card_one, card_two: str - card dealt. See below for values.
+    :return: int - either 1 or 11 value of the upcoming ace card.
 
-    :return: int - value of the upcoming ace card (either 1 or 11).
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 11 (if already in hand)
+    3.  '2' - '10' = numerical value.
     """
 
     pass
@@ -40,8 +50,12 @@ def value_of_ace(card_one, card_two):
 def is_blackjack(card_one, card_two):
     """Determine if the hand is a 'natural' or 'blackjack'.
 
-    :param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 11; numerical value otherwise.
-    :return: bool - if the hand is a blackjack (two cards worth 21).
+    :param card_one, card_two: str - card dealt. See below for values.
+    :return: bool - is the hand is a blackjack (two cards worth 21).
+
+    1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
+    2.  'A' (ace card) = 11 (if already in hand)
+    3.  '2' - '10' = numerical value.
     """
 
     pass
@@ -51,7 +65,7 @@ def can_split_pairs(card_one, card_two):
     """Determine if a player can split their hand into two hands.
 
     :param card_one, card_two: str - cards dealt.
-    :return: bool - if the hand can be split into two pairs (i.e. cards are of the same value).
+    :return: bool - can the hand be split into two pairs? (i.e. cards are of the same value).
     """
 
     pass
@@ -61,7 +75,7 @@ def can_double_down(card_one, card_two):
     """Determine if a blackjack player can place a double down bet.
 
     :param card_one, card_two: str - first and second cards in hand.
-    :return: bool - if the hand can be doubled down (i.e. totals 9, 10 or 11 points).
+    :return: bool - can the hand can be doubled down? (i.e. totals 9, 10 or 11 points).
     """
 
     pass

--- a/exercises/concept/card-games/.meta/exemplar.py
+++ b/exercises/concept/card-games/.meta/exemplar.py
@@ -37,7 +37,7 @@ def list_contains_round(rounds, number):
 
 
 def card_average(hand):
-    """Calculate and return the average card value from the list.
+    """Calculate and returns the average card value from the list.
 
     :param hand: list - cards in hand.
     :return: float - average value of the cards in the hand.
@@ -50,16 +50,18 @@ def approx_average_is_average(hand):
     """Return if an average is using (first + last index values ) OR ('middle' card) == calculated average.
 
     :param hand: list - cards in hand.
-    :return: bool - if approximate average equals to the `true average`.
+    :return: bool - does one of the approximate averages equal the `true average`?
     """
 
     real_average = card_average(hand)
+
     if card_average([hand[0], hand[-1]]) == real_average:
         is_same = True
     elif hand[len(hand) // 2] == real_average:
         is_same = True
     else:
         is_same = False
+
     return is_same
 
 
@@ -82,4 +84,5 @@ def maybe_double_last(hand):
 
     if hand[-1] == 11:
         hand[-1] *= 2
+
     return hand

--- a/exercises/concept/card-games/.meta/exemplar.py
+++ b/exercises/concept/card-games/.meta/exemplar.py
@@ -30,7 +30,7 @@ def list_contains_round(rounds, number):
 
     :param rounds: list - rounds played.
     :param number: int - round number.
-    :return:  bool - was the round played?
+    :return: bool - was the round played?
     """
 
     return number in rounds
@@ -40,7 +40,7 @@ def card_average(hand):
     """Calculate and return the average card value from the list.
 
     :param hand: list - cards in hand.
-    :return:  float - average value of the cards in the hand.
+    :return: float - average value of the cards in the hand.
     """
 
     return sum(hand) / len(hand)

--- a/exercises/concept/card-games/lists.py
+++ b/exercises/concept/card-games/lists.py
@@ -50,7 +50,7 @@ def approx_average_is_average(hand):
     """Return if an average is using (first + last index values ) OR ('middle' card) == calculated average.
 
     :param hand: list - cards in hand.
-    :return: bool - if approximate average equals to the `true average`.
+    :return: bool - does one of the approximate averages equal the `true average`?
     """
 
     pass

--- a/exercises/concept/card-games/lists.py
+++ b/exercises/concept/card-games/lists.py
@@ -30,7 +30,7 @@ def list_contains_round(rounds, number):
 
     :param rounds: list - rounds played.
     :param number: int - round number.
-    :return:  bool - was the round played?
+    :return: bool - was the round played?
     """
 
     pass
@@ -40,7 +40,7 @@ def card_average(hand):
     """Calculate and returns the average card value from the list.
 
     :param hand: list - cards in hand.
-    :return:  float - average value of the cards in the hand.
+    :return: float - average value of the cards in the hand.
     """
 
     pass

--- a/exercises/concept/cater-waiter/.meta/exemplar.py
+++ b/exercises/concept/cater-waiter/.meta/exemplar.py
@@ -25,14 +25,14 @@ def clean_ingredients(dish_name, dish_ingredients):
 
 
 def check_drinks(drink_name, drink_ingredients):
-    """Append "Cocktail" (alcoholic)  or "Mocktail" (no alcohol) to `drink_name`, based on the content of `drink_ingredients`.
+    """Append "Cocktail" (alcohol)  or "Mocktail" (no alcohol) to `drink_name`, based on `drink_ingredients`.
 
     :param drink_name: str - name of the drink.
     :param drink_ingredients: list - ingredients in the drink.
     :return: str - drink_name appended with "Mocktail" or "Cocktail".
 
-    The function should return the name of the drink followed by "Mocktail" if the drink has
-    no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
+    The function should return the name of the drink followed by "Mocktail" (non-alcoholic) and drink
+    name followed by "Cocktail" (includes alcohol).
     """
 
     if not ALCOHOLS.isdisjoint(drink_ingredients):
@@ -42,15 +42,16 @@ def check_drinks(drink_name, drink_ingredients):
 
 
 def categorize_dish(dish_name, dish_ingredients):
-    """Categorize `dish_name` and append its classification based on `dish_ingredients`.
+    """Categorize `dish_name` based on `dish_ingredients`.
 
     :param dish_name: str - dish to be categorized.
-    :param dish_ingredients: list - of ingredients for the dish.
+    :param dish_ingredients: list - ingredients for the dish.
     :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
+    `<CATEGORY>` can be any one of  (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
     All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
-    (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
+
     """
 
     categories = ((VEGAN, 'VEGAN'),
@@ -68,7 +69,7 @@ def categorize_dish(dish_name, dish_ingredients):
 def tag_special_ingredients(dish):
     """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`.
 
-    :param dish: tuple - of (str of dish name, list of dish ingredients).
+    :param dish: tuple - of (dish name, list of dish ingredients).
     :return: tuple - containing (dish name, dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
@@ -120,7 +121,7 @@ def singleton_ingredients(dishes, intersection):
     Each dish is represented by a `set` of its ingredients.
 
     Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category. `<CATEGORY>` can be any one of:
-        VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE.
+        (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
 
     The function should return a `set` of ingredients that only appear in a single dish.
     """

--- a/exercises/concept/cater-waiter/.meta/exemplar.py
+++ b/exercises/concept/cater-waiter/.meta/exemplar.py
@@ -11,7 +11,7 @@ from sets_categories_data import (VEGAN,
 
 
 def clean_ingredients(dish_name, dish_ingredients):
-    """Remove duplicates from `dish_ingredients` and return a tuple containing `dish_name` and the cleaned list.
+    """Remove duplicates from `dish_ingredients`.
 
     :param dish_name: str - containing the dish name.
     :param dish_ingredients: list - dish ingredients.
@@ -25,11 +25,11 @@ def clean_ingredients(dish_name, dish_ingredients):
 
 
 def check_drinks(drink_name, drink_ingredients):
-    """Append "Mocktail" or "Cocktail" to `dish_name` if alcoholic ingredients are present in `drink_ingredients`.
+    """Append "Cocktail" (alcoholic)  or "Mocktail" (no alcohol) to `drink_name`, based on the content of `drink_ingredients`.
 
     :param drink_name: str - name of the drink.
     :param drink_ingredients: list - ingredients in the drink.
-    :return: str - drink name appended with "Mocktail" or "Cocktail".
+    :return: str - drink_name appended with "Mocktail" or "Cocktail".
 
     The function should return the name of the drink followed by "Mocktail" if the drink has
     no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
@@ -42,7 +42,7 @@ def check_drinks(drink_name, drink_ingredients):
 
 
 def categorize_dish(dish_name, dish_ingredients):
-    """Categorize `dish_name` by appending its classification based on the `dish_ingredients` list.
+    """Categorize `dish_name` and append its classification based on `dish_ingredients`.
 
     :param dish_name: str - dish to be categorized.
     :param dish_ingredients: list - of ingredients for the dish.
@@ -66,10 +66,10 @@ def categorize_dish(dish_name, dish_ingredients):
 
 
 def tag_special_ingredients(dish):
-    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`, return a tuple with dish name and matching items in a set.
+    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`.
 
     :param dish: tuple - of (str of dish name, list of dish ingredients).
-    :return: tuple - of (str of dish name, set of dish special ingredients).
+    :return: tuple - containing (dish name, dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
     For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
@@ -80,10 +80,10 @@ def tag_special_ingredients(dish):
 
 
 def compile_ingredients(dishes):
-    """Create a master list of ingredients using the list of sets of ingredients from `dishes`.
+    """Create a master list of ingredients.
 
     :param dishes: list - of dish ingredient sets.
-    :return: set - of dishes compiled from ingredients sets.
+    :return: set - of ingredients compiled from `dishes`.
 
     This function should return a `set` of all ingredients from all listed dishes.
     """
@@ -97,11 +97,11 @@ def compile_ingredients(dishes):
 
 
 def separate_appetizers(dishes, appetizers):
-    """From the list of `dishes`, determine which are `appetizers` and return the result as a list.
+    """Determine which `dishes` are designated `appetizers` and remove them.
 
     :param dishes: list - of dish names.
     :param appetizers: list - of appetizer names.
-    :return: list - of dish names.
+    :return: list - of dish names that do not appear on appetizer list.
 
     The function should return the list of dish names with appetizer names removed.
     Either list could contain duplicates and may require de-duping.
@@ -111,16 +111,16 @@ def separate_appetizers(dishes, appetizers):
 
 
 def singleton_ingredients(dishes, intersection):
-    """Use `example_dishes` and `EXAMPLE_INTERSECTION` to determine which dishes have a singleton ingredient.
+    """Determine which `dishes` have a singleton ingredient (an ingredient that only appears once across dishes).
 
     :param dishes: list - of ingredient sets.
-    :param intersection: constant - can be one of `EXAMPLE_INTERSECTION` constants.
+    :param intersection: constant - can be one of `<CATEGORY>_INTERSECTION` constants imported from `sets_categories_data.py`.
     :return: set - containing singleton ingredients.
 
     Each dish is represented by a `set` of its ingredients.
 
-    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category and can be either:
-        VEGAN_INTERSECTION, VEGETARIAN_INTERSECTION, PALEO_INTERSECTION, KETO_INTERSECTION, or OMNIVORE_INTERSECTION.
+    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category. `<CATEGORY>` can be any one of:
+        VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE.
 
     The function should return a `set` of ingredients that only appear in a single dish.
     """

--- a/exercises/concept/cater-waiter/.meta/exemplar.py
+++ b/exercises/concept/cater-waiter/.meta/exemplar.py
@@ -1,3 +1,6 @@
+"""Functions for compiling dishes and ingredients for a catering company."""
+
+
 from sets_categories_data import (VEGAN,
                                   VEGETARIAN,
                                   KETO,
@@ -8,11 +11,11 @@ from sets_categories_data import (VEGAN,
 
 
 def clean_ingredients(dish_name, dish_ingredients):
-    """
+    """Remove duplicates from `dish_ingredients` and return a tuple containing `dish_name` and the cleaned list.
 
-    :param dish_name: str
-    :param dish_ingredients: list
-    :return: tuple of (dish_name, ingredient set)
+    :param dish_name: str - containing the dish name.
+    :param dish_ingredients: list - dish ingredients.
+    :return: tuple - containing (dish_name, ingredient set).
 
     This function should return a `tuple` with the name of the dish as the first item,
     followed by the de-duped `set` of ingredients as the second item.
@@ -22,11 +25,11 @@ def clean_ingredients(dish_name, dish_ingredients):
 
 
 def check_drinks(drink_name, drink_ingredients):
-    """
+    """Append "Mocktail" or "Cocktail" to `dish_name` if alcoholic ingredients are present in `drink_ingredients`.
 
-    :param drink_name: str
-    :param drink_ingredients: list
-    :return: str drink name + ("Mocktail" or "Cocktail")
+    :param drink_name: str - name of the drink.
+    :param drink_ingredients: list - ingredients in the drink.
+    :return: str - drink name appended with "Mocktail" or "Cocktail".
 
     The function should return the name of the drink followed by "Mocktail" if the drink has
     no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
@@ -39,14 +42,14 @@ def check_drinks(drink_name, drink_ingredients):
 
 
 def categorize_dish(dish_name, dish_ingredients):
-    """
+    """Categorize `dish_name` by appending its classification based on the `dish_ingredients` list.
 
-    :param dish_name: str
-    :param dish_ingredients: list
-    :return: str "dish name: CATEGORY"
+    :param dish_name: str - dish to be categorized.
+    :param dish_ingredients: list - of ingredients for the dish.
+    :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
-    All dishes will "fit" into one of the categories imported from `sets_categories_data`
+    All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
     (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
     """
 
@@ -63,24 +66,24 @@ def categorize_dish(dish_name, dish_ingredients):
 
 
 def tag_special_ingredients(dish):
-    """
+    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`, return a tuple with dish name and matching items in a set.
 
-    :param dish: tuple of (str of dish name, list of dish ingredients)
-    :return: tuple of (str of dish name, set of dish special ingredients)
+    :param dish: tuple - of (str of dish name, list of dish ingredients).
+    :return: tuple - of (str of dish name, set of dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
     For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
-    SPECIAL_INGREDIENTS constant imported from `sets_categories_data`.
+    SPECIAL_INGREDIENTS constant imported from `sets_categories_data.py`.
     """
 
     return dish[0], (SPECIAL_INGREDIENTS & set(dish[1]))
 
 
 def compile_ingredients(dishes):
-    """
+    """Create a master list of ingredients using the list of sets of ingredients from `dishes`.
 
-    :param dishes: list of dish ingredient sets
-    :return: set
+    :param dishes: list - of dish ingredient sets.
+    :return: set - of dishes compiled from ingredients sets.
 
     This function should return a `set` of all ingredients from all listed dishes.
     """
@@ -94,11 +97,11 @@ def compile_ingredients(dishes):
 
 
 def separate_appetizers(dishes, appetizers):
-    """
+    """From the list of `dishes`, determine which are `appetizers` and return the result as a list.
 
-    :param dishes: list of dish names
-    :param appetizers: list of appetizer names
-    :return: list of dish names
+    :param dishes: list - of dish names.
+    :param appetizers: list - of appetizer names.
+    :return: list - of dish names.
 
     The function should return the list of dish names with appetizer names removed.
     Either list could contain duplicates and may require de-duping.
@@ -108,15 +111,17 @@ def separate_appetizers(dishes, appetizers):
 
 
 def singleton_ingredients(dishes, intersection):
-    """
+    """Use `example_dishes` and `EXAMPLE_INTERSECTION` to determine which dishes have a singleton ingredient.
 
-    :param intersection: constant - one of (VEGAN_INTERSECTION,VEGETARIAN_INTERSECTION,PALEO_INTERSECTION,
-                                            KETO_INTERSECTION,OMNIVORE_INTERSECTION)
-    :param dishes:  list of ingredient sets
-    :return: set of singleton ingredients
+    :param dishes: list - of ingredient sets.
+    :param intersection: constant - can be one of `EXAMPLE_INTERSECTION` constants.
+    :return: set - containing singleton ingredients.
 
     Each dish is represented by a `set` of its ingredients.
-    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category.
+
+    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category and can be either:
+        VEGAN_INTERSECTION, VEGETARIAN_INTERSECTION, PALEO_INTERSECTION, KETO_INTERSECTION, or OMNIVORE_INTERSECTION.
+
     The function should return a `set` of ingredients that only appear in a single dish.
     """
 

--- a/exercises/concept/cater-waiter/sets.py
+++ b/exercises/concept/cater-waiter/sets.py
@@ -11,7 +11,7 @@ from sets_categories_data import (VEGAN,
 
 
 def clean_ingredients(dish_name, dish_ingredients):
-    """Remove duplicates from `dish_ingredients` and return a tuple containing `dish_name` and the cleaned list.
+    """Remove duplicates from `dish_ingredients`.
 
     :param dish_name: str - containing the dish name.
     :param dish_ingredients: list - dish ingredients.
@@ -25,39 +25,41 @@ def clean_ingredients(dish_name, dish_ingredients):
 
 
 def check_drinks(drink_name, drink_ingredients):
-    """Append "Mocktail" or "Cocktail" to `dish_name` if alcoholic ingredients are present in `drink_ingredients`.
+    """Append "Cocktail" (alcohol)  or "Mocktail" (no alcohol) to `drink_name`, based on `drink_ingredients`.
 
     :param drink_name: str - name of the drink.
     :param drink_ingredients: list - ingredients in the drink.
-    :return: str - drink name appended with "Mocktail" or "Cocktail".
+    :return: str - drink_name appended with "Mocktail" or "Cocktail".
 
-    The function should return the name of the drink followed by "Mocktail" if the drink has
-    no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
+    The function should return the name of the drink followed by "Mocktail" (non-alcoholic) and drink
+    name followed by "Cocktail" (includes alcohol).
+
     """
 
     pass
 
 
 def categorize_dish(dish_name, dish_ingredients):
-    """Categorize `dish_name` by appending its classification based on the `dish_ingredients` list.
+    """Categorize `dish_name` based on `dish_ingredients`.
 
     :param dish_name: str - dish to be categorized.
-    :param dish_ingredients: list - of ingredients for the dish.
+    :param dish_ingredients: list - ingredients for the dish.
     :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
+    `<CATEGORY>` can be any one of  (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
     All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
-    (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
+
     """
 
     pass
 
 
 def tag_special_ingredients(dish):
-    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`, return a tuple with dish name and matching items in a set.
+    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`.
 
-    :param dish: tuple - of (str of dish name, list of dish ingredients).
-    :return: tuple - of (str of dish name, set of dish special ingredients).
+    :param dish: tuple - of (dish name, list of dish ingredients).
+    :return: tuple - containing (dish name, dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
     For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
@@ -68,10 +70,10 @@ def tag_special_ingredients(dish):
 
 
 def compile_ingredients(dishes):
-    """Create a master list of ingredients using the list of sets of ingredients from `dishes`.
+    """Create a master list of ingredients.
 
     :param dishes: list - of dish ingredient sets.
-    :return: set - of dishes compiled from ingredients sets.
+    :return: set - of ingredients compiled from `dishes`.
 
     This function should return a `set` of all ingredients from all listed dishes.
     """
@@ -80,11 +82,11 @@ def compile_ingredients(dishes):
 
 
 def separate_appetizers(dishes, appetizers):
-    """From the list of `dishes`, determine which are `appetizers` and return the result as a list.
+    """Determine which `dishes` are designated `appetizers` and remove them.
 
     :param dishes: list - of dish names.
     :param appetizers: list - of appetizer names.
-    :return: list - of dish names.
+    :return: list - of dish names that do not appear on appetizer list.
 
     The function should return the list of dish names with appetizer names removed.
     Either list could contain duplicates and may require de-duping.
@@ -94,16 +96,16 @@ def separate_appetizers(dishes, appetizers):
 
 
 def singleton_ingredients(dishes, intersection):
-    """Use `example_dishes` and `EXAMPLE_INTERSECTION` to determine which dishes have a singleton ingredient.
+    """Determine which `dishes` have a singleton ingredient (an ingredient that only appears once across dishes).
 
     :param dishes: list - of ingredient sets.
-    :param intersection: constant - can be one of `EXAMPLE_INTERSECTION` constants.
+    :param intersection: constant - can be one of `<CATEGORY>_INTERSECTION` constants imported from `sets_categories_data.py`.
     :return: set - containing singleton ingredients.
 
     Each dish is represented by a `set` of its ingredients.
 
-    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category and can be either:
-        VEGAN_INTERSECTION, VEGETARIAN_INTERSECTION, PALEO_INTERSECTION, KETO_INTERSECTION, or OMNIVORE_INTERSECTION.
+    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category. `<CATEGORY>` can be any one of:
+        (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
 
     The function should return a `set` of ingredients that only appear in a single dish.
     """

--- a/exercises/concept/cater-waiter/sets.py
+++ b/exercises/concept/cater-waiter/sets.py
@@ -1,3 +1,6 @@
+"""Functions for compiling dishes and ingredients for a catering company."""
+
+
 from sets_categories_data import (VEGAN,
                                   VEGETARIAN,
                                   KETO,
@@ -8,11 +11,11 @@ from sets_categories_data import (VEGAN,
 
 
 def clean_ingredients(dish_name, dish_ingredients):
-    """
+    """Remove duplicates from `dish_ingredients` and return a tuple containing `dish_name` and the cleaned list.
 
-    :param dish_name: str
-    :param dish_ingredients: list
-    :return: tuple of (dish_name, ingredient set)
+    :param dish_name: str - containing the dish name.
+    :param dish_ingredients: list - dish ingredients.
+    :return: tuple - containing (dish_name, ingredient set).
 
     This function should return a `tuple` with the name of the dish as the first item,
     followed by the de-duped `set` of ingredients as the second item.
@@ -22,11 +25,11 @@ def clean_ingredients(dish_name, dish_ingredients):
 
 
 def check_drinks(drink_name, drink_ingredients):
-    """
+    """Append "Mocktail" or "Cocktail" to `dish_name` if alcoholic ingredients are present in `drink_ingredients`.
 
-    :param drink_name: str
-    :param drink_ingredients: list
-    :return: str drink name + ("Mocktail" or "Cocktail")
+    :param drink_name: str - name of the drink.
+    :param drink_ingredients: list - ingredients in the drink.
+    :return: str - drink name appended with "Mocktail" or "Cocktail".
 
     The function should return the name of the drink followed by "Mocktail" if the drink has
     no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
@@ -36,11 +39,11 @@ def check_drinks(drink_name, drink_ingredients):
 
 
 def categorize_dish(dish_name, dish_ingredients):
-    """
+    """Categorize `dish_name` by appending its classification based on the `dish_ingredients` list.
 
-    :param dish_name: str
-    :param dish_ingredients: list
-    :return: str "dish name: CATEGORY"
+    :param dish_name: str - dish to be categorized.
+    :param dish_ingredients: list - of ingredients for the dish.
+    :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
     All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
@@ -51,10 +54,10 @@ def categorize_dish(dish_name, dish_ingredients):
 
 
 def tag_special_ingredients(dish):
-    """
+    """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`, return a tuple with dish name and matching items in a set.
 
-    :param dish: tuple of (str of dish name, list of dish ingredients)
-    :return: tuple of (str of dish name, set of dish special ingredients)
+    :param dish: tuple - of (str of dish name, list of dish ingredients).
+    :return: tuple - of (str of dish name, set of dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
     For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
@@ -65,10 +68,10 @@ def tag_special_ingredients(dish):
 
 
 def compile_ingredients(dishes):
-    """
+    """Create a master list of ingredients using the list of sets of ingredients from `dishes`.
 
-    :param dishes: list of dish ingredient sets
-    :return: set
+    :param dishes: list - of dish ingredient sets.
+    :return: set - of dishes compiled from ingredients sets.
 
     This function should return a `set` of all ingredients from all listed dishes.
     """
@@ -77,11 +80,11 @@ def compile_ingredients(dishes):
 
 
 def separate_appetizers(dishes, appetizers):
-    """
+    """From the list of `dishes`, determine which are `appetizers` and return the result as a list.
 
-    :param dishes: list of dish names
-    :param appetizers: list of appetizer names
-    :return: list of dish names
+    :param dishes: list - of dish names.
+    :param appetizers: list - of appetizer names.
+    :return: list - of dish names.
 
     The function should return the list of dish names with appetizer names removed.
     Either list could contain duplicates and may require de-duping.
@@ -91,15 +94,17 @@ def separate_appetizers(dishes, appetizers):
 
 
 def singleton_ingredients(dishes, intersection):
-    """
+    """Use `example_dishes` and `EXAMPLE_INTERSECTION` to determine which dishes have a singleton ingredient.
 
-    :param intersection: constant - one of (VEGAN_INTERSECTION,VEGETARIAN_INTERSECTION,PALEO_INTERSECTION,
-                                            KETO_INTERSECTION,OMNIVORE_INTERSECTION)
-    :param dishes:  list of ingredient sets
-    :return: set of singleton ingredients
+    :param dishes: list - of ingredient sets.
+    :param intersection: constant - can be one of `EXAMPLE_INTERSECTION` constants.
+    :return: set - containing singleton ingredients.
 
     Each dish is represented by a `set` of its ingredients.
-    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category.
+
+    Each `<CATEGORY>_INTERSECTION` is an `intersection` of all dishes in the category and can be either:
+        VEGAN_INTERSECTION, VEGETARIAN_INTERSECTION, PALEO_INTERSECTION, KETO_INTERSECTION, or OMNIVORE_INTERSECTION.
+
     The function should return a `set` of ingredients that only appear in a single dish.
     """
 

--- a/exercises/concept/chaitanas-colossal-coaster/.meta/exemplar.py
+++ b/exercises/concept/chaitanas-colossal-coaster/.meta/exemplar.py
@@ -1,9 +1,12 @@
+"""Functions to manage and organize queues at Chaitana's roller coaster."""
+
+
 def add_me_to_the_queue(express_queue, normal_queue, ticket_type, person_name):
-    """
+    """Add a person to the 'express' or 'normal' queue depending on the ticket number.
 
     :param express_queue: list - names in the Fast-track queue.
-    :param normal_queue:  list - names in the normal queue.
-    :param ticket_type:  int - type of ticket. 1 = express, 0 = normal.
+    :param normal_queue: list - names in the normal queue.
+    :param ticket_type: int - type of ticket. 1 = express, 0 = normal.
     :param person_name: str - name of person to add to a queue.
     :return: list - the (updated) queue the name was added to.
     """
@@ -14,63 +17,69 @@ def add_me_to_the_queue(express_queue, normal_queue, ticket_type, person_name):
 
 
 def find_my_friend(queue, friend_name):
-    """
+    """Search the queue for a name and return their queue position (index).
 
     :param queue: list - names in the queue.
     :param friend_name: str - name of friend to find.
     :return: int - index at which the friends name was found.
     """
+
     return queue.index(friend_name)
 
 
 def add_me_with_my_friends(queue, index, person_name):
+    """Insert the late arrival's name at a specific index of the queue.
+
+    :param queue: list - names in the queue.
+    :param index: int - the index at which to add the new name.
+    :param person_name: str - the name to add.
+    :return: list - queue updated with new name.
     """
 
-     :param queue: list - names in the queue.
-     :param index: int - the index at which to add the new name.
-     :param person_name: str - the name to add.
-     :return: list - queue updated with new name.
-     """
     queue.insert(index, person_name)
     return queue
 
 
 def remove_the_mean_person(queue, person_name):
+    """Remove the mean person from the queue by the provided name.
+
+    :param queue: list - names in the queue.
+    :param person_name: str - name of mean person.
+    :return: list - queue update with the mean persons name removed.
     """
 
-     :param queue: list - names in the queue.
-     :param person_name: str - name of mean person.
-     :return:  list - queue update with the mean persons name removed.
-     """
     queue.remove(person_name)
     return queue
 
 
 def how_many_namefellows(queue, person_name):
-    """
+    """Count how many times the provided name appears in the queue.
 
     :param queue: list - names in the queue.
     :param person_name: str - name you wish to count or track.
-    :return:  int - the number of times the name appears in the queue.
+    :return: int - the number of times the name appears in the queue.
     """
+
     return queue.count(person_name)
 
 
 def remove_the_last_person(queue):
-    """
+    """Remove the person in the last index from the queue and return their name.
 
     :param queue: list - names in the queue.
     :return: str - name that has been removed from the end of the queue.
     """
+
     return queue.pop()
 
 
 def sorted_names(queue):
-    """
+    """Sort the names in the queue in alphabetical order and return the result.
 
     :param queue: list - names in the queue.
     :return: list - copy of the queue in alphabetical order.
     """
+
     new_queue = queue[:]
     new_queue.sort()
     return new_queue

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods.py
@@ -1,69 +1,79 @@
+"""Functions to manage and organize queues at Chaitana's roller coaster."""
+
+
 def add_me_to_the_queue(express_queue, normal_queue, ticket_type, person_name):
-    """
+    """Add a person to the 'express' or 'normal' queue depending on the ticket number.
 
     :param express_queue: list - names in the Fast-track queue.
-    :param normal_queue:  list - names in the normal queue.
-    :param ticket_type:  int - type of ticket. 1 = express, 0 = normal.
+    :param normal_queue: list - names in the normal queue.
+    :param ticket_type: int - type of ticket. 1 = express, 0 = normal.
     :param person_name: str - name of person to add to a queue.
     :return: list - the (updated) queue the name was added to.
     """
+
     pass
 
 
 def find_my_friend(queue, friend_name):
-    """
+    """Search the queue for a name and return their queue position (index).
 
     :param queue: list - names in the queue.
     :param friend_name: str - name of friend to find.
     :return: int - index at which the friends name was found.
     """
+
     pass
 
 
 def add_me_with_my_friends(queue, index, person_name):
-    """
+    """Insert the late arrival's name at a specific index of the queue.
 
     :param queue: list - names in the queue.
     :param index: int - the index at which to add the new name.
     :param person_name: str - the name to add.
     :return: list - queue updated with new name.
     """
+
     pass
 
 
 def remove_the_mean_person(queue, person_name):
-    """
+    """Remove the mean person from the queue by the provided name.
 
     :param queue: list - names in the queue.
     :param person_name: str - name of mean person.
-    :return:  list - queue update with the mean persons name removed.
+    :return: list - queue update with the mean persons name removed.
     """
+
     pass
 
 
 def how_many_namefellows(queue, person_name):
-    """
+    """Count how many times the provided name appears in the queue.
 
     :param queue: list - names in the queue.
     :param person_name: str - name you wish to count or track.
-    :return:  int - the number of times the name appears in the queue.
+    :return: int - the number of times the name appears in the queue.
     """
+
     pass
 
 
 def remove_the_last_person(queue):
-    """
+    """Remove the person in the last index from the queue and return their name.
 
     :param queue: list - names in the queue.
     :return: str - name that has been removed from the end of the queue.
     """
+
     pass
 
 
 def sorted_names(queue):
-    """
+    """Sort the names in the queue in alphabetical order and return the result.
 
     :param queue: list - names in the queue.
     :return: list - copy of the queue in alphabetical order.
     """
+
     pass

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
@@ -6,7 +6,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the result of the "eat ghost" boolean check, can be either True or False.
     """
 
     return power_pellet_active and touching_ghost
@@ -17,7 +17,7 @@ def score(touching_power_pellet, touching_dot):
 
     :param touching_power_pellet: bool - does the player have an active power pellet?
     :param touching_dot: bool - is the player touching a dot?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has scored or not.
     """
 
     return touching_power_pellet or touching_dot
@@ -28,7 +28,7 @@ def lose(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has lost the game.
     """
 
     return not power_pellet_active and touching_ghost
@@ -40,7 +40,7 @@ def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has won the game.
     """
 
     return has_eaten_all_dots and not lose(power_pellet_active, touching_ghost)

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
@@ -6,7 +6,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the result of the "eat ghost" boolean check, can be either True or False.
+    :return: bool - can the ghost be eaten?
     """
 
     return power_pellet_active and touching_ghost
@@ -17,7 +17,7 @@ def score(touching_power_pellet, touching_dot):
 
     :param touching_power_pellet: bool - does the player have an active power pellet?
     :param touching_dot: bool - is the player touching a dot?
-    :return: bool - the resulting check that determines if the player has scored or not.
+    :return: bool - has the player scored or not?
     """
 
     return touching_power_pellet or touching_dot
@@ -28,7 +28,7 @@ def lose(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the resulting check that determines if the player has lost the game.
+    :return: bool - has the player lost the game?
     """
 
     return not power_pellet_active and touching_ghost
@@ -40,7 +40,7 @@ def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the resulting check that determines if the player has won the game.
+    :return: bool - has the player won the game?
     """
 
     return has_eaten_all_dots and not lose(power_pellet_active, touching_ghost)

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
@@ -1,8 +1,11 @@
+"""Functions for implementing the rules of the classic arcade game Pac-Man."""
+
+
 def eat_ghost(power_pellet_active, touching_ghost):
-    """
+    """Verify that Pac-Man can eat a ghost if he is empowered by a power pellet.
 
     :param power_pellet_active: bool - does the player have an active power pellet?
-    :param touching_ghost:  bool - is the player touching a ghost?
+    :param touching_ghost: bool - is the player touching a ghost?
     :return: bool
     """
 
@@ -10,10 +13,10 @@ def eat_ghost(power_pellet_active, touching_ghost):
 
 
 def score(touching_power_pellet, touching_dot):
-    """
+    """Verify that Pac-Man has scored when a power pellet or dot has been eaten.
 
     :param touching_power_pellet: bool - does the player have an active power pellet?
-    :param touching_dot:  bool - is the player touching a dot?
+    :param touching_dot: bool - is the player touching a dot?
     :return: bool
     """
 
@@ -21,7 +24,7 @@ def score(touching_power_pellet, touching_dot):
 
 
 def lose(power_pellet_active, touching_ghost):
-    """
+    """Trigger the game loop to end (GAME OVER) when Pac-Man touches a ghost without his power pellet.
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
@@ -32,11 +35,11 @@ def lose(power_pellet_active, touching_ghost):
 
 
 def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
-    """
+    """Trigger the victory event when all dots have been eaten.
 
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
-    :param touching_ghost:  bool - is the player touching a ghost?
+    :param touching_ghost: bool - is the player touching a ghost?
     :return: bool
     """
 

--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
@@ -6,7 +6,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the result of the "eat ghost" boolean check, can be either True or False.
     """
 
     pass
@@ -17,7 +17,7 @@ def score(touching_power_pellet, touching_dot):
 
     :param touching_power_pellet: bool - does the player have an active power pellet?
     :param touching_dot: bool - is the player touching a dot?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has scored or not.
     """
 
     pass
@@ -28,7 +28,7 @@ def lose(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has lost the game.
     """
 
     pass
@@ -40,7 +40,7 @@ def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool
+    :return: bool - the resulting check that determines if the player has won the game.
     """
 
     pass

--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
@@ -1,39 +1,46 @@
+"""Functions for implementing the rules of the classic arcade game Pac-Man."""
+
+
 def eat_ghost(power_pellet_active, touching_ghost):
-    """
-
-    :param power_pellet_active: bool - does the player have an active power pellet?
-    :param touching_ghost:  bool - is the player touching a ghost?
-    :return: bool
-    """
-    pass
-
-
-def score(touching_power_pellet, touching_dot):
-    """
-
-    :param touching_power_pellet: bool - does the player have an active power pellet?
-    :param touching_dot:  bool - is the player touching a dot?
-    :return: bool
-    """
-    pass
-
-
-def lose(power_pellet_active, touching_ghost):
-    """
+    """Verify that Pac-Man can eat a ghost if he is empowered by a power pellet.
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
     :return: bool
     """
+
+    pass
+
+
+def score(touching_power_pellet, touching_dot):
+    """Verify that Pac-Man has scored when a power pellet or dot has been eaten.
+
+    :param touching_power_pellet: bool - does the player have an active power pellet?
+    :param touching_dot: bool - is the player touching a dot?
+    :return: bool
+    """
+
+    pass
+
+
+def lose(power_pellet_active, touching_ghost):
+    """Trigger the game loop to end (GAME OVER) when Pac-Man touches a ghost without his power pellet.
+
+    :param power_pellet_active: bool - does the player have an active power pellet?
+    :param touching_ghost: bool - is the player touching a ghost?
+    :return: bool
+    """
+
     pass
 
 
 def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
-    """
+    """Trigger the victory event when all dots have been eaten.
 
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
-    :param touching_ghost:  bool - is the player touching a ghost?
+    :param touching_ghost: bool - is the player touching a ghost?
     :return: bool
     """
+
     pass

--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
@@ -6,7 +6,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the result of the "eat ghost" boolean check, can be either True or False.
+    :return: bool - can the ghost be eaten?
     """
 
     pass
@@ -17,7 +17,7 @@ def score(touching_power_pellet, touching_dot):
 
     :param touching_power_pellet: bool - does the player have an active power pellet?
     :param touching_dot: bool - is the player touching a dot?
-    :return: bool - the resulting check that determines if the player has scored or not.
+    :return: bool - has the player scored or not?
     """
 
     pass
@@ -28,7 +28,7 @@ def lose(power_pellet_active, touching_ghost):
 
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the resulting check that determines if the player has lost the game.
+    :return: bool - has the player lost the game?
     """
 
     pass
@@ -40,7 +40,7 @@ def win(has_eaten_all_dots, power_pellet_active, touching_ghost):
     :param has_eaten_all_dots: bool - has the player "eaten" all the dots?
     :param power_pellet_active: bool - does the player have an active power pellet?
     :param touching_ghost: bool - is the player touching a ghost?
-    :return: bool - the resulting check that determines if the player has won the game.
+    :return: bool - has the player won the game?
     """
 
     pass

--- a/exercises/concept/guidos-gorgeous-lasagna/.meta/exemplar.py
+++ b/exercises/concept/guidos-gorgeous-lasagna/.meta/exemplar.py
@@ -11,8 +11,8 @@ PREPARATION_TIME = 2
 def bake_time_remaining(elapsed_bake_time):
     """Calculate the bake time remaining.
 
-    :param elapsed_bake_time: int - baking time already elapsed
-    :return: int - remaining bake time (in minutes) derived from 'EXPECTED_BAKE_TIME'
+    :param elapsed_bake_time: int - baking time already elapsed.
+    :return: int - remaining bake time (in minutes) derived from 'EXPECTED_BAKE_TIME'.
 
     Function that takes the actual minutes the lasagna has been in the oven as
     an argument and returns how many minutes the lasagna still needs to bake
@@ -25,8 +25,8 @@ def bake_time_remaining(elapsed_bake_time):
 def preparation_time_in_minutes(number_of_layers):
     """Calculate the preparation time.
 
-    :param number_of_layers: int - the number of lasagna layers made
-    :return: int - amount of prep time (in minutes), based on 2 minutes per layer added
+    :param number_of_layers: int - the number of lasagna layers made.
+    :return: int - amount of prep time (in minutes), based on 2 minutes per layer added.
 
     This function takes an integer representing the number of layers added to the dish,
     calculating preparation time using a time of 2 minutes per layer added.
@@ -38,9 +38,9 @@ def preparation_time_in_minutes(number_of_layers):
 def elapsed_time_in_minutes(number_of_layers, elapsed_bake_time):
     """Calculate the elapsed time.
 
-    :param number_of_layers: int - the number of layers in the lasagna
-    :param elapsed_bake_time: int - elapsed cooking time
-    :return: int - total time elapsed (in in minutes) preparing and cooking
+    :param number_of_layers: int - the number of layers in the lasagna.
+    :param elapsed_bake_time: int - elapsed cooking time.
+    :return: int - total time elapsed (in in minutes) preparing and cooking.
 
     This function takes two integers representing the number of lasagna layers and the
     time already spent baking and calculates the total elapsed minutes spent cooking the

--- a/exercises/concept/guidos-gorgeous-lasagna/lasagna.py
+++ b/exercises/concept/guidos-gorgeous-lasagna/lasagna.py
@@ -13,7 +13,7 @@ def bake_time_remaining():
     """Calculate the bake time remaining.
 
     :param elapsed_bake_time: int - baking time already elapsed.
-    :return: int - remaining bake time derived from 'EXPECTED_BAKE_TIME'.
+    :return: int - remaining bake time (in minutes) derived from 'EXPECTED_BAKE_TIME'.
 
     Function that takes the actual minutes the lasagna has been in the oven as
     an argument and returns how many minutes the lasagna still needs to bake

--- a/exercises/concept/guidos-gorgeous-lasagna/lasagna.py
+++ b/exercises/concept/guidos-gorgeous-lasagna/lasagna.py
@@ -22,7 +22,9 @@ def bake_time_remaining():
 
     pass
 
+
 # TODO: define the 'preparation_time_in_minutes()' function
 #       and consider using 'PREPARATION_TIME' here
+
 
 # TODO: define the 'elapsed_time_in_minutes()' function

--- a/exercises/concept/inventory-management/.meta/exemplar.py
+++ b/exercises/concept/inventory-management/.meta/exemplar.py
@@ -1,8 +1,8 @@
-"""Functions to keep track of inventory lists and alter them."""
+"""Functions to keep track and alter inventory."""
 
 
 def create_inventory(items):
-    """Create a dict that tracks the frequency (count) of each element in the `items` list.
+    """Create a dict that tracks the amount (count) of each element on the `items` list.
 
     :param items: list - list of items to create an inventory from.
     :return: dict - the inventory dictionary.
@@ -14,11 +14,11 @@ def create_inventory(items):
 
 
 def add_items(inventory, items):
-    """Add or increment items to the `inventory` dict using elements from the `items` list.
+    """Add or increment items in inventory using elements from the items `list`.
 
     :param inventory: dict - dictionary of existing inventory.
     :param items: list - list of items to update the inventory with.
-    :return: dict - the inventory dictionary update with the new items.
+    :return: dict - the inventory updated with the new items.
     """
 
     for item in items:
@@ -28,11 +28,11 @@ def add_items(inventory, items):
 
 
 def decrement_items(inventory, items):
-    """Decrement items in the `inventory` dict using elements from the `items` list.
+    """Decrement items in inventory using elements from the `items` list.
 
     :param inventory: dict - inventory dictionary.
     :param items: list - list of items to decrement from the inventory.
-    :return: dict - updated inventory dictionary with items decremented.
+    :return: dict - updated inventory with items decremented.
     """
 
     for item in items:
@@ -42,11 +42,11 @@ def decrement_items(inventory, items):
 
 
 def remove_item(inventory, item):
-    """Remove item from `inventory` dict if a key matches `item` string and return the result, else just return.
+    """Remove item from inventory if it matches `item` string.
 
     :param inventory: dict - inventory dictionary.
     :param item: str - item to remove from the inventory.
-    :return: dict - updated inventory dictionary with item removed.
+    :return: dict - updated inventory with item removed. Current inventory if item does not match.
     """
 
     if item in inventory:
@@ -55,7 +55,7 @@ def remove_item(inventory, item):
 
 
 def list_inventory(inventory):
-    """Create a list of tuples containing all key value pairs in `inventory` dict.
+    """Create a list containing all (item_name, item_count) pairs in inventory.
 
     :param inventory: dict - an inventory dictionary.
     :return: list of tuples - list of key, value pairs from the inventory dictionary.

--- a/exercises/concept/inventory-management/.meta/exemplar.py
+++ b/exercises/concept/inventory-management/.meta/exemplar.py
@@ -1,8 +1,11 @@
+"""Functions to keep track of inventory lists and alter them."""
+
+
 def create_inventory(items):
-    """
+    """Create a dict that tracks the frequency (count) of each element in the `items` list.
 
     :param items: list - list of items to create an inventory from.
-    :return:  dict - the inventory dictionary.
+    :return: dict - the inventory dictionary.
     """
 
     inventory = {}
@@ -11,11 +14,11 @@ def create_inventory(items):
 
 
 def add_items(inventory, items):
-    """
+    """Add or increment items to the `inventory` dict using elements from the `items` list.
 
     :param inventory: dict - dictionary of existing inventory.
     :param items: list - list of items to update the inventory with.
-    :return:  dict - the inventory dictionary update with the new items.
+    :return: dict - the inventory dictionary update with the new items.
     """
 
     for item in items:
@@ -25,11 +28,11 @@ def add_items(inventory, items):
 
 
 def decrement_items(inventory, items):
-    """
+    """Decrement items in the `inventory` dict using elements from the `items` list.
 
     :param inventory: dict - inventory dictionary.
     :param items: list - list of items to decrement from the inventory.
-    :return:  dict - updated inventory dictionary with items decremented.
+    :return: dict - updated inventory dictionary with items decremented.
     """
 
     for item in items:
@@ -39,11 +42,11 @@ def decrement_items(inventory, items):
 
 
 def remove_item(inventory, item):
-    """
+    """Remove item from `inventory` dict if a key matches `item` string and return the result, else just return.
 
     :param inventory: dict - inventory dictionary.
     :param item: str - item to remove from the inventory.
-    :return:  dict - updated inventory dictionary with item removed.
+    :return: dict - updated inventory dictionary with item removed.
     """
 
     if item in inventory:
@@ -52,7 +55,7 @@ def remove_item(inventory, item):
 
 
 def list_inventory(inventory):
-    """
+    """Create a list of tuples containing all key value pairs in `inventory` dict.
 
     :param inventory: dict - an inventory dictionary.
     :return: list of tuples - list of key, value pairs from the inventory dictionary.

--- a/exercises/concept/inventory-management/dicts.py
+++ b/exercises/concept/inventory-management/dicts.py
@@ -1,8 +1,8 @@
-"""Functions to keep track of inventory lists and alter them."""
+"""Functions to keep track and alter inventory."""
 
 
 def create_inventory(items):
-    """Create a dict that tracks the frequency (count) of each element in the `items` list.
+    """Create a dict that tracks the amount (count) of each element on the `items` list.
 
     :param items: list - list of items to create an inventory from.
     :return: dict - the inventory dictionary.
@@ -12,40 +12,40 @@ def create_inventory(items):
 
 
 def add_items(inventory, items):
-    """Add or increment items to the `inventory` dict using elements from the `items` list.
+    """Add or increment items in inventory using elements from the items `list`.
 
     :param inventory: dict - dictionary of existing inventory.
     :param items: list - list of items to update the inventory with.
-    :return: dict - the inventory dictionary update with the new items.
+    :return: dict - the inventory updated with the new items.
     """
 
     pass
 
 
 def decrement_items(inventory, items):
-    """Decrement items in the `inventory` dict using elements from the `items` list.
+    """Decrement items in inventory using elements from the `items` list.
 
     :param inventory: dict - inventory dictionary.
     :param items: list - list of items to decrement from the inventory.
-    :return: dict - updated inventory dictionary with items decremented.
+    :return: dict - updated inventory with items decremented.
     """
 
     pass
 
 
 def remove_item(inventory, item):
-    """Remove item from `inventory` dict if a key matches `item` string and return the result, else just return.
+    """Remove item from inventory if it matches `item` string.
 
     :param inventory: dict - inventory dictionary.
     :param item: str - item to remove from the inventory.
-    :return: dict - updated inventory dictionary with item removed.
+    :return: dict - updated inventory with item removed. Current inventory if item does not match.
     """
 
-    pass
+   pass
 
 
 def list_inventory(inventory):
-    """Create a list of tuples containing all key value pairs in `inventory` dict.
+    """Create a list containing all (item_name, item_count) pairs in inventory.
 
     :param inventory: dict - an inventory dictionary.
     :return: list of tuples - list of key, value pairs from the inventory dictionary.

--- a/exercises/concept/inventory-management/dicts.py
+++ b/exercises/concept/inventory-management/dicts.py
@@ -41,7 +41,7 @@ def remove_item(inventory, item):
     :return: dict - updated inventory with item removed. Current inventory if item does not match.
     """
 
-   pass
+    pass
 
 
 def list_inventory(inventory):

--- a/exercises/concept/inventory-management/dicts.py
+++ b/exercises/concept/inventory-management/dicts.py
@@ -1,47 +1,51 @@
+"""Functions to keep track of inventory lists and alter them."""
+
+
 def create_inventory(items):
-    """
+    """Create a dict that tracks the frequency (count) of each element in the `items` list.
 
     :param items: list - list of items to create an inventory from.
-    :return:  dict - the inventory dictionary.
+    :return: dict - the inventory dictionary.
     """
 
     pass
 
 
 def add_items(inventory, items):
-    """
+    """Add or increment items to the `inventory` dict using elements from the `items` list.
 
     :param inventory: dict - dictionary of existing inventory.
     :param items: list - list of items to update the inventory with.
-    :return:  dict - the inventory dictionary update with the new items.
+    :return: dict - the inventory dictionary update with the new items.
     """
 
     pass
 
 
 def decrement_items(inventory, items):
-    """
+    """Decrement items in the `inventory` dict using elements from the `items` list.
 
     :param inventory: dict - inventory dictionary.
     :param items: list - list of items to decrement from the inventory.
-    :return:  dict - updated inventory dictionary with items decremented.
+    :return: dict - updated inventory dictionary with items decremented.
     """
 
     pass
 
 
 def remove_item(inventory, item):
-    """
+    """Remove item from `inventory` dict if a key matches `item` string and return the result, else just return.
+
     :param inventory: dict - inventory dictionary.
     :param item: str - item to remove from the inventory.
-    :return:  dict - updated inventory dictionary with item removed.
+    :return: dict - updated inventory dictionary with item removed.
     """
 
     pass
 
 
 def list_inventory(inventory):
-    """
+    """Create a list of tuples containing all key value pairs in `inventory` dict.
 
     :param inventory: dict - an inventory dictionary.
     :return: list of tuples - list of key, value pairs from the inventory dictionary.

--- a/exercises/concept/little-sisters-essay/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-essay/.meta/exemplar.py
@@ -1,4 +1,4 @@
-"""Functions to help you edit little sister's essays."""
+"""Functions to help edit essay homework using string manipulation."""
 
 
 def capitalize_title(title):
@@ -14,7 +14,7 @@ def capitalize_title(title):
 def check_sentence_ending(sentence):
     """Check the ending of the sentence to verify that a period is present.
 
-    :param sentence: - str a sentence to check.
+    :param sentence: str - a sentence to check.
     :return: bool - return True if punctuated correctly with period, False otherwise.
     """
 

--- a/exercises/concept/little-sisters-essay/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-essay/.meta/exemplar.py
@@ -1,28 +1,31 @@
-def capitalize_title(title):
-    """
+"""Functions to help you edit little sister's essays."""
 
-    :param title: str title string that needs title casing
-    :return:  str title string in title case (first letters capitalized)
+
+def capitalize_title(title):
+    """Convert the first letter of each word in the title to uppercase if needed.
+
+    :param title: str - title string that needs title casing.
+    :return: str - title string in title case (first letters capitalized).
     """
 
     return title.title()
 
 
 def check_sentence_ending(sentence):
-    """
+    """Check the ending of the sentence to verify that a period is present.
 
-    :param sentence: str a sentence to check.
-    :return:  bool True if punctuated correctly with period, False otherwise.
+    :param sentence: - str a sentence to check.
+    :return: bool - return True if punctuated correctly with period, False otherwise.
     """
 
     return sentence.endswith(".")
 
 
 def clean_up_spacing(sentence):
-    """
+    """Verify that there isn't any whitespace at the start and end of the sentence.
 
-    :param sentence: str a sentence to clean of leading and trailing space characters.
-    :return: str a sentence that has been cleaned of leading and trailing space characters.
+    :param sentence: str - a sentence to clean of leading and trailing space characters.
+    :return: str - a sentence that has been cleaned of leading and trailing space characters.
     """
 
     clean_sentence = sentence.strip()
@@ -30,12 +33,12 @@ def clean_up_spacing(sentence):
 
 
 def replace_word_choice(sentence, old_word, new_word):
-    """
+    """Replace a word in the provided sentence with a new one.
 
-    :param sentence: str a sentence to replace words in.
-    :param old_word: str word to replace
-    :param new_word: str replacement word
-    :return:  str input sentence with new words in place of old words
+    :param sentence: str - a sentence to replace words in.
+    :param old_word: str - word to replace.
+    :param new_word: str - replacement word.
+    :return: str - input sentence with new words in place of old words.
     """
 
     better_sentence = sentence.replace(old_word, new_word)

--- a/exercises/concept/little-sisters-essay/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-essay/.meta/exemplar.py
@@ -15,14 +15,14 @@ def check_sentence_ending(sentence):
     """Check the ending of the sentence to verify that a period is present.
 
     :param sentence: str - a sentence to check.
-    :return: bool - return True if punctuated correctly with period, False otherwise.
+    :return: bool - is the sentence punctuated correctly?
     """
 
     return sentence.endswith(".")
 
 
 def clean_up_spacing(sentence):
-    """Verify that there isn't any whitespace at the start and end of the sentence.
+    """Trim any leading or trailing whitespace from the sentence.
 
     :param sentence: str - a sentence to clean of leading and trailing space characters.
     :return: str - a sentence that has been cleaned of leading and trailing space characters.

--- a/exercises/concept/little-sisters-essay/string_methods.py
+++ b/exercises/concept/little-sisters-essay/string_methods.py
@@ -1,4 +1,4 @@
-"""Functions to help you edit little sister's essays."""
+"""Functions to help edit essay homework using string manipulation."""
 
 
 def capitalize_title(title):
@@ -14,7 +14,7 @@ def capitalize_title(title):
 def check_sentence_ending(sentence):
     """Check the ending of the sentence to verify that a period is present.
 
-    :param sentence: - str a sentence to check.
+    :param sentence: str - a sentence to check.
     :return: bool - return True if punctuated correctly with period, False otherwise.
     """
 

--- a/exercises/concept/little-sisters-essay/string_methods.py
+++ b/exercises/concept/little-sisters-essay/string_methods.py
@@ -1,40 +1,43 @@
-def capitalize_title(title):
-    """
+"""Functions to help you edit little sister's essays."""
 
-    :param title: str title string that needs title casing
-    :return:  str title string in title case (first letters capitalized)
+
+def capitalize_title(title):
+    """Convert the first letter of each word in the title to uppercase if needed.
+
+    :param title: str - title string that needs title casing.
+    :return: str - title string in title case (first letters capitalized).
     """
 
     pass
 
 
 def check_sentence_ending(sentence):
-    """
+    """Check the ending of the sentence to verify that a period is present.
 
-    :param sentence: str a sentence to check.
-    :return:  bool True if punctuated correctly with period, False otherwise.
+    :param sentence: - str a sentence to check.
+    :return: bool - return True if punctuated correctly with period, False otherwise.
     """
 
     pass
 
 
 def clean_up_spacing(sentence):
-    """
+    """Verify that there isn't any whitespace at the start and end of the sentence.
 
-    :param sentence: str a sentence to clean of leading and trailing space characters.
-    :return: str a sentence that has been cleaned of leading and trailing space characters.
+    :param sentence: str - a sentence to clean of leading and trailing space characters.
+    :return: str - a sentence that has been cleaned of leading and trailing space characters.
     """
 
     pass
 
 
 def replace_word_choice(sentence, old_word, new_word):
-    """
+    """Replace a word in the provided sentence with a new one.
 
-    :param sentence: str a sentence to replace words in.
-    :param old_word: str word to replace
-    :param new_word: str replacement word
-    :return:  str input sentence with new words in place of old words
+    :param sentence: str - a sentence to replace words in.
+    :param old_word: str - word to replace.
+    :param new_word: str - replacement word.
+    :return: str - input sentence with new words in place of old words.
     """
 
     pass

--- a/exercises/concept/little-sisters-vocab/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-vocab/.meta/exemplar.py
@@ -1,5 +1,8 @@
+"""Functions for checking little sister's vocabulary homework."""
+
+
 def add_prefix_un(word):
-    """
+    """Take the given word and add the 'un' prefix to the start of it.
 
     :param word: str of a root word
     :return:  str of root word with un prefix
@@ -12,7 +15,7 @@ def add_prefix_un(word):
 
 
 def make_word_groups(vocab_words):
-    """
+    """Take a list containing a prefix at the first index, words as the rest, and prepend each word with it.
 
     :param vocab_words: list of vocabulary words with a prefix.
     :return: str of prefix followed by vocabulary words with
@@ -30,7 +33,7 @@ def make_word_groups(vocab_words):
 
 
 def remove_suffix_ness(word):
-    """
+    """Remove the suffix 'ness' from the word while considering resulting words that end in 'y'.
 
     :param word: str of word to remove suffix from.
     :return: str of word with suffix removed & spelling adjusted.
@@ -46,7 +49,7 @@ def remove_suffix_ness(word):
 
 
 def adjective_to_verb(sentence, index):
-    """
+    """Change the adjective within the sentence to a verb.
 
     :param sentence: str that uses the word in sentence
     :param index:  index of the word to remove and transform

--- a/exercises/concept/little-sisters-vocab/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-vocab/.meta/exemplar.py
@@ -4,8 +4,8 @@
 def add_prefix_un(word):
     """Take the given word and add the 'un' prefix to the start of it.
 
-    :param word: str of a root word
-    :return:  str of root word with un prefix
+    :param word: str - of a root word
+    :return: str - of root word with un prefix
 
     This function takes `word` as a parameter and
     returns a new word with an 'un' prefix.
@@ -17,8 +17,8 @@ def add_prefix_un(word):
 def make_word_groups(vocab_words):
     """Take a list containing a prefix at the first index, words as the rest, and prepend each word with it.
 
-    :param vocab_words: list of vocabulary words with a prefix.
-    :return: str of prefix followed by vocabulary words with
+    :param vocab_words: list - of vocabulary words with a prefix.
+    :return: str - of prefix followed by vocabulary words with
              prefix applied, separated by ' :: '.
 
     This function takes a `vocab_words` list and returns a string
@@ -35,8 +35,8 @@ def make_word_groups(vocab_words):
 def remove_suffix_ness(word):
     """Remove the suffix 'ness' from the word while considering resulting words that end in 'y'.
 
-    :param word: str of word to remove suffix from.
-    :return: str of word with suffix removed & spelling adjusted.
+    :param word: str - of word to remove suffix from.
+    :return: str - of word with suffix removed & spelling adjusted.
 
     This function takes in a word and returns the base word with `ness` removed.
     """
@@ -51,9 +51,9 @@ def remove_suffix_ness(word):
 def adjective_to_verb(sentence, index):
     """Change the adjective within the sentence to a verb.
 
-    :param sentence: str that uses the word in sentence
-    :param index:  index of the word to remove and transform
-    :return:  str word that changes the extracted adjective to a verb.
+    :param sentence: str - that uses the word in sentence
+    :param index: int - index of the word to remove and transform
+    :return: str - word that changes the extracted adjective to a verb.
 
     A function takes a `sentence` using the
     vocabulary word, and the `index` of the word once that sentence

--- a/exercises/concept/little-sisters-vocab/.meta/exemplar.py
+++ b/exercises/concept/little-sisters-vocab/.meta/exemplar.py
@@ -1,11 +1,11 @@
-"""Functions for checking little sister's vocabulary homework."""
+"""Functions for creating, transforming, and adding prefixes to strings."""
 
 
 def add_prefix_un(word):
     """Take the given word and add the 'un' prefix to the start of it.
 
-    :param word: str - of a root word
-    :return: str - of root word with un prefix
+    :param word: str - of a root word.
+    :return: str - of root word with 'un' prefix.
 
     This function takes `word` as a parameter and
     returns a new word with an 'un' prefix.
@@ -51,8 +51,8 @@ def remove_suffix_ness(word):
 def adjective_to_verb(sentence, index):
     """Change the adjective within the sentence to a verb.
 
-    :param sentence: str - that uses the word in sentence
-    :param index: int - index of the word to remove and transform
+    :param sentence: str - that uses the word in sentence.
+    :param index: int - index of the word to remove and transform.
     :return: str - word that changes the extracted adjective to a verb.
 
     A function takes a `sentence` using the

--- a/exercises/concept/little-sisters-vocab/strings.py
+++ b/exercises/concept/little-sisters-vocab/strings.py
@@ -4,8 +4,8 @@
 def add_prefix_un(word):
     """Take the given word and add the 'un' prefix to the start of it.
 
-    :param word: str of a root word
-    :return:  str of root word with un prefix
+    :param word: str - of a root word
+    :return: str - of root word with un prefix
 
     This function takes `word` as a parameter and
     returns a new word with an 'un' prefix.
@@ -17,8 +17,8 @@ def add_prefix_un(word):
 def make_word_groups(vocab_words):
     """Take a list containing a prefix at the first index, words as the rest, and prepend each word with it.
 
-    :param vocab_words: list of vocabulary words with a prefix.
-    :return: str of prefix followed by vocabulary words with
+    :param vocab_words: list - of vocabulary words with a prefix.
+    :return: str - of prefix followed by vocabulary words with
              prefix applied, separated by ' :: '.
 
     This function takes a `vocab_words` list and returns a string
@@ -32,8 +32,8 @@ def make_word_groups(vocab_words):
 def remove_suffix_ness(word):
     """Remove the suffix 'ness' from the word while considering resulting words that end in 'y'.
 
-    :param word: str of word to remove suffix from.
-    :return: str of word with suffix removed & spelling adjusted.
+    :param word: str - of word to remove suffix from.
+    :return: str - of word with suffix removed & spelling adjusted.
 
     This function takes in a word and returns the base word with `ness` removed.
     """
@@ -44,9 +44,9 @@ def remove_suffix_ness(word):
 def adjective_to_verb(sentence, index):
     """Change the adjective within the sentence to a verb.
 
-    :param sentence: str that uses the word in sentence
-    :param index:  index of the word to remove and transform
-    :return:  str word that changes the extracted adjective to a verb.
+    :param sentence: str - that uses the word in sentence
+    :param index: int - index of the word to remove and transform
+    :return: str - word that changes the extracted adjective to a verb.
 
     A function takes a `sentence` using the
     vocabulary word, and the `index` of the word once that sentence

--- a/exercises/concept/little-sisters-vocab/strings.py
+++ b/exercises/concept/little-sisters-vocab/strings.py
@@ -1,5 +1,8 @@
+"""Functions for checking little sister's vocabulary homework."""
+
+
 def add_prefix_un(word):
-    """
+    """Take the given word and add the 'un' prefix to the start of it.
 
     :param word: str of a root word
     :return:  str of root word with un prefix
@@ -12,7 +15,7 @@ def add_prefix_un(word):
 
 
 def make_word_groups(vocab_words):
-    """
+    """Take a list containing a prefix at the first index, words as the rest, and prepend each word with it.
 
     :param vocab_words: list of vocabulary words with a prefix.
     :return: str of prefix followed by vocabulary words with
@@ -27,7 +30,7 @@ def make_word_groups(vocab_words):
 
 
 def remove_suffix_ness(word):
-    """
+    """Remove the suffix 'ness' from the word while considering resulting words that end in 'y'.
 
     :param word: str of word to remove suffix from.
     :return: str of word with suffix removed & spelling adjusted.
@@ -39,7 +42,7 @@ def remove_suffix_ness(word):
 
 
 def adjective_to_verb(sentence, index):
-    """
+    """Change the adjective within the sentence to a verb.
 
     :param sentence: str that uses the word in sentence
     :param index:  index of the word to remove and transform

--- a/exercises/concept/little-sisters-vocab/strings.py
+++ b/exercises/concept/little-sisters-vocab/strings.py
@@ -1,11 +1,11 @@
-"""Functions for checking little sister's vocabulary homework."""
+"""Functions for creating, transforming, and adding prefixes to strings."""
 
 
 def add_prefix_un(word):
     """Take the given word and add the 'un' prefix to the start of it.
 
-    :param word: str - of a root word
-    :return: str - of root word with un prefix
+    :param word: str - of a root word.
+    :return: str - of root word with 'un' prefix.
 
     This function takes `word` as a parameter and
     returns a new word with an 'un' prefix.
@@ -44,8 +44,8 @@ def remove_suffix_ness(word):
 def adjective_to_verb(sentence, index):
     """Change the adjective within the sentence to a verb.
 
-    :param sentence: str - that uses the word in sentence
-    :param index: int - index of the word to remove and transform
+    :param sentence: str - that uses the word in sentence.
+    :param index: int - index of the word to remove and transform.
     :return: str - word that changes the extracted adjective to a verb.
 
     A function takes a `sentence` using the

--- a/exercises/concept/making-the-grade/.meta/exemplar.py
+++ b/exercises/concept/making-the-grade/.meta/exemplar.py
@@ -1,8 +1,11 @@
+"""Functions for organizing and calculating student exam scores."""
+
+
 def round_scores(student_scores):
     """Round all provided student scores.
 
-    :param student_scores: list of student exam scores as float or int.
-    :return: list of student scores *rounded* to nearest integer value.
+    :param student_scores: [int or float] - list of student exam scores as float or int.
+    :return: [int] - list of student scores *rounded* to nearest integer value.
     """
 
     rounded = []
@@ -14,8 +17,8 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: list of integer student scores.
-    :return: integer count of student scores at or below 40.
+    :param student_scores: [int] - list of integer student scores.
+    :return: int - integer count of student scores at or below 40.
     """
 
     non_passing = 0
@@ -28,9 +31,9 @@ def count_failed_students(student_scores):
 def above_threshold(student_scores, threshold):
     """Determine how many of the provided student scores were 'the best' based on the provided threshold.
 
-    :param student_scores: list of integer scores
-    :param threshold :  integer
-    :return: list of integer scores that are at or above the "best" threshold.
+    :param student_scores: [int] - list of integer scores.
+    :param threshold: int - threshold to cross to be the "best" score.
+    :return: [int] - list of integer scores that are at or above the "best" threshold.
     """
 
     above = []
@@ -44,11 +47,18 @@ def above_threshold(student_scores, threshold):
 def letter_grades(highest):
     """Create a list of grade thresholds based on the provided highest grade.
 
-    :param highest: integer of highest exam score.
-    :return: list of integer score thresholds for each F-A letter grades.
+    :param highest: int - value of highest exam score.
+    :return: [int] - list of lower threshold scores for each D-A letter grade interval.
+            For example, where the highest score is 100, and failing is <= 40,
+            The result would be [41, 56, 71, 86]:
+
+            41 <= "D" <= 55
+            56 <= "C" <= 70
+            71 <= "B" <= 85
+            86 <= "A" <= 100
     """
 
-    increment = round((highest - 40)/4)
+    increment = round((highest - 40) / 4)
     scores = []
     for score in range(41, highest, increment):
         scores.append(score)
@@ -58,10 +68,10 @@ def letter_grades(highest):
 def student_ranking(student_scores, student_names):
     """Organize the student's rank, name, and grade information in ascending order.
 
-     :param student_scores: list of scores in descending order.
-     :param student_names: list of names in descending order by exam score.
-     :return: list of strings in format ["<rank>. <student name>: <score>"].
-     """
+    :param student_scores: [int] - list of scores in descending order.
+    :param student_names: [str] - list of names in descending order by exam score.
+    :return: [str] - list of strings in format ["<rank>. <student name>: <score>"].
+    """
 
     results = []
     for index, name in enumerate(student_names):
@@ -74,7 +84,7 @@ def student_ranking(student_scores, student_names):
 def perfect_score(student_info):
     """Create a list that contains the name and grade of the first student to make a perfect score on the exam.
 
-    :param student_info: list of [<student name>, <score>] lists
+    :param student_info: list of [<student name>, <score>] lists.
     :return: first `[<student name>, 100]` or `[]` if no student score of 100 is found.
     """
 

--- a/exercises/concept/making-the-grade/.meta/exemplar.py
+++ b/exercises/concept/making-the-grade/.meta/exemplar.py
@@ -4,8 +4,8 @@
 def round_scores(student_scores):
     """Round all provided student scores.
 
-    :param student_scores: [int or float] - list of student exam scores as float or int.
-    :return: [int] - list of student scores *rounded* to nearest integer value.
+    :param student_scores: list - student exam scores as float or int.
+    :return: list - student scores *rounded* to nearest integer value.
     """
 
     rounded = []
@@ -17,8 +17,8 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: [int] - list of integer student scores.
-    :return: int - integer count of student scores at or below 40.
+    :param student_scores: list - list of integer student scores.
+    :return: int - count of student scores at or below 40.
     """
 
     non_passing = 0
@@ -31,9 +31,9 @@ def count_failed_students(student_scores):
 def above_threshold(student_scores, threshold):
     """Determine how many of the provided student scores were 'the best' based on the provided threshold.
 
-    :param student_scores: [int] - list of integer scores.
+    :param student_scores: list - of integer scores.
     :param threshold: int - threshold to cross to be the "best" score.
-    :return: [int] - list of integer scores that are at or above the "best" threshold.
+    :return: list - of integer scores that are at or above the "best" threshold.
     """
 
     above = []
@@ -48,7 +48,7 @@ def letter_grades(highest):
     """Create a list of grade thresholds based on the provided highest grade.
 
     :param highest: int - value of highest exam score.
-    :return: [int] - list of lower threshold scores for each D-A letter grade interval.
+    :return: list - of lower threshold scores for each D-A letter grade interval.
             For example, where the highest score is 100, and failing is <= 40,
             The result would be [41, 56, 71, 86]:
 
@@ -68,9 +68,9 @@ def letter_grades(highest):
 def student_ranking(student_scores, student_names):
     """Organize the student's rank, name, and grade information in ascending order.
 
-    :param student_scores: [int] - list of scores in descending order.
-    :param student_names: [str] - list of names in descending order by exam score.
-    :return: [str] - list of strings in format ["<rank>. <student name>: <score>"].
+    :param student_scores: list - of scores in descending order.
+    :param student_names: list - of string names by exam score in descending order.
+    :return: list - of strings in format ["<rank>. <student name>: <score>"].
     """
 
     results = []
@@ -84,8 +84,8 @@ def student_ranking(student_scores, student_names):
 def perfect_score(student_info):
     """Create a list that contains the name and grade of the first student to make a perfect score on the exam.
 
-    :param student_info: list of [<student name>, <score>] lists.
-    :return: first `[<student name>, 100]` or `[]` if no student score of 100 is found.
+    :param student_info: list - of [<student name>, <score>] lists.
+    :return: list - first `[<student name>, 100]` or `[]` if no student score of 100 is found.
     """
 
     result = []

--- a/exercises/concept/making-the-grade/.meta/exemplar.py
+++ b/exercises/concept/making-the-grade/.meta/exemplar.py
@@ -4,7 +4,7 @@
 def round_scores(student_scores):
     """Round all provided student scores.
 
-    :param student_scores: list - student exam scores as float or int.
+    :param student_scores: list - float or int of student exam scores.
     :return: list - student scores *rounded* to nearest integer value.
     """
 
@@ -17,7 +17,7 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: list - list of integer student scores.
+    :param student_scores: list - containing int student scores.
     :return: int - count of student scores at or below 40.
     """
 

--- a/exercises/concept/making-the-grade/loops.py
+++ b/exercises/concept/making-the-grade/loops.py
@@ -4,7 +4,7 @@
 def round_scores(student_scores):
     """Round all provided student scores.
 
-    :param student_scores: list - student exam scores as float or int.
+    :param student_scores: list - float or int of student exam scores.
     :return: list - student scores *rounded* to nearest integer value.
     """
 
@@ -14,7 +14,7 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: list - list of integer student scores.
+    :param student_scores: list - containing int student scores.
     :return: int - count of student scores at or below 40.
     """
 

--- a/exercises/concept/making-the-grade/loops.py
+++ b/exercises/concept/making-the-grade/loops.py
@@ -1,8 +1,11 @@
-def round_scores(student_scores):
-    """"Round all provided student scores.
+"""Functions for organizing and calculating student exam scores."""
 
-    :param student_scores: list of student exam scores as float or int.
-    :return: list of student scores *rounded* to nearest integer value.
+
+def round_scores(student_scores):
+    """Round all provided student scores.
+
+    :param student_scores: [int or float] - list of student exam scores as float or int.
+    :return: [int] - list of student scores *rounded* to nearest integer value.
     """
 
     pass
@@ -11,8 +14,8 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: list of integer student scores.
-    :return: integer count of student scores at or below 40.
+    :param student_scores: [int] - list of integer student scores.
+    :return: int - integer count of student scores at or below 40.
     """
 
     pass
@@ -21,9 +24,9 @@ def count_failed_students(student_scores):
 def above_threshold(student_scores, threshold):
     """Determine how many of the provided student scores were 'the best' based on the provided threshold.
 
-    :param student_scores: list of integer scores
-    :param threshold :  integer
-    :return: list of integer scores that are at or above the "best" threshold.
+    :param student_scores: [int] - list of integer scores.
+    :param threshold: int - threshold to cross to be the "best" score.
+    :return: [int] - list of integer scores that are at or above the "best" threshold.
     """
 
     pass
@@ -32,15 +35,15 @@ def above_threshold(student_scores, threshold):
 def letter_grades(highest):
     """Create a list of grade thresholds based on the provided highest grade.
 
-    :param highest: integer of highest exam score.
-    :return: list of integer lower threshold scores for each D-A letter grade interval.
-             For example, where the highest score is 100, and failing is <= 40,
-             The result would be [41, 56, 71, 86]:
+    :param highest: int - value of highest exam score.
+    :return: [int] - list of lower threshold scores for each D-A letter grade interval.
+            For example, where the highest score is 100, and failing is <= 40,
+            The result would be [41, 56, 71, 86]:
 
-             41 <= "D" <= 55
-             56 <= "C" <= 70
-             71 <= "B" <= 85
-             86 <= "A" <= 100
+            41 <= "D" <= 55
+            56 <= "C" <= 70
+            71 <= "B" <= 85
+            86 <= "A" <= 100
     """
 
     pass
@@ -49,10 +52,10 @@ def letter_grades(highest):
 def student_ranking(student_scores, student_names):
     """Organize the student's rank, name, and grade information in ascending order.
 
-     :param student_scores: list of scores in descending order.
-     :param student_names: list of names in descending order by exam score.
-     :return: list of strings in format ["<rank>. <student name>: <score>"].
-     """
+    :param student_scores: [int] - list of scores in descending order.
+    :param student_names: [str] - list of names in descending order by exam score.
+    :return: [str] - list of strings in format ["<rank>. <student name>: <score>"].
+    """
 
     pass
 
@@ -60,7 +63,7 @@ def student_ranking(student_scores, student_names):
 def perfect_score(student_info):
     """Create a list that contains the name and grade of the first student to make a perfect score on the exam.
 
-    :param student_info: list of [<student name>, <score>] lists
+    :param student_info: list of [<student name>, <score>] lists.
     :return: first `[<student name>, 100]` or `[]` if no student score of 100 is found.
     """
 

--- a/exercises/concept/making-the-grade/loops.py
+++ b/exercises/concept/making-the-grade/loops.py
@@ -4,8 +4,8 @@
 def round_scores(student_scores):
     """Round all provided student scores.
 
-    :param student_scores: [int or float] - list of student exam scores as float or int.
-    :return: [int] - list of student scores *rounded* to nearest integer value.
+    :param student_scores: list - student exam scores as float or int.
+    :return: list - student scores *rounded* to nearest integer value.
     """
 
     pass
@@ -14,8 +14,8 @@ def round_scores(student_scores):
 def count_failed_students(student_scores):
     """Count the number of failing students out of the group provided.
 
-    :param student_scores: [int] - list of integer student scores.
-    :return: int - integer count of student scores at or below 40.
+    :param student_scores: list - list of integer student scores.
+    :return: int - count of student scores at or below 40.
     """
 
     pass
@@ -24,9 +24,9 @@ def count_failed_students(student_scores):
 def above_threshold(student_scores, threshold):
     """Determine how many of the provided student scores were 'the best' based on the provided threshold.
 
-    :param student_scores: [int] - list of integer scores.
+    :param student_scores: list - of integer scores.
     :param threshold: int - threshold to cross to be the "best" score.
-    :return: [int] - list of integer scores that are at or above the "best" threshold.
+    :return: list - of integer scores that are at or above the "best" threshold.
     """
 
     pass
@@ -36,7 +36,7 @@ def letter_grades(highest):
     """Create a list of grade thresholds based on the provided highest grade.
 
     :param highest: int - value of highest exam score.
-    :return: [int] - list of lower threshold scores for each D-A letter grade interval.
+    :return: list - of lower threshold scores for each D-A letter grade interval.
             For example, where the highest score is 100, and failing is <= 40,
             The result would be [41, 56, 71, 86]:
 
@@ -52,9 +52,9 @@ def letter_grades(highest):
 def student_ranking(student_scores, student_names):
     """Organize the student's rank, name, and grade information in ascending order.
 
-    :param student_scores: [int] - list of scores in descending order.
-    :param student_names: [str] - list of names in descending order by exam score.
-    :return: [str] - list of strings in format ["<rank>. <student name>: <score>"].
+    :param student_scores: list - of scores in descending order.
+    :param student_names: list - of string names by exam score in descending order.
+    :return: list - of strings in format ["<rank>. <student name>: <score>"].
     """
 
     pass
@@ -63,8 +63,8 @@ def student_ranking(student_scores, student_names):
 def perfect_score(student_info):
     """Create a list that contains the name and grade of the first student to make a perfect score on the exam.
 
-    :param student_info: list of [<student name>, <score>] lists.
-    :return: first `[<student name>, 100]` or `[]` if no student score of 100 is found.
+    :param student_info: list - of [<student name>, <score>] lists.
+    :return: list - first `[<student name>, 100]` or `[]` if no student score of 100 is found.
     """
 
     pass

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -4,8 +4,8 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: Union[int, float] - temperature value in kelvin (integer or float).
-    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float).
+    :param temperature: number - temperature value in kelvin (integer or float).
+    :param neutrons_emitted: number - number of neutrons emitted per second (integer or float).
     :return: bool - return True if conditions met, False if not.
 
     A reactor is said to be critical if it satisfies the following conditions:
@@ -26,9 +26,9 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: Union[int, float] - voltage value (integer or float).
-    :param current: Union[int, float] - current value (integer or float).
-    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float).
+    :param voltage: number - voltage value (integer or float).
+    :param current: number - current value (integer or float).
+    :param theoretical_max_power: number - power that corresponds to a 100% efficiency (integer or float).
     :return: str - one of 'green', 'orange', 'red', or 'black'.
 
     Efficiency can be grouped into 4 bands:
@@ -62,9 +62,9 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float).
-    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float).
-    :param threshold: Union[int, float] - threshold (integer or float).
+    :param temperature: number - value of the temperature in kelvin (integer or float).
+    :param neutrons_produced_per_second: number - neutron flux (integer or float).
+    :param threshold: number - threshold (integer or float).
     :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -4,9 +4,9 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: Union[int, float] - temperature value in kelvin (integer or float)
-    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float)
-    :return: bool - True if conditions met, False if not
+    :param temperature: Union[int, float] - temperature value in kelvin (integer or float).
+    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float).
+    :return: bool - return True if conditions met, False if not.
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
@@ -26,10 +26,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: Union[int, float] - voltage value (integer or float)
-    :param current: Union[int, float] - current value (integer or float)
-    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float)
-    :return: str - one of 'green', 'orange', 'red', or 'black'
+    :param voltage: Union[int, float] - voltage value (integer or float).
+    :param current: Union[int, float] - current value (integer or float).
+    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float).
+    :return: str - one of 'green', 'orange', 'red', or 'black'.
 
     Efficiency can be grouped into 4 bands:
 
@@ -62,10 +62,10 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float)
-    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float)
-    :param threshold: Union[int, float] - threshold (integer or float)
-    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'
+    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float).
+    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float).
+    :param threshold: Union[int, float] - threshold (integer or float).
+    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -1,12 +1,12 @@
-"""Meltdown Mitigation exercise."""
+"""Functions to prevent a nuclear meltdown."""
 
 
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: number - temperature value in kelvin (integer or float).
-    :param neutrons_emitted: number - number of neutrons emitted per second (integer or float).
-    :return: bool - return True if conditions met, False if not.
+    :param temperature: int or float - temperature value in kelvin.
+    :param neutrons_emitted: int or float - number of neutrons emitted per second.
+    :return: bool - is criticality balanced?
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
@@ -26,10 +26,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: number - voltage value (integer or float).
-    :param current: number - current value (integer or float).
-    :param theoretical_max_power: number - power that corresponds to a 100% efficiency (integer or float).
-    :return: str - one of 'green', 'orange', 'red', or 'black'.
+    :param voltage: int or float - voltage value.
+    :param current: int or float - current value.
+    :param theoretical_max_power: int or float - power that corresponds to a 100% efficiency.
+    :return: str - one of ('green', 'orange', 'red', or 'black').
 
     Efficiency can be grouped into 4 bands:
 
@@ -62,14 +62,14 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: number - value of the temperature in kelvin (integer or float).
-    :param neutrons_produced_per_second: number - neutron flux (integer or float).
-    :param threshold: number - threshold (integer or float).
-    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
+    :param temperature: int or float - value of the temperature in kelvin.
+    :param neutrons_produced_per_second: int or float - neutron flux.
+    :param threshold: int or float - threshold for category.
+    :return: str - one of ('LOW', 'NORMAL', 'DANGER').
 
-    - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
-    - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'
-    - `temperature * neutron per second` is not in the above-stated ranges ==  'DANGER'
+    1. 'LOW' -> `temperature * neutrons per second` < 90% of `threshold`
+    2. 'NORMAL' -> `temperature * neutrons per second` +/- 10% of `threshold`
+    3. 'DANGER' -> `temperature * neutrons per second` is not in the above-stated ranges
     """
 
     output = temperature * neutrons_produced_per_second

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -1,15 +1,19 @@
+"""Meltdown Mitigation exercise."""
+
+
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: temperature value in kelvin (integer or float)
-    :param neutrons_emitted: number of neutrons emitted per second (integer or float)
-    :return:  boolean True if conditions met, False if not
+    :param temperature: Union[int, float] - temperature value in kelvin (integer or float)
+    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float)
+    :return: bool - True if conditions met, False if not
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
     - The number of neutrons emitted per second is greater than 500.
     - The product of temperature and neutrons emitted per second is less than 500000.
     """
+
     output = temperature * neutrons_emitted
     balanced = False
 
@@ -22,10 +26,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: voltage value (integer or float)
-    :param current: current value (integer or float)
-    :param theoretical_max_power: power that corresponds to a 100% efficiency (integer or float)
-    :return: str one of 'green', 'orange', 'red', or 'black'
+    :param voltage: Union[int, float] - voltage value (integer or float)
+    :param current: Union[int, float] - current value (integer or float)
+    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float)
+    :return: str - one of 'green', 'orange', 'red', or 'black'
 
     Efficiency can be grouped into 4 bands:
 
@@ -38,6 +42,7 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
     (generated power/ theoretical max power)*100
     where generated power = voltage * current
     """
+
     generated_power = voltage * current
     percentage_range = (generated_power / theoretical_max_power) * 100
     efficiency_level = 'unknown'
@@ -57,15 +62,16 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: value of the temperature in kelvin (integer or float)
-    :param neutrons_produced_per_second: neutron flux (integer or float)
-    :param threshold: threshold (integer or float)
-    :return: str one of: 'LOW', 'NORMAL', 'DANGER'
+    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float)
+    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float)
+    :param threshold: Union[int, float] - threshold (integer or float)
+    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'
     - `temperature * neutron per second` is not in the above-stated ranges ==  'DANGER'
     """
+
     output = temperature * neutrons_produced_per_second
     operational_percentage = (output / threshold) * 100
 

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -1,12 +1,12 @@
-"""Meltdown Mitigation exercise."""
+"""Functions to prevent a nuclear meltdown."""
 
 
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: number - temperature value in kelvin (integer or float).
-    :param neutrons_emitted: number - number of neutrons emitted per second (integer or float).
-    :return: bool - return True if conditions met, False if not.
+    :param temperature: int or float - temperature value in kelvin.
+    :param neutrons_emitted: int or float - number of neutrons emitted per second.
+    :return: bool - is criticality balanced?
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
@@ -20,10 +20,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: number - voltage value (integer or float).
-    :param current: number - current value (integer or float).
-    :param theoretical_max_power: number - power that corresponds to a 100% efficiency (integer or float).
-    :return: str - one of 'green', 'orange', 'red', or 'black'.
+    :param voltage: int or float - voltage value.
+    :param current: int or float - current value.
+    :param theoretical_max_power: int or float - power that corresponds to a 100% efficiency.
+    :return: str - one of ('green', 'orange', 'red', or 'black').
 
     Efficiency can be grouped into 4 bands:
 
@@ -43,14 +43,14 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: number - value of the temperature in kelvin (integer or float).
-    :param neutrons_produced_per_second: number - neutron flux (integer or float).
-    :param threshold: number - threshold (integer or float).
-    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
+    :param temperature: int or float - value of the temperature in kelvin.
+    :param neutrons_produced_per_second: int or float - neutron flux.
+    :param threshold: int or float - threshold for category.
+    :return: str - one of ('LOW', 'NORMAL', 'DANGER').
 
-    - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
-    - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'
-    - `temperature * neutrons per second` is not in the above-stated ranges ==  'DANGER'
+    1. 'LOW' -> `temperature * neutrons per second` < 90% of `threshold`
+    2. 'NORMAL' -> `temperature * neutrons per second` +/- 10% of `threshold`
+    3. 'DANGER' -> `temperature * neutrons per second` is not in the above-stated ranges
     """
 
     pass

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -4,8 +4,8 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: Union[int, float] - temperature value in kelvin (integer or float).
-    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float).
+    :param temperature: number - temperature value in kelvin (integer or float).
+    :param neutrons_emitted: number - number of neutrons emitted per second (integer or float).
     :return: bool - return True if conditions met, False if not.
 
     A reactor is said to be critical if it satisfies the following conditions:
@@ -20,9 +20,9 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: Union[int, float] - voltage value (integer or float).
-    :param current: Union[int, float] - current value (integer or float).
-    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float).
+    :param voltage: number - voltage value (integer or float).
+    :param current: number - current value (integer or float).
+    :param theoretical_max_power: number - power that corresponds to a 100% efficiency (integer or float).
     :return: str - one of 'green', 'orange', 'red', or 'black'.
 
     Efficiency can be grouped into 4 bands:
@@ -43,9 +43,9 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float).
-    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float).
-    :param threshold: Union[int, float] - threshold (integer or float).
+    :param temperature: number - value of the temperature in kelvin (integer or float).
+    :param neutrons_produced_per_second: number - neutron flux (integer or float).
+    :param threshold: number - threshold (integer or float).
     :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -1,12 +1,12 @@
-""" Meltdown Mitigation exercise """
+"""Meltdown Mitigation exercise."""
 
 
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: temperature value in kelvin (integer or float)
-    :param neutrons_emitted: number of neutrons emitted per second (integer or float)
-    :return:  boolean True if conditions met, False if not
+    :param temperature: Union[int, float] - temperature value in kelvin (integer or float)
+    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float)
+    :return: bool - True if conditions met, False if not
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
@@ -20,10 +20,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: voltage value (integer or float)
-    :param current: current value (integer or float)
-    :param theoretical_max_power: power that corresponds to a 100% efficiency (integer or float)
-    :return: str one of 'green', 'orange', 'red', or 'black'
+    :param voltage: Union[int, float] - voltage value (integer or float)
+    :param current: Union[int, float] - current value (integer or float)
+    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float)
+    :return: str - one of 'green', 'orange', 'red', or 'black'
 
     Efficiency can be grouped into 4 bands:
 
@@ -43,10 +43,10 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: value of the temperature in kelvin (integer or float)
-    :param neutrons_produced_per_second: neutron flux (integer or float)
-    :param threshold: threshold (integer or float)
-    :return: str one of: 'LOW', 'NORMAL', 'DANGER'
+    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float)
+    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float)
+    :param threshold: Union[int, float] - threshold (integer or float)
+    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -4,9 +4,9 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: Union[int, float] - temperature value in kelvin (integer or float)
-    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float)
-    :return: bool - True if conditions met, False if not
+    :param temperature: Union[int, float] - temperature value in kelvin (integer or float).
+    :param neutrons_emitted: Union[int, float] - number of neutrons emitted per second (integer or float).
+    :return: bool - return True if conditions met, False if not.
 
     A reactor is said to be critical if it satisfies the following conditions:
     - The temperature is less than 800 K.
@@ -20,10 +20,10 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: Union[int, float] - voltage value (integer or float)
-    :param current: Union[int, float] - current value (integer or float)
-    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float)
-    :return: str - one of 'green', 'orange', 'red', or 'black'
+    :param voltage: Union[int, float] - voltage value (integer or float).
+    :param current: Union[int, float] - current value (integer or float).
+    :param theoretical_max_power: Union[int, float] - power that corresponds to a 100% efficiency (integer or float).
+    :return: str - one of 'green', 'orange', 'red', or 'black'.
 
     Efficiency can be grouped into 4 bands:
 
@@ -43,10 +43,10 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float)
-    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float)
-    :param threshold: Union[int, float] - threshold (integer or float)
-    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'
+    :param temperature: Union[int, float] - value of the temperature in kelvin (integer or float).
+    :param neutrons_produced_per_second: Union[int, float] - neutron flux (integer or float).
+    :param threshold: Union[int, float] - threshold (integer or float).
+    :return: str - one of: 'LOW', 'NORMAL', 'DANGER'.
 
     - `temperature * neutrons per second` < 90% of `threshold` == 'LOW'
     - `temperature * neutrons per second` +/- 10% of `threshold` == 'NORMAL'

--- a/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
@@ -26,7 +26,7 @@ def compare_records(azara_record, rui_record):
 
     :param azara_record: tuple - a (treasure, coordinate) pair.
     :param rui_record: tuple - a (location, tuple(coordinate_1, coordinate_2), quadrant) trio.
-    :return: bool - returns True if coordinates match, False otherwise.
+    :return: bool - do the coordinates match?
     """
 
     return convert_coordinate(azara_record[1]) in rui_record

--- a/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
@@ -12,20 +12,20 @@ def get_coordinate(record):
 
 
 def convert_coordinate(coordinate):
-    """Create and return a tuple containing two characters from the treasure coordinate.
+    """Split the given coordinate into tuple containing its individual components.
 
     :param coordinate: str - a string map coordinate
-    :return: tuple - the string coordinate seperated into its individual components.
+    :return: tuple - the string coordinate split into its individual components.
     """
 
     return tuple(coordinate)
 
 
 def compare_records(azara_record, rui_record):
-    """Compare two record types and determine if the coordinates match.
+    """Compare two record types and determine if their coordinates match.
 
     :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio with a nested tuple.
+    :param rui_record: tuple - a (location, tuple(coordinate_1, coordinate_2), quadrant) trio.
     :return: bool - returns True if coordinates match, False otherwise.
     """
 
@@ -33,11 +33,11 @@ def compare_records(azara_record, rui_record):
 
 
 def create_record(azara_record, rui_record):
-    """Combine the two record types (if possible) and create a combined record group, else return "not a match".
+    """Combine the two record types (if possible) and create a combined record group.
 
     :param azara_record: tuple - a (treasure, coordinate) pair.
     :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return: tuple or str - combined record, or "not a match" if the records are incompatible.
+    :return: tuple or str - the combined record (if compatible), or the string "not a match" (if incompatible).
     """
 
     result = "not a match"

--- a/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
@@ -4,7 +4,7 @@
 def get_coordinate(record):
     """Return coordinate value from a tuple containing the treasure name, and treasure coordinate.
 
-    :param record: (str, str) - a tuple with a (treasure, coordinate) pair.
+    :param record: tuple - with a (treasure, coordinate) pair.
     :return: str - the extracted map coordinate.
     """
 
@@ -15,7 +15,7 @@ def convert_coordinate(coordinate):
     """Create and return a tuple containing two characters from the treasure coordinate.
 
     :param coordinate: str - a string map coordinate
-    :return: (str, str) - the string coordinate seperated into its individual components.
+    :return: tuple - the string coordinate seperated into its individual components.
     """
 
     return tuple(coordinate)
@@ -24,8 +24,8 @@ def convert_coordinate(coordinate):
 def compare_records(azara_record, rui_record):
     """Compare two record types and determine if the coordinates match.
 
-    :param azara_record: (str, str) - a (treasure, coordinate) pair.
-    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :param azara_record: tuple - a (treasure, coordinate) pair.
+    :param rui_record: tuple - a (location, coordinate, quadrant) trio with a nested tuple.
     :return: bool - returns True if coordinates match, False otherwise.
     """
 
@@ -35,9 +35,9 @@ def compare_records(azara_record, rui_record):
 def create_record(azara_record, rui_record):
     """Combine the two record types (if possible) and create a combined record group, else return "not a match".
 
-    :param azara_record: (str, str) - a (treasure, coordinate) pair.
-    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
-    :return: (str, str, str, (str, str), str) or str - combined record, or "not a match" if the records are incompatible.
+    :param azara_record: tuple - a (treasure, coordinate) pair.
+    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
+    :return: tuple or str - combined record, or "not a match" if the records are incompatible.
     """
 
     result = "not a match"
@@ -51,8 +51,12 @@ def create_record(azara_record, rui_record):
 def clean_up(combined_record_group):
     """Clean up a combined record group into a multi-line string of single records.
 
-    :param combined_record_group: ((str, str, str, (str, str), str), ...) - everything from both participants.
+    :param combined_record_group: tuple - everything from both participants.
     :return: str - everything "cleaned", excess coordinates and information are removed.
+
+    The return statement should be a multi-lined string with items separated by newlines.
+
+    (see HINTS.md for an example).
     """
 
     report = ""

--- a/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/exemplar.py
@@ -1,7 +1,10 @@
-def get_coordinate(record):
-    """
+"""Functions to help Azara and Rui locate pirate treasure."""
 
-    :param record: tuple - a (treasure, coordinate) pair.
+
+def get_coordinate(record):
+    """Return coordinate value from a tuple containing the treasure name, and treasure coordinate.
+
+    :param record: (str, str) - a tuple with a (treasure, coordinate) pair.
     :return: str - the extracted map coordinate.
     """
 
@@ -9,33 +12,34 @@ def get_coordinate(record):
 
 
 def convert_coordinate(coordinate):
-    """
+    """Create and return a tuple containing two characters from the treasure coordinate.
 
     :param coordinate: str - a string map coordinate
-    :return:  tuple - the string coordinate seperated into its individual components.
+    :return: (str, str) - the string coordinate seperated into its individual components.
     """
 
     return tuple(coordinate)
 
 
 def compare_records(azara_record, rui_record):
-    """
+    """Compare two record types and determine if the coordinates match.
 
-    :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return: bool - True if coordinates match, False otherwise.
+    :param azara_record: (str, str) - a (treasure, coordinate) pair.
+    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :return: bool - returns True if coordinates match, False otherwise.
     """
 
     return convert_coordinate(azara_record[1]) in rui_record
 
 
 def create_record(azara_record, rui_record):
+    """Combine the two record types (if possible) and create a combined record group, else return "not a match".
+
+    :param azara_record: (str, str) - a (treasure, coordinate) pair.
+    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :return: (str, str, str, (str, str), str) or str - combined record, or "not a match" if the records are incompatible.
     """
 
-    :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return:  tuple - combined record, or "not a match" if the records are incompatible.
-    """
     result = "not a match"
 
     if compare_records(azara_record, rui_record):
@@ -45,10 +49,10 @@ def create_record(azara_record, rui_record):
 
 
 def clean_up(combined_record_group):
-    """
+    """Clean up a combined record group into a multi-line string of single records.
 
-    :param combined_record_group: tuple of tuples - everything from both participants.
-    :return: tuple of tuples - everything "cleaned". Excess coordinates and information removed.
+    :param combined_record_group: ((str, str, str, (str, str), str), ...) - everything from both participants.
+    :return: str - everything "cleaned", excess coordinates and information are removed.
     """
 
     report = ""

--- a/exercises/concept/tisbury-treasure-hunt/tuples.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples.py
@@ -1,7 +1,10 @@
-def get_coordinate(record):
-    """
+"""Functions to help Azara and Rui locate pirate treasure."""
 
-    :param record: tuple - a (treasure, coordinate) pair.
+
+def get_coordinate(record):
+    """Return coordinate value from a tuple containing the treasure name, and treasure coordinate.
+
+    :param record: (str, str) - a tuple with a (treasure, coordinate) pair.
     :return: str - the extracted map coordinate.
     """
 
@@ -9,42 +12,42 @@ def get_coordinate(record):
 
 
 def convert_coordinate(coordinate):
-    """
+    """Create and return a tuple containing two characters from the treasure coordinate.
 
     :param coordinate: str - a string map coordinate
-    :return:  tuple - the string coordinate seperated into its individual components.
+    :return: (str, str) - the string coordinate seperated into its individual components.
     """
 
     pass
 
 
 def compare_records(azara_record, rui_record):
-    """
+    """Compare two record types and determine if the coordinates match.
 
-    :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return: bool - True if coordinates match, False otherwise.
+    :param azara_record: (str, str) - a (treasure, coordinate) pair.
+    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :return: bool - returns True if coordinates match, False otherwise.
     """
 
     pass
 
 
 def create_record(azara_record, rui_record):
-    """
+    """Combine the two record types (if possible) and create a combined record group, else return "not a match".
 
-    :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return:  tuple - combined record, or "not a match" if the records are incompatible.
+    :param azara_record: (str, str) - a (treasure, coordinate) pair.
+    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :return: (str, str, str, (str, str), str) or str - combined record, or "not a match" if the records are incompatible.
     """
 
     pass
 
 
 def clean_up(combined_record_group):
-    """
+    """Clean up a combined record group into a multi-line string of single records.
 
-    :param combined_record_group: tuple of tuples - everything from both participants.
-    :return: string of tuples separated by newlines - everything "cleaned". Excess coordinates and information removed.
+    :param combined_record_group: ((str, str, str, (str, str), str), ...) - everything from both participants.
+    :return: str - everything "cleaned", excess coordinates and information are removed.
     """
 
     pass

--- a/exercises/concept/tisbury-treasure-hunt/tuples.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples.py
@@ -4,7 +4,7 @@
 def get_coordinate(record):
     """Return coordinate value from a tuple containing the treasure name, and treasure coordinate.
 
-    :param record: (str, str) - a tuple with a (treasure, coordinate) pair.
+    :param record: tuple - with a (treasure, coordinate) pair.
     :return: str - the extracted map coordinate.
     """
 
@@ -15,7 +15,7 @@ def convert_coordinate(coordinate):
     """Create and return a tuple containing two characters from the treasure coordinate.
 
     :param coordinate: str - a string map coordinate
-    :return: (str, str) - the string coordinate seperated into its individual components.
+    :return: tuple - the string coordinate seperated into its individual components.
     """
 
     pass
@@ -24,8 +24,8 @@ def convert_coordinate(coordinate):
 def compare_records(azara_record, rui_record):
     """Compare two record types and determine if the coordinates match.
 
-    :param azara_record: (str, str) - a (treasure, coordinate) pair.
-    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
+    :param azara_record: tuple - a (treasure, coordinate) pair.
+    :param rui_record: tuple - a (location, coordinate, quadrant) trio with a nested tuple.
     :return: bool - returns True if coordinates match, False otherwise.
     """
 
@@ -35,9 +35,9 @@ def compare_records(azara_record, rui_record):
 def create_record(azara_record, rui_record):
     """Combine the two record types (if possible) and create a combined record group, else return "not a match".
 
-    :param azara_record: (str, str) - a (treasure, coordinate) pair.
-    :param rui_record: (str, (str, str), str) - a (location, coordinate, quadrant) trio.
-    :return: (str, str, str, (str, str), str) or str - combined record, or "not a match" if the records are incompatible.
+    :param azara_record: tuple - a (treasure, coordinate) pair.
+    :param rui_record: tuple - a (location, coordinate, quadrant) trio.
+    :return: tuple or str - combined record, or "not a match" if the records are incompatible.
     """
 
     pass
@@ -46,8 +46,12 @@ def create_record(azara_record, rui_record):
 def clean_up(combined_record_group):
     """Clean up a combined record group into a multi-line string of single records.
 
-    :param combined_record_group: ((str, str, str, (str, str), str), ...) - everything from both participants.
+    :param combined_record_group: tuple - everything from both participants.
     :return: str - everything "cleaned", excess coordinates and information are removed.
+
+    The return statement should be a multi-lined string with items separated by newlines.
+
+    (see HINTS.md for an example).
     """
 
     pass

--- a/exercises/concept/tisbury-treasure-hunt/tuples.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples.py
@@ -12,32 +12,32 @@ def get_coordinate(record):
 
 
 def convert_coordinate(coordinate):
-    """Create and return a tuple containing two characters from the treasure coordinate.
+    """Split the given coordinate into tuple containing its individual components.
 
     :param coordinate: str - a string map coordinate
-    :return: tuple - the string coordinate seperated into its individual components.
+    :return: tuple - the string coordinate split into its individual components.
     """
 
     pass
 
 
 def compare_records(azara_record, rui_record):
-    """Compare two record types and determine if the coordinates match.
+    """Compare two record types and determine if their coordinates match.
 
     :param azara_record: tuple - a (treasure, coordinate) pair.
-    :param rui_record: tuple - a (location, coordinate, quadrant) trio with a nested tuple.
-    :return: bool - returns True if coordinates match, False otherwise.
+    :param rui_record: tuple - a (location, tuple(coordinate_1, coordinate_2), quadrant) trio.
+    :return: bool - do the coordinates match?
     """
 
     pass
 
 
 def create_record(azara_record, rui_record):
-    """Combine the two record types (if possible) and create a combined record group, else return "not a match".
+    """Combine the two record types (if possible) and create a combined record group.
 
     :param azara_record: tuple - a (treasure, coordinate) pair.
     :param rui_record: tuple - a (location, coordinate, quadrant) trio.
-    :return: tuple or str - combined record, or "not a match" if the records are incompatible.
+    :return: tuple or str - the combined record (if compatible), or the string "not a match" (if incompatible).
     """
 
     pass


### PR DESCRIPTION
Adresses #2974.

### A sweeping docstring cleanup effort in concept exercises that includes changes such as:

- Making sure a module level (top of file) docstring exists in concepts that need them, such as early exercises.
- Making sure a summary first line (function scope) docstring exists in concepts that need them.
- Making sure that summary first line docstrings begin with an imperative mood as per pycdocstyle [D401](https://manpages.ubuntu.com/manpages/xenial/man1/pydocstyle.1.html#:~:text=D401%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%20First%20%20%20line%20%20%20should%20%20%20be%20%20%20%20in%20%E2%94%82%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%20imperative%20mood).
- The summary level and module level docstring should end in a period per pydocstyle [D400](https://manpages.ubuntu.com/manpages/xenial/man1/pydocstyle.1.html#:~:text=D400%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%20First%20%20line%20%20should%20%20end%20%20with%20a).
- Making sure that there is some sort of uniformity across the various concepts, for example, docstring params/return lines should have a general format that looks like:

```
:param <name>: <type> - <description>
:return: <type> - <description>
``` 

Where the \<description\> begins with a lowercase letter and ends in a period.

- Other various housekeeping, such as inconsistent tabbing, messy looking docstrings, grammar mistakes.

<br>

### What I found while working through the concepts

1. Docstring param/return types are a little non-specific, for example, instead of a `typing` module style union which tells us which types the list can hold:

```
Union[list[str], list[int]]
```

we have just:

```
list - look at me, I'm a description -- can be either an int list or float list.
```

we then rely on the description to talk about the type and clarify, this is most evident in Metldown Mitigation and Tisbury Treasure Hunt, however, I can recognize that this can be seen as more confusing to the student, so I would love to hear some input and discuss and maybe implement something before merging. 

I was also thinking of a syntax that looks succinct and readable, like:

```
list[int or float]
```

that way you can understand what is happening without needing a background in the `typing` module and remove a lot of extra unnecessary descriptions.

<br>

2. Multiple params per line in Black Jack:

```
...
:param card_one, card_two: str - cards dealt. 'J', 'Q', 'K' = 10; 'A' = 1; numerical value otherwise.
...
"""
```

How attached are we to this? I feel it would look less messy overall, especially when you hover over the function to view the docstring in the editor popup box.

<br>

3. I'm open to going through each and adding markdown such as `pre-format` and *emphasis* if you think that will make our docstrings look better in editor popups. I noticed that some have them and some don't, but am curious what others think about this or if we even care about this right now. 

<br>

**Thanks for reading! Happy reviewing!**