### PR TITLE
Resurrected Class Based High Scores.

### DIFF
--- a/exercises/practice/high-scores/.meta/example.py
+++ b/exercises/practice/high-scores/.meta/example.py
@@ -1,11 +1,12 @@
+class HighScores:
+    def __init__(self, scores):
+        self.scores = scores
 
-def latest(scores):
-    return scores[-1]
+    def latest(self):
+        return self.scores[-1]
 
+    def personal_best(self):
+        return max(self.scores)
 
-def personal_best(scores):
-    return max(scores)
-
-
-def personal_top_three(scores):
-    return sorted(scores, reverse=True)[:3]
+    def personal_top_three(self):
+        return sorted(self.scores, reverse=True)[:3]

--- a/exercises/practice/high-scores/.meta/template.j2
+++ b/exercises/practice/high-scores/.meta/template.j2
@@ -3,9 +3,10 @@
     def test_{{ case["description"] | to_snake }}(self):
         scores = {{ case["input"]["scores"] }}
         expected = {{ case["expected"] }}
-        self.assertEqual({{ case["property"] | to_snake }}(scores), expected)
+        self.assertEqual(HighScores(scores).{{ case["property"] | to_snake }}(), expected)
 {% endmacro -%}
-{{ macros.header(ignore=["scores"]) }}
+
+{{ macros.header(["HighScores"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- for case in cases -%}

--- a/exercises/practice/high-scores/high_scores.py
+++ b/exercises/practice/high-scores/high_scores.py
@@ -1,10 +1,15 @@
-def latest(scores):
-    pass
+# class HighScores:
+#     def __init__(self, scores):
+#         pass
+class HighScores:
+    def __init__(self, scores):
+        self.scores = scores
 
+    def latest(self):
+        return self.scores[-1]
 
-def personal_best(scores):
-    pass
+    def personal_best(self):
+        return max(self.scores)
 
-
-def personal_top_three(scores):
-    pass
+    def personal_top_three(self):
+        return sorted(self.scores, reverse=True)[:3]

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -1,9 +1,7 @@
 import unittest
 
 from high_scores import (
-    latest,
-    personal_best,
-    personal_top_three,
+    HighScores,
 )
 
 # Tests adapted from `problem-specifications//canonical-data.json`
@@ -13,34 +11,44 @@ class HighScoresTest(unittest.TestCase):
     def test_latest_score(self):
         scores = [100, 0, 90, 30]
         expected = 30
-        self.assertEqual(latest(scores), expected)
+        self.assertEqual(HighScores(scores).latest(), expected)
 
     def test_personal_best(self):
         scores = [40, 100, 70]
         expected = 100
-        self.assertEqual(personal_best(scores), expected)
+        self.assertEqual(HighScores(scores).personal_best(), expected)
 
     def test_personal_top_three_from_a_list_of_scores(self):
         scores = [10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70]
         expected = [100, 90, 70]
-        self.assertEqual(personal_top_three(scores), expected)
+        self.assertEqual(HighScores(scores).personal_top_three(), expected)
 
     def test_personal_top_highest_to_lowest(self):
         scores = [20, 10, 30]
         expected = [30, 20, 10]
-        self.assertEqual(personal_top_three(scores), expected)
+        self.assertEqual(HighScores(scores).personal_top_three(), expected)
 
     def test_personal_top_when_there_is_a_tie(self):
         scores = [40, 20, 40, 30]
         expected = [40, 40, 30]
-        self.assertEqual(personal_top_three(scores), expected)
+        self.assertEqual(HighScores(scores).personal_top_three(), expected)
 
     def test_personal_top_when_there_are_less_than_3(self):
         scores = [30, 70]
         expected = [70, 30]
-        self.assertEqual(personal_top_three(scores), expected)
+        self.assertEqual(HighScores(scores).personal_top_three(), expected)
 
     def test_personal_top_when_there_is_only_one(self):
         scores = [40]
         expected = [40]
-        self.assertEqual(personal_top_three(scores), expected)
+        self.assertEqual(HighScores(scores).personal_top_three(), expected)
+
+    def test_latest_score_after_personal_top_scores(self):
+        scores = [70, 50, 20, 30]
+        expected = 30
+        self.assertEqual(HighScores(scores).latest_after_top_three(), expected)
+
+    def test_scores_after_personal_top_scores(self):
+        scores = [30, 50, 20, 70]
+        expected = [30, 50, 20, 70]
+        self.assertEqual(HighScores(scores).scores_after_top_three(), expected)


### PR DESCRIPTION
Adding back the following files from [2019 High Scores](https://github.com/exercism/python/tree/839e3fe2581ee5c7df2f1978931db9137fe2f68c/exercises/high-scores) (_before the exercise was changed to a non-class based exercise_).  

Because this exercise version was prior to our test generation templates, the JinJa2 template is a modified version of the one in use for the current exercise.

- [x] 	exercises/practice/high-scores/.meta/example.py
- [x] 	exercises/practice/high-scores/.meta/template.j2
- [x] 	exercises/practice/high-scores/high_scores.py
- [x] 	exercises/practice/high-scores/high_scores_test.py

`tests.toml` was not modified, so there is additional work in getting the "immutability" test cases working by setting them to true and then modifying the JinJa2 template and re-generating the test file.