### PR TITLE
[Darts]: Restore Nested Bullets

### DIFF
--- a/exercises/practice/darts/.docs/hints.md
+++ b/exercises/practice/darts/.docs/hints.md
@@ -3,9 +3,10 @@
 ## General
 
 -  This challenge is all about calculating if a point falls _on, in, or outside_ a given circle.
--  There are two different ways of calculating if a point falls on, in, or outside a circle: _Stack Overflow_ - [Equation for Testing if a Point is Inside a Circle][point-circle-equation] outlines one method.
-_DoubleRoot_ - [Position of a point relative to a circle][point-to-circle] outlines a different one.
-- This _Math is Fun_ post covers a more general [Distance Between 2 Points][distance-between-two-points] calculation.
+-  There are two different ways of calculating if a point falls on, in, or outside a circle.
+   - This _Stack Overflow_ Post: [Equation for Testing if a Point is Inside a Circle][point-circle-equation] outlines one method.
+   - This _DoubleRoot_ post [Position of a point relative to a circle][point-to-circle] outlines a different one.
+   - This _Math is Fun_ post covers a more general [Distance Between 2 Points][distance-between-two-points] calculation.
 - Because the dart board is a set of _nested_ circles, the order in which you calculate points could change the answer significantly.
   You should pay attention to which direction your calculations "move" in.
 -  Remember that this exercise has many potential solutions and many paths you can take along the way.

--- a/exercises/practice/darts/.docs/hints.md
+++ b/exercises/practice/darts/.docs/hints.md
@@ -7,7 +7,7 @@
    - This _Stack Overflow_ Post: [Equation for Testing if a Point is Inside a Circle][point-circle-equation] outlines one method.
    - This _DoubleRoot_ post [Position of a point relative to a circle][point-to-circle] outlines a different one.
    - This _Math is Fun_ post covers a more general [Distance Between 2 Points][distance-between-two-points] calculation.
-- Because the dart board is a set of _nested_ circles, the order in which you calculate points could change the answer significantly.
+- Because the dart board is a set of _concentric_ circles, the order in which you calculate points could change the answer significantly.
   You should pay attention to which direction your calculations "move" in.
 -  Remember that this exercise has many potential solutions and many paths you can take along the way.
    No path is manifestly "better" than another, although a particular path may be more interesting or better suited to what you want to learn or explore right now.


### PR DESCRIPTION
Per issue #2998 (_which has been resolved in the linked website issue_), nested bullets were not working in `hints` files.
They are now, so this PR restores `hints` for the `Darts` exercise to the nested-bullet state.

Closes #2998. 