### PR TITLE
Removed mention of non-affiliation

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -7,7 +7,6 @@ This is a collection of tools that are popular in our community.
 It is not intended to be prescriptive nor exhaustive.
 We think these tools do their job well, but there are most certainly other tools that are also good.
 If you have an editor, IDE, tool, or plugin recommendation, we encourage you to add it to this document on GitHub.
-Exercism does not have any affiliations with any of the tools listed below.
 
 ~~~~
 


### PR DESCRIPTION
There are two (at least) reasons for this:

1. The paragraph itself indicates that it is a community effort to
   provide this list
2. We indicate a claim of lack of bias (organization wise) based on
    - "this is a collection of tools that are popular in the community"
    - "it is not intended to be prescriptive"
    - welcoming others to add to this list
3. I am not aware of affiliations or lack thereof of any in this list at
   this time, in the past, or at any point in the future.
4. It is better to not claim the negative, and instead claim the
   affirmative when it happens.  (Less maintenance work.)
