### PR TITLE
[Card Games] Additional test for Task 6.

### DIFF
--- a/exercises/concept/card-games/lists_test.py
+++ b/exercises/concept/card-games/lists_test.py
@@ -85,9 +85,9 @@ class CardGamesTest(unittest.TestCase):
     @pytest.mark.task(taskno=6)
     def test_average_even_is_average_odd(self):
 
-        input_vars = [[5, 6, 8], [1, 2, 3, 4], [1, 2, 3], [5, 6, 7], ]
+        input_vars = [[5, 6, 8], [1, 2, 3, 4], [1, 2, 3], [5, 6, 7], [1, 3, 5, 7, 9]]
 
-        results = [False, False, True, True]
+        results = [False, False, True, True, True]
 
         for variant, (hand, same) in enumerate(zip(input_vars, results), start=1):
             error_message = f'Hand {hand} {"does" if same else "does not"} yield the same odd-even average.'


### PR DESCRIPTION
Adding in a test for `[1, 3, 5, 7, 9]` to prevent an invalid alternate solution for Task 6.

Alternate solution that passes all current tests: `return card_average(hand) % 2 == 0`.

Fixes #3025 .