### PR TITLE
[List Methods]: Fix Markdown Heading in Hints File

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/.docs/hints.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/hints.md
@@ -19,7 +19,7 @@ Make sure you have a good understanding of how to create and update lists.
 
 - You know the mean persons name, so you can `remove()` them from the queue.
 
-# 5. Namefellows
+## 5. Namefellows
 
 -  `count()`-ing the occurrences of the `name` in the queue could be a good strategy here.
 


### PR DESCRIPTION
I was going through this exercise and noticed that one of the hints was not being displayed due to a missing `#`.