### PR TITLE
Updating the test in the Tisbury Treasure Hunt

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/tuples_test.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples_test.py
@@ -123,7 +123,7 @@ class TisburyTreasureTest(unittest.TestCase):
             ('Silver Seahorse', '4E', 'Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow')
         )
 
-        result_data = """(\"Scrimshaw Whale's Tooth\", 'Deserted Docks', ('2', 'A'), 'Blue')\n\
+        result_data = """('Scrimshaw Whale's Tooth', 'Deserted Docks', ('2', 'A'), 'Blue')\n\
 ('Brass Spyglass', 'Abandoned Lighthouse', ('4', 'B'), 'Blue')\n\
 ('Robot Parrot', 'Seaside Cottages', ('1', 'C'), 'Blue')\n\
 ('Glass Starfish', 'Tangled Seaweed Patch', ('6', 'D'), 'Orange')\n\


### PR DESCRIPTION
Since the first tuple contains a string with souble quotes it seems
the editor used to create the file made it a string with duouble quotes
to save the \' inside it. Putting this verbatim in the result string
make the test inconsistent with the instructions set.