### PR TITLE
[Tisbury Treasure Hunt]: Updated instances of Scrimshaw Whale's Tooth per issue 3068

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
@@ -2,11 +2,10 @@
 
 ## General
 
-- [Tuples][tuples] are immutable.
-  [Sequence Types][sequence types] that can contain any data type.
-- Tuples are [iterable][iterable].
-- Elements within tuples can be accessed via [bracket notation][bracket notation], using a zero-based index.
-- Other [Common Sequence Operations][common sequence operations] can also be used when working with tuples.
+
+[Tuples][tuples] are immutable [sequence Types][sequence types] that can contain any data type.
+Tuples are [iterable][iterable], and elements within tuples can be accessed via [bracket notation][bracket notation], using a zero-based index from the left, or -1 from the right.
+Other [Common Sequence Operations][common sequence operations] can also be used when working with tuples.
 
 ## 1. Extract coordinates
 

--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -21,7 +21,7 @@ They've also been given blank maps with a starting place marked YOU ARE HERE.
 | Model Ship in Large Bottle  | 8A          |
 | Pirate Flag                 | 7F          |
 | Robot Parrot                | 1C          |
-| Scrimshaw Whale's Tooth     | 2A          |
+| Scrimshawed Whale Tooth     | 2A          |
 | Silver Seahorse             | 4E          |
 | Vintage Pirate Hat          | 7E          |
 
@@ -58,7 +58,7 @@ Implement the `get_coordinate()` function that takes a `(treasure, coordinate)` 
 
 
 ```python
->>> get_coordinate(("Scrimshaw Whale's Tooth", "2A"))
+>>> get_coordinate(('Scrimshawed Whale Tooth', "2A"))
 "2A"
 ```
 

--- a/exercises/concept/tisbury-treasure-hunt/tuples_test.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples_test.py
@@ -7,7 +7,7 @@ class TisburyTreasureTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_get_coordinate(self):
-        input_data = [("Scrimshaw Whale's Tooth", '2A'),
+        input_data = [('Scrimshawed Whale Tooth', '2A'),
                       ('Brass Spyglass', '4B'),
                       ('Robot Parrot', '1C'),
                       ('Glass Starfish', '6D'),
@@ -54,16 +54,16 @@ class TisburyTreasureTest(unittest.TestCase):
     @pytest.mark.task(taskno=3)
     def test_compare_records(self):
         input_data = [
-            (("Scrimshaw Whale's Tooth", '2A'), ('Deserted Docks', ('2', 'A'), 'Blue')),
-            (('Brass Spyglass', '4B'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue')),
-            (('Robot Parrot', '1C'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
-            (('Glass Starfish', '6D'), ('Tangled Seaweed Patch', ('6', 'D'), 'Orange')),
-            (('Vintage Pirate Hat', '7E'), ('Quiet Inlet (Island of Mystery)', ('7', 'E'), 'Orange')),
-            (('Amethyst  Octopus', '1F'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
-            (('Angry Monkey Figurine', '5B'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
-            (('Antique Glass Fishnet Float', '3D'), ('Deserted Docks', ('2', 'A'), 'Blue')),
-            (('Brass Spyglass', '4B'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
-            (('Carved Wooden Elephant', '8C'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
+                (('Scrimshawed Whale Tooth', '2A'), ('Deserted Docks', ('2', 'A'), 'Blue')),
+                (('Brass Spyglass', '4B'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue')),
+                (('Robot Parrot', '1C'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
+                (('Glass Starfish', '6D'), ('Tangled Seaweed Patch', ('6', 'D'), 'Orange')),
+                (('Vintage Pirate Hat', '7E'), ('Quiet Inlet (Island of Mystery)', ('7', 'E'), 'Orange')),
+                (('Amethyst  Octopus', '1F'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
+                (('Angry Monkey Figurine', '5B'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
+                (('Antique Glass Fishnet Float', '3D'), ('Deserted Docks', ('2', 'A'), 'Blue')),
+                (('Brass Spyglass', '4B'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
+                (('Carved Wooden Elephant', '8C'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
         ]
         result_data = [True, True, True, True, True, False, False, False, False, False]
         number_of_variants = range(1, len(input_data) + 1)
@@ -75,28 +75,28 @@ class TisburyTreasureTest(unittest.TestCase):
     @pytest.mark.task(taskno=4)
     def test_create_record(self):
         input_data = [
-            (('Angry Monkey Figurine', '5B'), ('Stormy Breakwater', ('5', 'B'), 'Purple')),
-            (('Carved Wooden Elephant', '8C'), ('Foggy Seacave', ('8', 'C'), 'Purple')),
-            (('Amethyst  Octopus', '1F'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
-            (('Antique Glass Fishnet Float', '3D'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
-            (('Silver Seahorse', '4E'), ('Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow')),
-            (('Amethyst  Octopus', '1F'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
-            (('Angry Monkey Figurine', '5B'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
-            (('Antique Glass Fishnet Float', '3D'), ('Deserted Docks', ('2', 'A'), 'Blue')),
-            (('Brass Spyglass', '4B'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
-            (('Carved Wooden Elephant', '8C'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
+                (('Angry Monkey Figurine', '5B'), ('Stormy Breakwater', ('5', 'B'), 'Purple')),
+                (('Carved Wooden Elephant', '8C'), ('Foggy Seacave', ('8', 'C'), 'Purple')),
+                (('Amethyst  Octopus', '1F'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
+                (('Antique Glass Fishnet Float', '3D'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
+                (('Silver Seahorse', '4E'), ('Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow')),
+                (('Amethyst  Octopus', '1F'), ('Seaside Cottages', ('1', 'C'), 'Blue')),
+                (('Angry Monkey Figurine', '5B'), ('Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow')),
+                (('Antique Glass Fishnet Float', '3D'), ('Deserted Docks', ('2', 'A'), 'Blue')),
+                (('Brass Spyglass', '4B'), ('Spiky Rocks', ('3', 'D'), 'Yellow')),
+                (('Carved Wooden Elephant', '8C'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
         ]
         result_data = [
-            ('Angry Monkey Figurine', '5B', 'Stormy Breakwater', ('5', 'B'), 'Purple'),
-            ('Carved Wooden Elephant', '8C', 'Foggy Seacave', ('8', 'C'), 'Purple'),
-            ('Amethyst  Octopus', '1F', 'Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow'),
-            ('Antique Glass Fishnet Float', '3D', 'Spiky Rocks', ('3', 'D'), 'Yellow'),
-            ('Silver Seahorse', '4E', 'Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow'),
-            'not a match',
-            'not a match',
-            'not a match',
-            'not a match',
-            'not a match'
+                ('Angry Monkey Figurine', '5B', 'Stormy Breakwater', ('5', 'B'), 'Purple'),
+                ('Carved Wooden Elephant', '8C', 'Foggy Seacave', ('8', 'C'), 'Purple'),
+                ('Amethyst  Octopus', '1F', 'Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow'),
+                ('Antique Glass Fishnet Float', '3D', 'Spiky Rocks', ('3', 'D'), 'Yellow'),
+                ('Silver Seahorse', '4E', 'Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow'),
+                'not a match',
+                'not a match',
+                'not a match',
+                'not a match',
+                'not a match'
         ]
 
         number_of_variants = range(1, len(input_data) + 1)
@@ -108,22 +108,22 @@ class TisburyTreasureTest(unittest.TestCase):
     @pytest.mark.task(taskno=5)
     def test_clean_up(self):
         input_data = (
-            ("Scrimshaw Whale's Tooth", '2A', 'Deserted Docks', ('2', 'A'), 'Blue'),
-            ('Brass Spyglass', '4B', 'Abandoned Lighthouse', ('4', 'B'), 'Blue'),
-            ('Robot Parrot', '1C', 'Seaside Cottages', ('1', 'C'), 'Blue'),
-            ('Glass Starfish', '6D', 'Tangled Seaweed Patch', ('6', 'D'), 'Orange'),
-            ('Vintage Pirate Hat', '7E', 'Quiet Inlet (Island of Mystery)', ('7', 'E'), 'Orange'),
-            ('Pirate Flag', '7F', 'Windswept Hilltop (Island of Mystery)', ('7', 'F'), 'Orange'),
-            ('Crystal Crab', '6A', 'Old Schooner', ('6', 'A'), 'Purple'),
-            ('Model Ship in Large Bottle', '8A', 'Harbor Managers Office', ('8', 'A'), 'Purple'),
-            ('Angry Monkey Figurine', '5B', 'Stormy Breakwater', ('5', 'B'), 'Purple'),
-            ('Carved Wooden Elephant', '8C', 'Foggy Seacave', ('8', 'C'), 'Purple'),
-            ('Amethyst  Octopus', '1F', 'Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow'),
-            ('Antique Glass Fishnet Float', '3D', 'Spiky Rocks', ('3', 'D'), 'Yellow'),
-            ('Silver Seahorse', '4E', 'Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow')
+                ('Scrimshawed Whale Tooth', '2A', 'Deserted Docks', ('2', 'A'), 'Blue'),
+                ('Brass Spyglass', '4B', 'Abandoned Lighthouse', ('4', 'B'), 'Blue'),
+                ('Robot Parrot', '1C', 'Seaside Cottages', ('1', 'C'), 'Blue'),
+                ('Glass Starfish', '6D', 'Tangled Seaweed Patch', ('6', 'D'), 'Orange'),
+                ('Vintage Pirate Hat', '7E', 'Quiet Inlet (Island of Mystery)', ('7', 'E'), 'Orange'),
+                ('Pirate Flag', '7F', 'Windswept Hilltop (Island of Mystery)', ('7', 'F'), 'Orange'),
+                ('Crystal Crab', '6A', 'Old Schooner', ('6', 'A'), 'Purple'),
+                ('Model Ship in Large Bottle', '8A', 'Harbor Managers Office', ('8', 'A'), 'Purple'),
+                ('Angry Monkey Figurine', '5B', 'Stormy Breakwater', ('5', 'B'), 'Purple'),
+                ('Carved Wooden Elephant', '8C', 'Foggy Seacave', ('8', 'C'), 'Purple'),
+                ('Amethyst  Octopus', '1F', 'Aqua Lagoon (Island of Mystery)', ('1', 'F'), 'Yellow'),
+                ('Antique Glass Fishnet Float', '3D', 'Spiky Rocks', ('3', 'D'), 'Yellow'),
+                ('Silver Seahorse', '4E', 'Hidden Spring (Island of Mystery)', ('4', 'E'), 'Yellow')
         )
 
-        result_data = """(\"Scrimshaw Whale's Tooth\", 'Deserted Docks', ('2', 'A'), 'Blue')\n\
+        result_data = """('Scrimshawed Whale Tooth', 'Deserted Docks', ('2', 'A'), 'Blue')\n\
 ('Brass Spyglass', 'Abandoned Lighthouse', ('4', 'B'), 'Blue')\n\
 ('Robot Parrot', 'Seaside Cottages', ('1', 'C'), 'Blue')\n\
 ('Glass Starfish', 'Tangled Seaweed Patch', ('6', 'D'), 'Orange')\n\


### PR DESCRIPTION
See discussion in #3068.  Rather than complicate the tests by making them fuzzzy, went with changing the test data from `"Scrimshaw Whale's Tooth"` to  `'Scrimshawed Whale Tooth'`.

- [x] Updated test data in `tuples_test.py`
- [x] Updated Treasure Table in `instructions.py`
- [x] Changed hints.py for clarity.  