### PR TITLE
Correct config.json link to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This repository uses the [MIT License](/LICENSE).
 [being-a-good-community-member]: https://github.com/exercism/docs/tree/main/community/good-member
 [chestertons-fence]: https://github.com/exercism/docs/blob/main/community/good-member/chestertons-fence.md
 [concept-exercises]: https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md
-[config-json]: https://github.com/exercism/javascript/blob/main/config.json
+[config-json]: https://github.com/exercism/python/blob/main/config.json
 [contributing-guidelines]: https://github.com/exercism/python/blob/main/CONTRIBUTING.md
 [exercise-presentation]: https://github.com/exercism/docs/blob/main/building/tracks/presentation.md
 [exercism-admins]: https://github.com/exercism/docs/blob/main/community/administrators.md


### PR DESCRIPTION
Changed link to config.json to point at the python track config instead of the JavaScript track  config.