### PR TITLE
[Twelve Days]: Corrected Markdown Header Tags in `hints.md` File

### DIFF
--- a/exercises/practice/twelve-days/.docs/hints.md
+++ b/exercises/practice/twelve-days/.docs/hints.md
@@ -1,18 +1,18 @@
 # Hints
 
-# General
+## General
 
 Have you tried to break your logic up into one or more helper functions?
 This type of song is known as a [cumulative song][cumulative song], so it could be particularly well suited to being "broken up".
 Doing so may make your code easier to reason about and will conform to the [Single Responsibility Principle][Single Responsibility Principle].
 
-# Approaches
+## Approaches
 
-## Looping
+### Looping
 
 To learn about the ways to loop in Python, please see [loops](https://exercism.org/tracks/python/concepts/loops).
 
-## Recursion
+### Recursion
 
 To learn about using recursion in Python you can start with [python-programming: recursion][python-programming: recursion], [Real Python: python-recursion][Real Python: python-recursion], or [Real Python: python-thinking-recursively][Real Python: python-thinking-recursively].
 


### PR DESCRIPTION
Tagging @exercism/reviewers  since bobahop is traveling for the next week+.

The `hints.md` file for this exercise was getting cut off in the UI due to having multiple top-level headers (see the `hints.md` file as intended [here](https://github.com/exercism/python/blob/main/exercises/practice/twelve-days/.docs/hints.md)):


![image](https://user-images.githubusercontent.com/5923094/176052664-dedcdaa3-fb40-49c5-bedd-ab8909b06941.png)


This PR should fix that.