### PR TITLE
Fixed docstring on the score() function

### DIFF
--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
@@ -15,7 +15,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 def score(touching_power_pellet, touching_dot):
     """Verify that Pac-Man has scored when a power pellet or dot has been eaten.
 
-    :param touching_power_pellet: bool - does the player have an active power pellet?
+    :param touching_power_pellet: bool - is the player touching a power pellet?
     :param touching_dot: bool - is the player touching a dot?
     :return: bool - has the player scored or not?
     """


### PR DESCRIPTION
Changed the touching_power_pellet param docstring on the score() function to accurately reflect the game's functionality, according to the instructions. It should be "is the player touching a power pellet?". Unless I'm missing something...