### PR TITLE
[Ghost Gobble Arcade Game] Docstring fix

### DIFF
--- a/concepts/bools/about.md
+++ b/concepts/bools/about.md
@@ -29,7 +29,7 @@ False
 True
 ```
 
-All `boolean operators` are considered lower precedence than Pythons [`comparison operators`][comparisons], such as `==`, `>`, `<`, `is` and `is not`.
+All `boolean operators` are considered lower precedence than Python's [`comparison operators`][comparisons], such as `==`, `>`, `<`, `is` and `is not`.
 
 
 ## Type Coercion and Truthiness

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/exemplar.py
@@ -15,7 +15,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 def score(touching_power_pellet, touching_dot):
     """Verify that Pac-Man has scored when a power pellet or dot has been eaten.
 
-    :param touching_power_pellet: bool - does the player have an active power pellet?
+    :param touching_power_pellet: bool - is the player touching a power pellet?
     :param touching_dot: bool - is the player touching a dot?
     :return: bool - has the player scored or not?
     """

--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game.py
@@ -15,7 +15,7 @@ def eat_ghost(power_pellet_active, touching_ghost):
 def score(touching_power_pellet, touching_dot):
     """Verify that Pac-Man has scored when a power pellet or dot has been eaten.
 
-    :param touching_power_pellet: bool - does the player have an active power pellet?
+    :param touching_power_pellet: bool - is the player touching a power pellet?
     :param touching_dot: bool - is the player touching a dot?
     :return: bool - has the player scored or not?
     """


### PR DESCRIPTION
Changed the touching_power_pellet param docstring on the score() function to accurately reflect the instructions and the param name itself. Changed from "does the player have an active power pellet" to "is the player touching a power pellet".
I've also fixed a small typo on the concepts/bools/about.md file.