### PR TITLE
blackjack: Add test with ace as first card for 'value_of_ace' function

### DIFF
--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -51,7 +51,7 @@ class BlackJackTest(unittest.TestCase):
                 ('2', '3', 11), ('3', '6', 11), ('5', '2', 11),
                 ('8', '2', 11), ('5', '5', 11), ('Q', 'A', 1),
                 ('10', '2', 1), ('7', '8', 1), ('J', '9', 1),
-                ('K', 'K', 1), ('2', 'A', 1)]
+                ('K', 'K', 1), ('2', 'A', 1), ('A', '2', 1)]
 
         for variant, (card_one, card_two, ace_value) in enumerate(data, 1):
             with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, ace_value=ace_value):


### PR DESCRIPTION
When solving this exercise, initially I was not considering that an Ace in hand would have the value of 21, so the last test was rightfully failing: `('2', 'A', 1)`:

```python
# Naive solution that doesn't check for aces.
# Fails only the last test which has an ace as card_two
def value_of_ace(card_one: str, card_two: str) -> int:
    c1 = value_of_card(card_one)
    c2 = value_of_card(card_two)
    diff = 21 - (c1 + c2)
    if diff >= 11:
        return 11

    return 1
```

A quick-fix would have been to just check if `card_two` is an ace, something like:

```python
# Checks card_two for an ace, but not card_one.
# Passes current tests but it shouldn't.
def value_of_ace(card_one: str, card_two: str) -> int:
    c1 = value_of_card(card_one)
    c2 = 11 if card_two == 'A' else value_of_card(card_two)
    diff = 21 - (c1 + c2)
    if diff >= 11:
        return 11

    return 1
```

This last solution passes the current tests, but it shouldn't, because it is not checking if the first card is an ace.

This PR adds a test where the first card is an ace, making this last solution fail the tests and forcing solutions that check for aces in both `card_one` and `card_two`.