### PR TITLE
[Python Version Upgrade]: First Pass at Upgrading Track to  use `python:3.10.6-slim`

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -53,7 +53,7 @@ jobs:
     needs: housekeeping
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10.6]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.10.6
 
     - name: Download & Install dependencies
       run: |
@@ -66,7 +66,7 @@ jobs:
       run: pip install dataclasses
 
     - name: Install pytest
-      run: pip install pytest~=7.0.1
+      run: pip install pytest~=7.1.2
 
     - name: Check exercises
       run: |

--- a/pylintrc
+++ b/pylintrc
@@ -231,7 +231,7 @@ single-line-if-stmt=yes
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=
+# no-space-check=
 
 # Maximum number of lines in a module
 max-module-lines=99999

--- a/requirements-generator.txt
+++ b/requirements-generator.txt
@@ -1,6 +1,6 @@
 black==22.3.0
 flake8==3.7.8
-Jinja2
+Jinja2~=3.1.2
 python-dateutil==2.8.1
 markupsafe==2.0.1
 tomli~=2.0.1

--- a/requirements-generator.txt
+++ b/requirements-generator.txt
@@ -1,6 +1,6 @@
 black==22.3.0
 flake8==3.7.8
-Jinja2==2.10.1
+Jinja2
 python-dateutil==2.8.1
 markupsafe==2.0.1
 tomli~=2.0.1

--- a/requirements-generator.txt
+++ b/requirements-generator.txt
@@ -3,4 +3,4 @@ flake8==3.7.8
 Jinja2==2.10.1
 python-dateutil==2.8.1
 markupsafe==2.0.1
-tomli
+tomli~=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-astroid>=2.6.5
-flake8==4.0.1
-pylint>=2.9.2
-yapf>=0.31.0
-tomli
+astroid~=2.12.2
+flake8~=5.0.4
+pylint~=2.14.5
+yapf~=0.32.0
+tomli~=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astroid~=2.12.0
+astroid<=2.12.0
 flake8~=5.0.4
 pylint~=2.14.5
 yapf~=0.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astroid~=2.12.2
+astroid~=2.12.0
 flake8~=5.0.4
 pylint~=2.14.5
 yapf~=0.32.0


### PR DESCRIPTION
**Please Note:** This PR **should not be merged** before reviewing and merging these related PRs:
- [`python-test-runner` #105](https://github.com/exercism/python-test-runner/pull/105)
- [`python-analyzer` #55](https://github.com/exercism/python-analyzer/pull/55)
- [`python-representer` #35](https://github.com/exercism/python-representer/pull/35)

The changes made here depend on the updated tooling images in the linked PRs, so those should be in place first before doing upgrades here.  Otherwise, we risk issues on the site due to missing docker images.

Potentially closes #2656 

- [x] Adjusted GH workflow to use `Python 3.10.6` for CI setup.
- [x] Adjusted GH workflow to remove Python `3.6` from version check (_it is not longer supported by the versions of PyLint and PyTest that we are using_) and added Python `3.10.6` 
- [x] Edited `.pylintrc` to omit depreciated check for whitespace, since tooling will now use `PyLint 2.14.5`, which does not support that check.
- [x] Upgraded templating to use latest version of JinJa2, which is `3.x` instead of `2.x`.  Python `3.10` has moved the `Mapping` type from `collections` to `collections.abc`, and `JinJa2 2.x` depends on `collections.Mapping`. 
- [x] Checked and pinned library versions for `requirements.txt` and `requirements-generator.txt`
- [x] Re-generated test files and checked all exercise example/exemplar files against them to see if they'd explode.