### PR TITLE
Correct PEP 515 underscore rules (Ref. issue #3159)

### DIFF
--- a/concepts/numbers/.meta/config.json
+++ b/concepts/numbers/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "There are three different types of built-in numbers: integers (\"int\"), floating-point (\"float\"), and complex (\"complex\"). Ints have arbitrary precision and floats typically have 15 decimal places of precision -- but both Int and float precision vary by host system. Complex numbers have a real and an imaginary part - each represented by floats.",
   "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007"],
-  "contributors": ["BethanyG"]
+  "contributors": ["BethanyG", "KaiAragaki"]
 }

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -84,10 +84,9 @@ As of version 3.6, Python supports the use of underscores in numerical literals 
 35000000.0
 ```
 
-Rules for using underscores as outlined in [pep 515][pep 515] are as follows:
-* Only one consecutive underscore allowed, and only between digits.
-* Multiple consecutive underscores allowed, but only between digits.
-* Multiple consecutive underscores allowed, in most positions except for the start of the literal, or special positions like after a decimal point.
+The rules for underscores are outline in [pep 515][pep 515] under 'Literal Grammar' are quite dense, but essentially boil down to:
+* Underscores can only be between two digits (not at beginning or ends of numbers, or next to signs (+/-) or decimals points)
+* No consecutive underscores
 
 [arbitrary-precision]: https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic#:~:text=In%20computer%20science%2C%20arbitrary%2Dprecision,memory%20of%20the%20host%20system.
 [numeric-type-docs]: https://docs.python.org/3/library/stdtypes.html#typesnumeric


### PR DESCRIPTION
Corrected underscore rules in concept introduction.

Of the four files checked (concept introduction and about, exercise introduction and instructions) only one file needed to be fixed. Since only the concept was changed, contribution was only added to the concept.

I searched through the repo to determine if it came up anywhere else - later exercises, for instance - but that appears not to be the case.
