### PR TITLE
[Currency Exchange] Improve the `int`/`float` usage consistency

### DIFF
--- a/exercises/concept/currency-exchange/.docs/hints.md
+++ b/exercises/concept/currency-exchange/.docs/hints.md
@@ -24,7 +24,12 @@
 
   **Note:** The `//` operator also does floor division. But, if the operand has `float`, the result is still `float`.
 
-## 5. Calculate value after exchange
+## 5. Calculate leftover after exchanging into bills
+
+- You need to find the remainder of `budget` that does not equal a whole `denomination`.
+- Modulo operator `%` finds the remainder.
+
+## 6. Calculate value after exchange
 
 - You need to calculate `spread` percent of `exchange_rate` using multiplication operator and add it to `exchange_rate` to get the exchanged currency.
 - The actual rate needs to be computed. Remember to add exchange rate and exchange fee.

--- a/exercises/concept/currency-exchange/.docs/hints.md
+++ b/exercises/concept/currency-exchange/.docs/hints.md
@@ -27,7 +27,7 @@
 ## 5. Calculate leftover after exchanging into bills
 
 - You need to find the remainder of `budget` that does not equal a whole `denomination`.
-- Modulo operator `%` finds the remainder.
+- The Modulo operator `%` can help find the remainder.
 
 ## 6. Calculate value after exchange
 

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -62,7 +62,19 @@ Effectively, you are rounding _down_ to the nearest whole bill/denomination.
 25
 ```
 
-## 5. Calculate value after exchange
+## 5. Calculate leftover after exchanging into bills
+
+Create the `get_leftover_of_bills()` function, taking `budget` and `denomination`.
+
+This function should return the _leftover amount_ that cannot be exchanged from your _budget_ given the denomination of bills.
+It is very important to know how much exactly the booth gets to keep.
+
+```python
+>>> get_leftover_of_bills(127.5, 20)
+7.5
+```
+
+## 6. Calculate value after exchange
 
 Create the `exchangeable_value()` function, taking `budget`, `exchange_rate`, `spread`, and `denomination`.
 
@@ -80,22 +92,4 @@ Remember that the currency *denomination* is a whole number, and cannot be sub-d
 80
 >>> exchangeable_value(127.25, 1.20, 10, 5)
 95
-```
-
-## 6. Calculate non-exchangeable value
-
-Create the `non_exchangeable_value()` function, taking `budget`, `exchange_rate`, `spread`, and `denomination`.
-
-This function should return the value that is *not* exchangeable due to the *denomination* of the bills.
-Remember - this booth gets to keep the change _in addition_ to charging an exchange fee.
-Start by calculating the value you would receive if you were able to keep subdivided bills, then subtract the amount you would receive in whole bills.
-Both amounts should take the spread, or the exchange fee into account.
-
-**Note:** Returned value should be `int` type.
-
-```python
->>> non_exchangeable_value(127.25, 1.20, 10, 20)
-16
->>> non_exchangeable_value(127.25, 1.20, 10, 5)
-1
 ```

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -67,7 +67,7 @@ Effectively, you are rounding _down_ to the nearest whole bill/denomination.
 Create the `get_leftover_of_bills()` function, taking `budget` and `denomination`.
 
 This function should return the _leftover amount_ that cannot be exchanged from your _budget_ given the denomination of bills.
-It is very important to know how much exactly the booth gets to keep.
+It is very important to know exactly how much the booth gets to keep.
 
 ```python
 >>> get_leftover_of_bills(127.5, 20)

--- a/exercises/concept/currency-exchange/.meta/config.json
+++ b/exercises/concept/currency-exchange/.meta/config.json
@@ -2,6 +2,7 @@
   "blurb": "Learn about numbers by solving Chandler's currency exchange conundrums.",
   "icon": "hyperia-forex",
   "authors": ["Ticktakto", "Yabby1997", "limm-jk", "OMEGA-Y", "wnstj2007", "J08K"],
+  "contributors": ["pranasziaukas"],
   "files": {
     "solution": ["exchange.py"],
     "test": ["exchange_test.py"],

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -13,7 +13,7 @@ def get_change(budget, exchanging_value):
     """
 
     :param budget: float - amount of money you own.
-    :param exchanging_value: int - amount of your money you want to exchange now.
+    :param exchanging_value: float - amount of your money you want to exchange now.
     :return: float - amount left of your starting currency after exchanging.
     """
 
@@ -24,11 +24,11 @@ def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int amount of bills you received.
+    :param number_of_bills: int - amount of bills you received.
     :return: int - total value of bills you now have.
     """
 
-    return number_of_bills * denomination
+    return denomination * number_of_bills
 
 
 def get_number_of_bills(budget, denomination):
@@ -39,7 +39,18 @@ def get_number_of_bills(budget, denomination):
     :return: int - number of bills after exchanging all your money.
     """
 
-    return int(budget / denomination)
+    return int(budget) // denomination
+
+
+def get_leftover_of_bills(budget, denomination):
+    """
+
+    :param budget: float - the amount of money you are planning to exchange.
+    :param denomination: int - the value of a single bill.
+    :return: float - the leftover amount that cannot be exchanged given the current denomination.
+    """
+
+    return budget % denomination
 
 
 def exchangeable_value(budget, exchange_rate, spread, denomination):
@@ -53,22 +64,7 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     """
 
     exchange_fee = (exchange_rate / 100) * spread
-    actual_rate = exchange_rate + exchange_fee
-    exchangeable_amount = int((budget / actual_rate) / denomination)
-    return exchangeable_amount * denomination
-
-
-def non_exchangeable_value(budget, exchange_rate, spread, denomination):
-    """
-
-    :param budget: float - amount of money you are planning to exchange.
-    :param exchange_rate: float - unit value of the foreign currency.
-    :param spread: int - the percentage taken as an exchange fee.
-    :param denomination:  int - the value of a single bill.
-    :return: int - the value that cannot be exchanged, due to the denomination.
-    """
-
-    exchange_fee = (exchange_rate / 100) * spread
-    actual_rate = exchange_rate + exchange_fee
-    non_exchangeable_amount = int((budget / actual_rate) % denomination)
-    return non_exchangeable_amount
+    exchange_value = exchange_money(budget, exchange_rate + exchange_fee)
+    number_of_bills = get_number_of_bills(exchange_value, denomination)
+    value_of_bills = get_value_of_bills(denomination, number_of_bills)
+    return value_of_bills

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -13,7 +13,7 @@ def get_change(budget, exchanging_value):
     """
 
     :param budget: float - amount of money you own.
-    :param exchanging_value: int - amount of your money you want to exchange now.
+    :param exchanging_value: float - amount of your money you want to exchange now.
     :return: float - amount left of your starting currency after exchanging.
     """
 
@@ -42,6 +42,17 @@ def get_number_of_bills(budget, denomination):
     pass
 
 
+def get_leftover_of_bills(budget, denomination):
+    """
+
+    :param budget: float - the amount of money you are planning to exchange.
+    :param denomination: int - the value of a single bill.
+    :return: float - the leftover amount that cannot be exchanged given the current denomination.
+    """
+
+    pass
+
+
 def exchangeable_value(budget, exchange_rate, spread, denomination):
     """
 
@@ -50,19 +61,6 @@ def exchangeable_value(budget, exchange_rate, spread, denomination):
     :param spread: int - percentage that is taken as an exchange fee.
     :param denomination: int - the value of a single bill.
     :return: int - maximum value you can get.
-    """
-
-    pass
-
-
-def non_exchangeable_value(budget, exchange_rate, spread, denomination):
-    """
-
-    :param budget: float - the amount of your money you are planning to exchange.
-    :param exchange_rate: float - the unit value of the foreign currency.
-    :param spread: int - percentage that is taken as an exchange fee.
-    :param denomination: int - the value of a single bill.
-    :return: int non-exchangeable value.
     """
 
     pass

--- a/exercises/concept/currency-exchange/exchange_test.py
+++ b/exercises/concept/currency-exchange/exchange_test.py
@@ -5,20 +5,20 @@ from exchange import (
     get_change,
     get_value_of_bills,
     get_number_of_bills,
-    exchangeable_value,
-    non_exchangeable_value)
+    get_leftover_of_bills,
+    exchangeable_value)
 
 
 class CurrencyExchangeTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_exchange_money(self):
-        input_data = [(100000, 0.84), (700000, 10.1)]
-        output_data = [119047, 69306]
+        input_data = [(100000, 0.8), (700000, 10.0)]
+        output_data = [125000, 70000]
 
         for variant, (input_data, output_data) in enumerate(zip(input_data, output_data), start=1):
             with self.subTest(f"variation #{variant}", input_data=input_data, output_data=output_data):
-                self.assertEqual(int(exchange_money(input_data[0], input_data[1])), output_data)
+                self.assertAlmostEqual(exchange_money(input_data[0], input_data[1]), output_data)
 
     @pytest.mark.task(taskno=2)
     def test_get_change(self):
@@ -27,7 +27,7 @@ class CurrencyExchangeTest(unittest.TestCase):
 
         for variant, (input_data, output_data) in enumerate(zip(input_data, output_data), start=1):
             with self.subTest(f"variation #{variant}", input_data=input_data, output_data=output_data):
-                self.assertEqual(get_change(input_data[0], input_data[1]), output_data)
+                self.assertAlmostEqual(get_change(input_data[0], input_data[1]), output_data)
 
     @pytest.mark.task(taskno=3)
     def test_get_value_of_bills(self):
@@ -48,6 +48,15 @@ class CurrencyExchangeTest(unittest.TestCase):
                 self.assertEqual(get_number_of_bills(input_data[0], input_data[1]), output_data)
 
     @pytest.mark.task(taskno=5)
+    def test_get_leftover_of_bills(self):
+        input_data = [(10.1, 10), (654321.0, 5), (3.14, 2)]
+        output_data = [0.1, 1.0, 1.14]
+
+        for variant, (input_data, output_data) in enumerate(zip(input_data, output_data), start=1):
+            with self.subTest(f"variation #{variant}", input_data=input_data, output_data=output_data):
+                self.assertAlmostEqual(get_leftover_of_bills(input_data[0], input_data[1]), output_data)
+
+    @pytest.mark.task(taskno=6)
     def test_exchangeable_value(self):
         inputs = [
             (100000, 10.61, 10, 1),
@@ -61,17 +70,3 @@ class CurrencyExchangeTest(unittest.TestCase):
         for variant, (inputs, output_data) in enumerate(zip(inputs, output_data), start=1):
             with self.subTest(f"variation #{variant}", inputs=inputs, output_data=output_data):
                 self.assertEqual(exchangeable_value(inputs[0], inputs[1], inputs[2], inputs[3]), output_data)
-
-    @pytest.mark.task(taskno=6)
-    def test_non_exchangeable_value(self):
-        inputs = [
-            (100000, 10.61, 10, 1),
-            (1500, 0.84, 25, 40),
-            (425.33, 0.0009, 30, 700),
-            (12000, 0.0096, 10, 50)]
-
-        output_data = [0, 28, 229, 13]
-
-        for variant, (inputs, output_data) in enumerate(zip(inputs, output_data), start=1):
-            with self.subTest(f"variation #{variant}", inputs=inputs, output_data=output_data):
-                self.assertEqual(non_exchangeable_value(inputs[0], inputs[1], inputs[2], inputs[3]), output_data)


### PR DESCRIPTION
Fixes #3157 and is somewhat discussed there.

Basically, what I ended up doing is:
- Added a new task asking to implement `get_leftover_of_bills`, which encourages using modulo operator `%`.
- Removed task 6, which was a weird semi-duplicate of task 5 (and also potentially hinted at using `%`).

Also, along the way:
- Tried to make `int` and `float` usage more intuitive.
- Used `assertAlmostEqual` method to compare floating point values in tests.
- Modified some test values to improve the variety of cases being tested.