### PR TITLE
Add Prerequisite to Gigasecond

### DIFF
--- a/config.json
+++ b/config.json
@@ -431,7 +431,7 @@
         "name": "Gigasecond",
         "uuid": "22606e91-57f3-44cf-ab2d-94f6ee6402e8",
         "practices": [],
-        "prerequisites": [],
+        "prerequisites": ["classes"],
         "difficulty": 1
       },
       {


### PR DESCRIPTION
Added "classes" as a prerequisite for `Gigasecond` so that it will not unlock until a student has completed all the existing learning exercises for the track (currently, the last concept in the syllabus is "classes").   

Hopefully, this avoids confusion and frustration as expressed by user @GKotfis in gitter:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/5923094/189358503-3e229bec-555c-435c-a32b-8e2b0f9ebb15.png">
