### PR TITLE
Fix bad assertion in DiffieHellmanTest

### DIFF
--- a/exercises/practice/diffie-hellman/.meta/template.j2
+++ b/exercises/practice/diffie-hellman/.meta/template.j2
@@ -13,10 +13,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         for prime in [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]:
             with self.subTest(f"prime={prime}"):
                 key = private_key(prime)
-                self.assertTrue(
-                    1 < key < prime,
-                    msg=f"{key} out of range, expected to be >1 and <{prime}"
-                )
+                self.assertTrue(1 < key < prime, msg=f"{key} out of range, expected to be >1 and <{prime}") # fmt: skip
     {%- elif property == "private_key_is_random" %}
         """
         Can fail due to randomness, but most likely will not,

--- a/exercises/practice/diffie-hellman/.meta/template.j2
+++ b/exercises/practice/diffie-hellman/.meta/template.j2
@@ -10,8 +10,13 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% set input = case['input'] %}
     def test_{{ description }}(self):
     {%- if property == "private_key_is_in_range" %}
-        primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
-        self.assertTrue(1 < private_key(p) < p for p in primes)
+        for prime in [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]:
+            with self.subTest(f"prime={prime}"):
+                key = private_key(prime)
+                self.assertTrue(
+                    1 < key < prime,
+                    msg=f"{key} out of range, expected to be >1 and <{prime}"
+                )
     {%- elif property == "private_key_is_random" %}
         """
         Can fail due to randomness, but most likely will not,

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -14,10 +14,7 @@ class DiffieHellmanTest(unittest.TestCase):
         for prime in [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]:
             with self.subTest(f"prime={prime}"):
                 key = private_key(prime)
-                self.assertTrue(
-                    1 < key < prime,
-                    msg=f"{key} out of range, expected to be >1 and <{prime}",
-                )
+                self.assertTrue(1 < key < prime, msg=f"{key} out of range, expected to be >1 and <{prime}")  # fmt: skip
 
     def test_private_key_is_random(self):
         """

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -11,8 +11,13 @@ from diffie_hellman import (
 
 class DiffieHellmanTest(unittest.TestCase):
     def test_private_key_is_greater_than_1_and_less_than_p(self):
-        primes = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
-        self.assertTrue(1 < private_key(p) < p for p in primes)
+        for prime in [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]:
+            with self.subTest(f"prime={prime}"):
+                key = private_key(prime)
+                self.assertTrue(
+                    1 < key < prime,
+                    msg=f"{key} out of range, expected to be >1 and <{prime}",
+                )
 
     def test_private_key_is_random(self):
         """


### PR DESCRIPTION
The original code passed a generator expression into the assertion, which was converted into a list prior to being evaluated for truthiness.

Even if all the values in the generator are False, the assertion will check whether `[False, False, False, ...]` is truthy, which it is.

I can't see how this test can ever have failed.

The most obvious solution is to have one assertion for each case that we want to test.

We could fix this by using `all()` around the generator expression, but I don't feel that's good style in tests. We want feedback about what failed, so I've used `subTest()` which is is used in other exercises.