### PR TITLE
[Tree Building] swap parent_id and record_id in the exception message according to the task instruction

### DIFF
--- a/exercises/practice/tree-building/.meta/example.py
+++ b/exercises/practice/tree-building/.meta/example.py
@@ -18,7 +18,7 @@ def validate_record(record):
         raise ValueError('Only root should have equal record and parent id.')
 
     if not record.equal_id() and record.parent_id >= record.record_id:
-        raise ValueError("Node record_id should be smaller than it's parent_id.")
+        raise ValueError("Node parent_id should be smaller than it's record_id.")
 
 
 def BuildTree(records):

--- a/exercises/practice/tree-building/tree_building_test.py
+++ b/exercises/practice/tree-building/tree_building_test.py
@@ -111,7 +111,7 @@ class TreeBuildingTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             BuildTree(records)
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Node record_id should be smaller than it's parent_id.")
+        self.assertEqual(err.exception.args[0], "Node parent_id should be smaller than it's record_id.")
 
     def test_no_root_node(self):
         records = [
@@ -167,7 +167,7 @@ class TreeBuildingTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             BuildTree(records)
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Node record_id should be smaller than it's parent_id.")
+        self.assertEqual(err.exception.args[0], "Node parent_id should be smaller than it's record_id.")
 
     def test_higher_id_parent_of_lower_id(self):
         records = [
@@ -179,7 +179,7 @@ class TreeBuildingTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             BuildTree(records)
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "Node record_id should be smaller than it's parent_id.")
+        self.assertEqual(err.exception.args[0], "Node parent_id should be smaller than it's record_id.")
 
     def assert_node_is_branch(self, node, node_id, children_count):
         self.assertEqual(node.node_id, node_id)


### PR DESCRIPTION
From exercise's [instruction](https://github.com/exercism/problem-specifications/blob/main/exercises/tree-building/description.md) we know that 

> All records have a **parent ID lower than their own ID**, except for the root record, which has a **parent ID that's equal to its own ID**.

But the current exception message in the tests and the example code says the opposite

> Node record_id should be smaller than it's parent_id.

This could lead to misunderstanding while solving the exercise. PR fixes this by replacing parent_id with record_id and vice versa in the exception message

> Node parent_id should be smaller than it's record_id.