### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 ![Exercism_II](https://img.shields.io/badge/Exercism--Built-9101FF?logo=python&logoColor=FFDF58&labelColor=3D7AAB&label=Python-Powered)
 [![Build Status](https://github.com/exercism/python/workflows/Exercises%20check/badge.svg)](https://github.com/exercism/python/actions?query=workflow%3A%22Exercises+check%22)
-[![Join the chat at https://gitter.im/exercism/python](https://badges.gitter.im/exercism/python.svg)](https://gitter.im/exercism/python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 <br>
 

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -6,12 +6,10 @@ Below are some resources for getting help if you run into trouble:
 - [Python Community on Discord](https://pythondiscord.com/) is a very helpful and active community.
 - [/r/learnpython/](https://www.reddit.com/r/learnpython/) is a subreddit designed for Python learners.
 - [#python on Libera.chat](https://www.python.org/community/irc/) this is where the core developers for the language hang out and get work done.
-- [**Exercism on Gitter**](https://gitter.im/exercism/home) join the Python room for Python-related questions or problems.
 - [Python Community Forums](https://discuss.python.org/)
 - [Free Code Camp Community Forums](https://forum.freecodecamp.org/)
 - [CodeNewbie Community Help Tag](https://community.codenewbie.org/t/help)
 - [Pythontutor](http://pythontutor.com/) for stepping through small code snippets visually.
-
 
 Additionally, [StackOverflow](http://stackoverflow.com/questions/tagged/python) is a good spot to search for your problem/question to see if it has been answered already.
  If not - you can always [ask](https://stackoverflow.com/help/how-to-ask) or [answer](https://stackoverflow.com/help/how-to-answer) someone else's question.


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
