### PR TITLE
[Cater Waiter] Correct type in docstring

### DIFF
--- a/exercises/concept/cater-waiter/sets.py
+++ b/exercises/concept/cater-waiter/sets.py
@@ -43,7 +43,7 @@ def categorize_dish(dish_name, dish_ingredients):
     """Categorize `dish_name` based on `dish_ingredients`.
 
     :param dish_name: str - dish to be categorized.
-    :param dish_ingredients: list - ingredients for the dish.
+    :param dish_ingredients: set - ingredients for the dish.
     :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).


### PR DESCRIPTION
The function categorize_dish has parameter `dish_ingredients` which is supposed to be a [set](https://github.com/exercism/python/blob/main/exercises/concept/cater-waiter/.docs/instructions.md#3-categorize-dishes) according to README file:

>  Implement the categorize_dish(<dish_name>, <dish_ingredients>) function that takes a dish name and a set of that dish's' ingredients.

This is also evident when launching the tests with a debugger