### PR TITLE
Fixed typo in Task 4 example

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -98,7 +98,7 @@ Re-format the coordinate as needed for accurate comparison.
 >>> create_record(('Brass Spyglass', '4B'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
 ('Brass Spyglass', '4B', 'Abandoned Lighthouse', ('4', 'B'), 'Blue')
 
->>> create_record(('Brass Spyglass', '4B'), (('1', 'C'), 'Seaside Cottages', 'blue'))
+>>> create_record(('Brass Spyglass', '4B'), ('Seaside Cottages', ('1', 'C'), 'blue'))
 "not a match"
 ```
 


### PR DESCRIPTION
Resolves issue #3196 

## Changes

- Fixed the type in the Task 4 example to reflect what is actually passed to the function.