### PR TITLE
Sync exercise metadata with problem-specifications

### DIFF
--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -21,5 +21,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"
+  "source_url": "https://en.wikipedia.org/wiki/Affine_cipher"
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -30,6 +30,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "Jumpstart Lab Warm-up",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -29,5 +29,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Atbash"
+  "source_url": "https://en.wikipedia.org/wiki/Atbash"
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -26,5 +26,5 @@
     ]
   },
   "source": "Learn to Program by Chris Pine",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -31,5 +31,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"
+  "source_url": "https://en.wikipedia.org/wiki/Binary_search_algorithm"
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -43,5 +43,5 @@
     ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -28,5 +28,5 @@
     ]
   },
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
-  "source_url": "http://cyber-dojo.org"
+  "source_url": "https://cyber-dojo.org"
 }

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -23,5 +23,5 @@
     ]
   },
   "source": "The Bowling Game Kata from UncleBob",
-  "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
+  "source_url": "https://web.archive.org/web/20221001111000/http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -26,5 +26,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"
+  "source_url": "https://en.wikipedia.org/wiki/Circular_buffer"
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -30,5 +30,5 @@
     ]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "https://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -26,5 +26,5 @@
     ]
   },
   "source": "Seb Rose",
-  "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"
+  "source_url": "https://web.archive.org/web/20220807163751/http://claysnow.co.uk/recycling-tests-in-tdd/"
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -28,5 +28,5 @@
     ]
   },
   "source": "Problem 6 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=6"
+  "source_url": "https://projecteuler.net/problem=6"
 }

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -21,5 +21,5 @@
     ]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
-  "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"
+  "source_url": "https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -28,6 +28,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "The Jumpstart Lab team",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -22,5 +22,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"
+  "source_url": "https://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -30,5 +30,5 @@
     ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=09"
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -29,6 +29,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "JavaRanch Cattle Drive, exercise 6",
-  "source_url": "http://www.javaranch.com/grains.jsp"
+  "source": "The CodeRanch Cattle Drive, Assignment 6",
+  "source_url": "https://coderanch.com/wiki/718824/Grains"
 }

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -27,5 +27,5 @@
     ]
   },
   "source": "Conversation with Nate Foster.",
-  "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"
+  "source_url": "https://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -33,5 +33,5 @@
     ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
-  "source_url": "http://rosalind.info/problems/hamm/"
+  "source_url": "https://rosalind.info/problems/hamm/"
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -29,5 +29,5 @@
     ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
-  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+  "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -27,5 +27,5 @@
     ]
   },
   "source": "British nursery rhyme",
-  "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"
+  "source_url": "https://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"
 }

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -27,6 +27,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "Random musings during airplane trip.",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -29,5 +29,5 @@
     ]
   },
   "source": "A variation on Problem 8 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=8"
+  "source_url": "https://projecteuler.net/problem=8"
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -33,6 +33,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -35,5 +35,5 @@
     ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"
+  "source_url": "https://en.wikipedia.org/wiki/Luhn_algorithm"
 }

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -28,6 +28,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "Warmup to the `saddle-points` warmup.",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -30,5 +30,5 @@
     ]
   },
   "source": "A variation on Problem 7 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=7"
+  "source_url": "https://projecteuler.net/problem=7"
 }

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -29,5 +29,5 @@
     ]
   },
   "source": "Inspired by the Bank OCR kata",
-  "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"
+  "source_url": "https://codingdojo.org/kata/BankOCR/"
 }

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -31,5 +31,5 @@
     ]
   },
   "source": "Problem 4 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=4"
+  "source_url": "https://projecteuler.net/problem=4"
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -27,5 +27,5 @@
     ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
-  "source_url": "http://shop.oreilly.com/product/0636920029687.do"
+  "source_url": "https://www.oreilly.com/library/view/functional-thinking/9781449365509/"
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -29,6 +29,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "Event Manager by JumpstartLab",
-  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -28,5 +28,5 @@
     ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
-  "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"
+  "source_url": "https://web.archive.org/web/20221026171801/http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"
 }

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -33,5 +33,5 @@
     ]
   },
   "source": "Problem 9 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=9"
+  "source_url": "https://projecteuler.net/problem=9"
 }

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -33,5 +33,5 @@
     ]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "https://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -34,5 +34,5 @@
     ]
   },
   "source": "Hyperphysics",
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
+  "source_url": "https://web.archive.org/web/20220408112140/http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -28,5 +28,5 @@
     ]
   },
   "source": "The Roman Numeral Kata",
-  "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"
+  "source_url": "https://codingdojo.org/kata/RomanNumerals/"
 }

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -36,5 +36,5 @@
     ]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "https://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
 }

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -29,6 +29,6 @@
       ".meta/example.py"
     ]
   },
-  "source": "A variation on JavaRanch CattleDrive, exercise 4a",
-  "source_url": "http://www.javaranch.com/say.jsp"
+  "source": "A variation on the JavaRanch CattleDrive, Assignment 4",
+  "source_url": "https://coderanch.com/wiki/718804"
 }

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -31,5 +31,5 @@
     ]
   },
   "source": "Bert, in Mary Poppins",
-  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
+  "source_url": "https://www.imdb.com/title/tt0058331/quotes/qt0437047"
 }

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -28,5 +28,5 @@
     ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=8"
+  "source_url": "https://projecteuler.net/problem=8"
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -30,5 +30,5 @@
     ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"
+  "source_url": "https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"
 }

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -32,5 +32,5 @@
     ]
   },
   "source": "Substitution Cipher at Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"
+  "source_url": "https://en.wikipedia.org/wiki/Substitution_cipher"
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -29,5 +29,5 @@
     ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=01"
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -32,5 +32,5 @@
     ]
   },
   "source": "A variation on Problem 1 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=1"
+  "source_url": "https://projecteuler.net/problem=1"
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -32,5 +32,5 @@
     ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
-  "source_url": "http://rubykoans.com"
+  "source_url": "https://web.archive.org/web/20220831105330/http://rubykoans.com"
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -27,5 +27,5 @@
     ]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"
+  "source_url": "https://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"
 }

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -26,5 +26,5 @@
     ]
   },
   "source": "Water Pouring Problem",
-  "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"
+  "source_url": "https://demonstrations.wolfram.com/WaterPouringProblem/"
 }


### PR DESCRIPTION
This syncs all the metadata for all the practice exercises with
upstream changes in problem-specifications, in one fell swoop.

The changes are all nitpicky changes made in order to ensure that
source urls all use https rather than http, along with some
tweaks to better describe the source of certain exercises.

If you have a different preferred process for `configlet`-related changes,
feel free to close this. If so, and if it's not too much trouble, please point me
in the right direction, and I will happily follow it. Or I can stay out of your way and
just let you get on with things :-) 💙 