### PR TITLE
fix types in fix_wagon_depot

### DIFF
--- a/exercises/concept/locomotive-engineer/.meta/exemplar.py
+++ b/exercises/concept/locomotive-engineer/.meta/exemplar.py
@@ -49,8 +49,8 @@ def extend_route_information(route, more_route_information):
 def fix_wagon_depot(wagons_rows):
     """Fix the list of rows of wagons.
 
-    :param wagons_rows: list[tuple] - the list of rows of wagons.
-    :return: list[tuple] - list of rows of wagons.
+    :param wagons_rows: list[list[tuple]] - the list of rows of wagons.
+    :return: list[list[tuple]] - list of rows of wagons.
     """
 
     [*row_one], [*row_two], [*row_three] = zip(*wagons_rows)

--- a/exercises/concept/locomotive-engineer/locomotive_engineer.py
+++ b/exercises/concept/locomotive-engineer/locomotive_engineer.py
@@ -48,7 +48,7 @@ def extend_route_information(route, more_route_information):
 def fix_wagon_depot(wagons_rows):
     """Fix the list of rows of wagons.
 
-    :param wagons_rows: list[tuple] - the list of rows of wagons.
-    :return: list[tuple] - list of rows of wagons.
+    :param wagons_rows: list[list[tuple]] - the list of rows of wagons.
+    :return: list[list[tuple]] - list of rows of wagons.
     """
     pass


### PR DESCRIPTION
Change  types of the parameters in the fix_wagon_depot function from list[tuple] to list[list[tuple]] according to the [instructions](https://github.com/exercism/python/blob/main/exercises/concept/locomotive-engineer/.docs/instructions.md#5-fix-the-wagon-depot)

`Implement a function called fix_wagon_depot() that accepts a list of three items. Each list item is a sublist (or "row") that contains three tuples. Each tuple is a (<wagon ID>, <wagon color>) pair.`

Before fix:
```
    :param wagons_rows: list[tuple] - the list of rows of wagons.
    :return: list[tuple] - list of rows of wagons.
```

After fix:
```
    :param wagons_rows: list[list[tuple]] - the list of rows of wagons.
    :return: list[list[tuple]] - list of rows of wagons.
```