### PR TITLE
Fail closed on pause contributions workflow

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -30,7 +30,7 @@ jobs:
               org: context.repo.owner,
               username: context.actor,
             }).then(response => response.status == 204)
-              .catch(err => true);
+              .catch(err => false);
       - name: Comment
         if: steps.is-organization-member.outputs.result == 'false'
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0


### PR DESCRIPTION
In the original workflow, I had `catch(err) => false`.

But during code review the question was raised:
What happens if we get rate limited and all the requests from the API fail?
(E.g. if we do a script and automatically create PRs across all of Exercism, which is totally a thing).

We were like: ooh, that would suck, wouldn’t it? It would be better if we occasionally had to deal with manually closing a PR.
But here’s the kicker. The API response has no body. It’s either 204 or 404, where 404 is perceived as… an error.

So I changed it, and (importantly) forgot to test the script one final time.

So here is a version that will actually work. (I tested.)
