### PR TITLE
Update about.md

### DIFF
--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -170,7 +170,7 @@ This means calculations within `()` have the highest priority, followed by `**`,
 20
 
 # In the following example, the `**` operator has the highest priority, then `*`, then `+`
-# Meaning we first do 4 ** 4, then 3 * 64, then 2 + 192
+# Meaning we first do 4 ** 4, then 3 * 256, then 2 + 768
 >>> 2 + 3 * 4 ** 4
 770
 ```


### PR DESCRIPTION
In the explanation of Priority and parenthesis there was a spelling mistake, in the example it is 4 ** 4 which is equal to 256 not 64, but in the example it said that it is 3 * 64 and it should be 3 * 256, which also causes an error in the sum, placing that it is 2 + 192 instead of 2 + 768.