### PR TITLE
Improve test for Ellen's Alien game

### DIFF
--- a/exercises/concept/ellens-alien-game/classes_test.py
+++ b/exercises/concept/ellens-alien-game/classes_test.py
@@ -142,7 +142,7 @@ class ClassesTest(unittest.TestCase):
         obj_list = new_aliens_collection(position_data)
         obj_error = "new_aliens_collection must return a list of Alien objects."
 
-        for obj, position in zip(obj_list, position_data):
+        for obj, position in zip(obj_list, position_data, strict=True):
             self.assertIsInstance(obj, Alien, msg=obj_error)
 
             pos_error = (


### PR DESCRIPTION
The test is using a zip iterator from the expected input
`position_data` and output, `obj_list`, returned by the
user's new_aliens_collection implementation.

However the zip is not Strict, meaning that if the user provided
a list with less objects than the expected output, the test would
still pass. For example: `return [Alien(x,y)]`.

Call the zip() function with the strict argument, so that it will
error out if the `obj_list` doesn't match the length of the
`position_data`.
