### PR TITLE
little-sisters-vocab: update test cases

### DIFF
--- a/exercises/concept/little-sisters-vocab/strings_test.py
+++ b/exercises/concept/little-sisters-vocab/strings_test.py
@@ -75,14 +75,14 @@ class LittleSistersVocabTest(unittest.TestCase):
     @pytest.mark.task(taskno=4)
     def test_adjective_to_verb(self):
         input_data = ['Look at the bright sky.',
-                      'His expression went dark.',
+                      'His expression went dark!',
                       'The bread got hard after sitting out.',
                       'The butter got soft in the sun.',
                       'Her eyes were light blue.',
                       'The morning fog made everything damp with mist.',
                       'He cut the fence pickets short by mistake.',
                       'Charles made weak crying noises.',
-                      'The black oil got on the white dog.']
+                      'The black, cooking oil got on the white dog.']
         index_data = [-2, -1, 3, 3, -2, -3, 5, 2, 1]
         result_data = ['brighten', 'darken', 'harden', 'soften',
                        'lighten', 'dampen', 'shorten', 'weaken', 'blacken']


### PR DESCRIPTION
Add punctuations other than period. For example, words that end with exclamation mark, or have a trailing comma should be cleaned before verbifying as well.

To this end, I've added one word to the last test (i.e. cooking) that follows the logic stated in grammarbook.com [1], also, replaced an ending period with exclamation mark.

[1] https://www.grammarbook.com/blog/commas/arranging-multiple-adjectives/