### PR TITLE
[Rotational Cipher Approaches] Msc link, punctuation, & formatting fixes.

### DIFF
--- a/exercises/practice/rotational-cipher/.approaches/alphabet/content.md
+++ b/exercises/practice/rotational-cipher/.approaches/alphabet/content.md
@@ -22,7 +22,7 @@ The function `rotate()` is then declared, and a variable `result` is defined as 
 The text argument is then iterated over via a [`for loop`][for-loop].
 Each element is checked to make sure it is a letter, and subsequently checked if it is uppercase or lowercase.
 Uppercase letters are converted to lowercase.
-Then index of each letter is found in the `AlPHABET` constant.
+Then the index of each letter is found in the `AlPHABET` constant.
 The numeric key value is added to the letter index and [modulo (`%`)][modulo] 26 is used on the result.
 Finally, the new number is used as an index into the `AlPHABET` constant, and the resulting letter is converted back to uppercase.
 

--- a/exercises/practice/rotational-cipher/.approaches/ascii-values/content.md
+++ b/exercises/practice/rotational-cipher/.approaches/ascii-values/content.md
@@ -26,24 +26,24 @@ While the uppercase letters are in the range between 65 and 91.
 
 This approach only supports the English alphabet.
 Non-English alphabets are not contiguous in their ascii number ranges, and are not consistently defined across platforms.
-For example, the Scandinavian letter: **å** has the extended ascii value of 132, but is used in combination with Latin characters that appear in the 65-91 and 97-123 ranges.
+For example, the Scandinavian letter **å** has the extended ascii value of **134**, but is used in combination with Latin-1  characters that appear in the 65-91 and 97-123 ranges.
 This means that a shift for an extended ascii word containing **å** won't result in an accurate alphabet position for a Scandinavian language.
 
 ~~~~
 
 The approach starts with defining the function `rotate()`, with a variable `result` is assigned to an empty string.
 The elements of the text argument are then iterated over using a [`for loop`][for-loop].
-Each element is checked to see if it is a letter, and then is checked if it is an uppercase letter.
+Each element is checked to see if it is a letter, and if it is a lower or uppercase letter.
 
 Python has a builtin function called `ord` that converts a [unicode][unicode] symbol to an integer representation.
 Unicode's first 128 code points have the same numbers as their ascii counterparts.
 
 If the element is an uppercase letter, [`ord`][ord] is used to convert the letter to an integer.
 The integer is added to the numeric key and then 65 is subtracted from the total.
-Finally, the result is [modulo (%)][modulo] 26 (_to put the value within the 0-26 range_) and 65 is added back.
+Finally, the result is [modulo (%)][modulo] 26 to put the value within the 0-26 range, and 65 is added back.
 
 This is because we want to know which letter of the alphabet the number will become.
-And if the new number is over 26 we want to make sure that it "wraps around" to remain in the range of 0-26.
+If the new number is over 26 we want to make sure that it "wraps around" to remain in the range of 0-26.
 To properly use modulo for a range we have to make sure that it starts at zero, so we subtract 65.
 To get back to a letter in the ascii range we add 65 and use the [`chr`][chr] method to convert the value to a letter.
 

--- a/exercises/practice/rotational-cipher/.approaches/introduction.md
+++ b/exercises/practice/rotational-cipher/.approaches/introduction.md
@@ -99,10 +99,9 @@ A recursive function is a function that calls itself.
 This approach can be more concise than other approaches, and may also be more readable for some audiences.
 
 ~~~~exercism/caution
-Python does not have any tail-call optimization and has a default [recursion limit][recursion-limit] of 1000 calls on the stack.
+Python does not have any tail-call optimization and has a default [recursion limit](https://docs.python.org/3/library/sys.html#sys.setrecursionlimit) of 1000 calls on the stack.
 Calculate your base case carefully to avoid errors.
 
-[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit
 ~~~~
 
 

--- a/exercises/practice/rotational-cipher/.approaches/introduction.md
+++ b/exercises/practice/rotational-cipher/.approaches/introduction.md
@@ -1,12 +1,13 @@
 # Introduction
 
-There are various ways to solve `rotational-cipher`.
-You can for example use [ascii values][ascii], an alphabet `str` or `list`, recursion, or `str.translate`.
+There are various ways to solve `Rotational Cipher`.
+For example, you can use [ascii values][ascii], an alphabet `str`/`list`, recursion, or `str.translate`.
 
 ## General guidance
 
 The goal of this exercise is to shift the letters in a string by a given integer key between 0 and 26.
 The letter in the encrypted string is shifted for as many values (or "positions") as the value of the key.
+
 
 ## Approach: Using ascii values
 
@@ -18,10 +19,11 @@ The numbers 65-91 in the ascii range represent lowercase Latin letters, while 97
 
 This approach only supports the English alphabet.
 Non-English alphabets are not contiguous in their ascii number ranges, and are not consistently defined across platforms.
-For example, the Scandinavian letter: **å** has the extended ascii value of 132, but is used in combination with Latin characters that appear in the 65-91 and 97-123 ranges.
+For example, the Scandinavian letter **å** has the extended ascii value of **134**, but is used in combination with Latin-1  characters that appear in the 65-91 and 97-123 ranges.
 This means that a shift for an extended ascii word containing **å** won't result in an accurate alphabet position for a Scandinavian language.
 
 ~~~~
+
 
 ```python
 def rotate(text, key):
@@ -37,17 +39,18 @@ def rotate(text, key):
     return result
 ```
 
-For more information, check the [ascii values approach][approach-ascii-values].
+For more information, check out the [ascii values approach][approach-ascii-values].
 
 ## Approach: Alphabet
 
-This approach is similar to the ascii one, but it uses the index number of each letter in an alphabet string.
+This approach is similar to the ascii one, but it uses the index number of each letter in a defined alphabet string.
 It requires making a string for all the letters in an alphabet.
 And unless two strings are used, you will have to convert individual letters from lower to upper case (or vice-versa).
 
-The big advantage of this approach is the ability to use any alphabet (_although there are some issues with combining characters in Unicode._).
-Here, if we want to use the scandinavian letter: **å**, we can simply insert it into our string where we want it:
-`abcdefghijklmnopqrstuvwxyzå` and the rotation will work correctly.
+The big advantage of this approach is the ability to use _any_ alphabet (_although there are some issues with combining characters in Unicode._).
+Here, if we want to use the Scandinavian letter: **å**, we can simply insert it into our string where we want it:
+`abcdefghijklmnopqrstuvwxyzå` and the key rotation will work correctly.
+
 
 ```python
 # This only uses English characters
@@ -66,7 +69,7 @@ def rotate(text, key):
     return result
 ```
 
-For more information, check the [Alphabet approach][approach-alphabet].
+For more information, see the [Alphabet approach][approach-alphabet].
 
 ## Approach: Str translate
 
@@ -77,6 +80,7 @@ The benefit of this approach is that it has no visible loop, making the code mor
 `str.translate` **still loops over the `string`**  even if it is not visibly doing so.
 ~~~~
 
+
 ```python
 AlPHABET = "abcdefghijklmnopqrstuvwxyz
 
@@ -85,7 +89,8 @@ def rotate(text, key):
     return text.translate(str.maketrans(AlPHABET + AlPHABET.upper(), translator + translator.upper()))
 ```
 
-For more information, check the [Str translate approach][approach-str-translate].
+For more information, check out the [Str translate approach][approach-str-translate].
+
 
 ## Approach: Recursion
 
@@ -96,7 +101,10 @@ This approach can be more concise than other approaches, and may also be more re
 ~~~~exercism/caution
 Python does not have any tail-call optimization and has a default [recursion limit][recursion-limit] of 1000 calls on the stack.
 Calculate your base case carefully to avoid errors.
+
+[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit
 ~~~~
+
 
 ```python
 AlPHABET = "abcdefghijklmnopqrstuvwxyz"
@@ -114,11 +122,12 @@ def rotate(text, key):
         return first_letter + rotate(rest, key)
 ```
 
-For more information, check the [Recursion approach][approach-recursion].
+For more information, read the [Recursion approach][approach-recursion].
 
 ## Benchmark
 
-For more information, check the [Performance article][article-performance].
+For more information on the speed of these various approaches, check out the Rotational Cipher [Performance article][article-performance].
+
 
 [ascii]: https://en.wikipedia.org/wiki/ASCII
 [approach-recursion]: https://exercism.org/tracks/python/exercises/rotational-cipher/approaches/recursion
@@ -126,5 +135,4 @@ For more information, check the [Performance article][article-performance].
 [approach-ascii-values]: https://exercism.org/tracks/python/exercises/rotational-cipher/approaches/ascii-values
 [approach-alphabet]: https://exercism.org/tracks/python/exercises/rotational-cipher/approaches/alphabet
 [article-performance]: https://exercism.org/tracks/python/exercises/rotational-cipher/articles/performance
-[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit
 [str-translate]: https://docs.python.org/3/library/stdtypes.html?highlight=str%20translate#str.translate

--- a/exercises/practice/rotational-cipher/.approaches/introduction.md
+++ b/exercises/practice/rotational-cipher/.approaches/introduction.md
@@ -82,7 +82,7 @@ The benefit of this approach is that it has no visible loop, making the code mor
 
 
 ```python
-AlPHABET = "abcdefghijklmnopqrstuvwxyz
+AlPHABET = "abcdefghijklmnopqrstuvwxyz"
 
 def rotate(text, key):
     translator = AlPHABET[key:] + AlPHABET[:key]

--- a/exercises/practice/rotational-cipher/.approaches/recursion/content.md
+++ b/exercises/practice/rotational-cipher/.approaches/recursion/content.md
@@ -18,7 +18,7 @@ def rotate(text, key):
 
 This approach uses the same logic as that of the `alphabet` approach, but instead of a `loop`, [concept:python/recursion]() is used to parse the text and solve the problem.
 
-Recursion is a programming technique where a function calls itself.
+[Recursion][recursion] is a programming technique where a function calls itself.
 It is powerful, but can be more tricky to implement than a `while loop` or `for loop`.
 Recursive techniques are more common in functional programming languages like [Elixir][elixir], [Haskell][haskell], and [Clojure][clojure] than they are in Python.
 
@@ -28,16 +28,18 @@ Then the `rotate` function can execute the same code again with new values.
 We can build a long chain or "stack" of `<letter> + rotate(rest)` calls until the `rest` variable is exhausted and the code adds `""`.
 That translates to something like this: `<letter> + <letter> + <letter> + <letter> + ""`.
 
+
 ~~~~exercism/note
 By default, we can't have a function call itself more than 1000 times.
-Code that exceeds this recursion limit will throw a RecursionError.
-While it is possible to adjust the recursion limit, doing so risks crashing Python and may also crash your system.
+Code that exceeds this recursion limit will throw a [`RecursionError`][recursion-error].
+While it is possible to [adjust the recursion limit][recursion-limit], doing so risks crashing Python and may also crash your system.
 Casually raising the recursion limit is not recommended.
+
+[recursion-error]: https://docs.python.org/3/library/exceptions.html#RecursionError
+[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit
 ~~~~
 
 [clojure]: https://exercism.org/tracks/clojure
 [elixir]: https://exercism.org/tracks/elixir
 [haskell]: https://exercism.org/tracks/haskell
 [recursion]: https://realpython.com/python-thinking-recursively/
-[recursion-error]: https://docs.python.org/3/library/exceptions.html#RecursionError
-[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit

--- a/exercises/practice/rotational-cipher/.approaches/recursion/content.md
+++ b/exercises/practice/rotational-cipher/.approaches/recursion/content.md
@@ -31,12 +31,10 @@ That translates to something like this: `<letter> + <letter> + <letter> + <lette
 
 ~~~~exercism/note
 By default, we can't have a function call itself more than 1000 times.
-Code that exceeds this recursion limit will throw a [`RecursionError`][recursion-error].
-While it is possible to [adjust the recursion limit][recursion-limit], doing so risks crashing Python and may also crash your system.
+Code that exceeds this recursion limit will throw a [`RecursionError`](https://docs.python.org/3/library/exceptions.html#RecursionError).
+While it is possible to [adjust the recursion limit](https://docs.python.org/3/library/sys.html#sys.setrecursionlimit), doing so risks crashing Python and may also crash your system.
 Casually raising the recursion limit is not recommended.
 
-[recursion-error]: https://docs.python.org/3/library/exceptions.html#RecursionError
-[recursion-limit]: https://docs.python.org/3/library/sys.html#sys.setrecursionlimit
 ~~~~
 
 [clojure]: https://exercism.org/tracks/clojure

--- a/exercises/practice/rotational-cipher/.approaches/str-translate/content.md
+++ b/exercises/practice/rotational-cipher/.approaches/str-translate/content.md
@@ -10,7 +10,7 @@ def rotate(text, key):
 
 This approach uses the [`<str>.translate`][translate] method.
 `translate` takes a translation table as an argument.
-To create a translation table we use [str.`makestrans`][maketrans].
+To create a translation table we use [`str.makestrans`][maketrans].
 
 This approach starts with defining a constant of all the lowercase letters in the alphabet.
 Then the function `rotate()` is declared.


### PR DESCRIPTION
See [this forum post](https://forum.exercism.org/t/link-references-in-special-blocks-admonitions-are-not-rendered/3803/5) for the proposed fix for reflinks inside an admonition block. 

Fixed some other msc.  errors while reviewing the docs.