### PR TITLE
[Hello World]: Modified ImportError Message to be More Direct.

### DIFF
--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,10 +1,28 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+
+import unittest
+
+try:
+    from hello_world import (
+    hello,
+    )
+
+except ImportError as import_fail:
+    message = import_fail.args[0].split('(', maxsplit=1)
+    item_name = import_fail.args[0].split()[3]
+
+    item_name = item_name[:-1] + "()'"
+
+    # pylint: disable=raise-missing-from
+    raise ImportError("\n\nMISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the"
+    f' function named {item_name}. \nThe tests for this first exercise expect a function that'
+    f' returns the string "Hello, World!"'
+    f'\n\nDid you use print("Hello, World!") instead?') from None
+
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
     def test_{{ case["description"] | to_snake }}(self):
-        self.assertEqual({{ case["property"] }}(), "{{ case["expected"] }}")
+        msg = "\n\nThis test expects a return of the string 'Hello, World!' \nDid you use print('Hello, World!') by mistake?"
+        self.assertEqual({{ case["property"] }}(), "{{ case["expected"] }}", msg=msg)
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/hello-world/hello_world.py
+++ b/exercises/practice/hello-world/hello_world.py
@@ -1,2 +1,2 @@
-def hello():
-    return 'Goodbye, Mars!'
+print('Hello, World!')
+    #'Goodbye, Mars!'

--- a/exercises/practice/hello-world/hello_world.py
+++ b/exercises/practice/hello-world/hello_world.py
@@ -1,2 +1,2 @@
-print('Hello, World!')
-    #'Goodbye, Mars!'
+def hello():
+    return 'Goodbye, Mars!'

--- a/exercises/practice/hello-world/hello_world_test.py
+++ b/exercises/practice/hello-world/hello_world_test.py
@@ -1,16 +1,26 @@
 import unittest
 
-from hello_world import (
-    hello,
-)
+try:
+    from hello_world import (
+        hello,
+    )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+except ImportError as import_fail:
+    message = import_fail.args[0].split("(", maxsplit=1)
+    item_name = import_fail.args[0].split()[3]
+
+    item_name = item_name[:-1] + "()'"
+
+    # pylint: disable=raise-missing-from
+    raise ImportError(
+        "\n\nMISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the"
+        f" function named {item_name}. \nThe tests for this first exercise expect a function that"
+        f' returns the string "Hello, World!"'
+        f'\n\nDid you use print("Hello, World!") instead?'
+    ) from None
 
 
 class HelloWorldTest(unittest.TestCase):
     def test_say_hi(self):
-        self.assertEqual(hello(), "Hello, World!")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        msg = "\n\nThis test expects a return of the string 'Hello, World!' \nDid you use print('Hello, World!') by mistake?"
+        self.assertEqual(hello(), "Hello, World!", msg=msg)


### PR DESCRIPTION
In conjunction with [Python Test Runner #111](https://github.com/exercism/python-test-runner/pull/111), modified the template and regenerated the test file to include explicit error messages about needing a function with a `return`, and not using `print()` for "Hello, World!".

Error message will now read:

```python
ImportError:
        
       MISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the function named hello(). 
       The tests for this first exercise expect a function that returns the string "Hello, World!"
        
        Did you use print("Hello, World!") instead?

```

If the student instead uses the function but replaces `return` with `print()`, they should see the following:

```python

 def test_say_hi(self):
        msg = "\n\nThis test expects a return of the string 'Hello, World!' \nDid you use print('Hello, World!') by mistake?"
       self.assertEqual(hello(), "Hello, World!", msg=msg)
        AssertionError: None != 'Hello, World!' : 
       
        This test expects a return of the string 'Hello, World!' 
        Did you use print('Hello, World!') by mistake?

```