### PR TITLE
[JinJa2] Corrected the macro used for comments on the test file.

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -394,7 +394,7 @@ def generate(
     env.filters["zip"] = zip
     env.filters["parse_datetime"] = parse_datetime
     env.filters["escape_invalid_escapes"] = escape_invalid_escapes
-    env.globals["current_date"] = datetime.now(tz=timezone.utc)
+    env.globals["current_date"] = datetime.now(tz=timezone.utc).date()
     env.tests["error_case"] = error_case
     result = True
     for exercise in sorted(Path("exercises/practice").glob(exercise_glob)):

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -393,6 +393,7 @@ def generate(
     env.filters["zip"] = zip
     env.filters["parse_datetime"] = parse_datetime
     env.filters["escape_invalid_escapes"] = escape_invalid_escapes
+    env.globals["current_date"] = datetime.utcnow()
     env.tests["error_case"] = error_case
     result = True
     for exercise in sorted(Path("exercises/practice").glob(exercise_glob)):

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -17,12 +17,13 @@ import sys
 from githelp import Repo
 
 _py = sys.version_info
-if _py.major < 3 or (_py.major == 3 and _py.minor < 6):
-    print("Python version must be at least 3.6")
+if _py.major < 3 or (_py.major == 3 and _py.minor < 7):
+    print("Python version must be at least 3.7")
     sys.exit(1)
 
 import argparse
 from datetime import datetime
+from datetime import timezone
 import difflib
 import filecmp
 import importlib.util
@@ -393,7 +394,7 @@ def generate(
     env.filters["zip"] = zip
     env.filters["parse_datetime"] = parse_datetime
     env.filters["escape_invalid_escapes"] = escape_invalid_escapes
-    env.globals["current_date"] = datetime.utcnow()
+    env.globals["current_date"] = datetime.now(tz=timezone.utc)
     env.tests["error_case"] = error_case
     result = True
     for exercise in sorted(Path("exercises/practice").glob(exercise_glob)):

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -10,7 +10,8 @@
 {% endmacro -%}
 
 {% macro canonical_ref() -%}
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/{{ exercise }}/canonical-data.json
 {%- endmacro %}
 
 {% macro header(imports=[], ignore=[]) -%}

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -1,6 +1,8 @@
 {# Usage: {%- import "generator_macros.j2" as macros -%} #}
 {# {{ macros.linebreak(text) }} #}
 
+import datetime
+
 {%- macro linebreak(s) %}
 {%- set parts = s.split(": ") -%}
 "{{ parts[0] }}: "
@@ -12,6 +14,7 @@
 {% macro canonical_ref() -%}
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/{{ exercise }}/canonical-data.json
+# File last updated on {{ current_date }}
 {%- endmacro %}
 
 {% macro header(imports=[], ignore=[]) -%}

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -1,8 +1,6 @@
 {# Usage: {%- import "generator_macros.j2" as macros -%} #}
 {# {{ macros.linebreak(text) }} #}
 
-import datetime
-
 {%- macro linebreak(s) %}
 {%- set parts = s.split(": ") -%}
 "{{ parts[0] }}: "

--- a/exercises/practice/acronym/acronym_test.py
+++ b/exercises/practice/acronym/acronym_test.py
@@ -6,7 +6,7 @@ from acronym import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/acronym/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AcronymTest(unittest.TestCase):

--- a/exercises/practice/acronym/acronym_test.py
+++ b/exercises/practice/acronym/acronym_test.py
@@ -4,7 +4,9 @@ from acronym import (
     abbreviate,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/acronym/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AcronymTest(unittest.TestCase):

--- a/exercises/practice/affine-cipher/affine_cipher_test.py
+++ b/exercises/practice/affine-cipher/affine_cipher_test.py
@@ -5,7 +5,9 @@ from affine_cipher import (
     encode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AffineCipherTest(unittest.TestCase):

--- a/exercises/practice/affine-cipher/affine_cipher_test.py
+++ b/exercises/practice/affine-cipher/affine_cipher_test.py
@@ -7,7 +7,7 @@ from affine_cipher import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AffineCipherTest(unittest.TestCase):

--- a/exercises/practice/all-your-base/all_your_base_test.py
+++ b/exercises/practice/all-your-base/all_your_base_test.py
@@ -4,7 +4,9 @@ from all_your_base import (
     rebase,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/all-your-base/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AllYourBaseTest(unittest.TestCase):

--- a/exercises/practice/all-your-base/all_your_base_test.py
+++ b/exercises/practice/all-your-base/all_your_base_test.py
@@ -6,7 +6,7 @@ from all_your_base import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/all-your-base/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AllYourBaseTest(unittest.TestCase):

--- a/exercises/practice/allergies/allergies_test.py
+++ b/exercises/practice/allergies/allergies_test.py
@@ -4,7 +4,9 @@ from allergies import (
     Allergies,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/allergies/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AllergiesTest(unittest.TestCase):

--- a/exercises/practice/allergies/allergies_test.py
+++ b/exercises/practice/allergies/allergies_test.py
@@ -6,7 +6,7 @@ from allergies import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/allergies/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AllergiesTest(unittest.TestCase):

--- a/exercises/practice/alphametics/alphametics_test.py
+++ b/exercises/practice/alphametics/alphametics_test.py
@@ -4,7 +4,9 @@ from alphametics import (
     solve,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AlphameticsTest(unittest.TestCase):

--- a/exercises/practice/alphametics/alphametics_test.py
+++ b/exercises/practice/alphametics/alphametics_test.py
@@ -6,7 +6,7 @@ from alphametics import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AlphameticsTest(unittest.TestCase):

--- a/exercises/practice/anagram/anagram_test.py
+++ b/exercises/practice/anagram/anagram_test.py
@@ -4,7 +4,9 @@ from anagram import (
     find_anagrams,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AnagramTest(unittest.TestCase):

--- a/exercises/practice/anagram/anagram_test.py
+++ b/exercises/practice/anagram/anagram_test.py
@@ -6,7 +6,7 @@ from anagram import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AnagramTest(unittest.TestCase):

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
@@ -6,7 +6,7 @@ from armstrong_numbers import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/armstrong-numbers/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ArmstrongNumbersTest(unittest.TestCase):

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
@@ -4,7 +4,9 @@ from armstrong_numbers import (
     is_armstrong_number,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/armstrong-numbers/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ArmstrongNumbersTest(unittest.TestCase):

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.py
@@ -7,7 +7,7 @@ from atbash_cipher import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/atbash-cipher/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class AtbashCipherTest(unittest.TestCase):

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.py
@@ -5,7 +5,9 @@ from atbash_cipher import (
     encode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/atbash-cipher/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class AtbashCipherTest(unittest.TestCase):

--- a/exercises/practice/bank-account/bank_account_test.py
+++ b/exercises/practice/bank-account/bank_account_test.py
@@ -6,7 +6,7 @@ from bank_account import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bank-account/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BankAccountTest(unittest.TestCase):

--- a/exercises/practice/bank-account/bank_account_test.py
+++ b/exercises/practice/bank-account/bank_account_test.py
@@ -4,7 +4,9 @@ from bank_account import (
     BankAccount,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bank-account/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BankAccountTest(unittest.TestCase):

--- a/exercises/practice/beer-song/beer_song_test.py
+++ b/exercises/practice/beer-song/beer_song_test.py
@@ -4,7 +4,9 @@ from beer_song import (
     recite,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/beer-song/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BeerSongTest(unittest.TestCase):

--- a/exercises/practice/beer-song/beer_song_test.py
+++ b/exercises/practice/beer-song/beer_song_test.py
@@ -6,7 +6,7 @@ from beer_song import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/beer-song/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BeerSongTest(unittest.TestCase):

--- a/exercises/practice/binary-search-tree/binary_search_tree_test.py
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.py
@@ -5,7 +5,9 @@ from binary_search_tree import (
     TreeNode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search-tree/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BinarySearchTreeTest(unittest.TestCase):

--- a/exercises/practice/binary-search-tree/binary_search_tree_test.py
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.py
@@ -7,7 +7,7 @@ from binary_search_tree import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search-tree/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BinarySearchTreeTest(unittest.TestCase):

--- a/exercises/practice/binary-search/binary_search_test.py
+++ b/exercises/practice/binary-search/binary_search_test.py
@@ -6,7 +6,7 @@ from binary_search import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BinarySearchTest(unittest.TestCase):

--- a/exercises/practice/binary-search/binary_search_test.py
+++ b/exercises/practice/binary-search/binary_search_test.py
@@ -4,7 +4,9 @@ from binary_search import (
     find,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BinarySearchTest(unittest.TestCase):

--- a/exercises/practice/bob/bob_test.py
+++ b/exercises/practice/bob/bob_test.py
@@ -6,7 +6,7 @@ from bob import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BobTest(unittest.TestCase):

--- a/exercises/practice/bob/bob_test.py
+++ b/exercises/practice/bob/bob_test.py
@@ -4,7 +4,9 @@ from bob import (
     response,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BobTest(unittest.TestCase):

--- a/exercises/practice/book-store/book_store_test.py
+++ b/exercises/practice/book-store/book_store_test.py
@@ -4,7 +4,9 @@ from book_store import (
     total,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/book-store/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BookStoreTest(unittest.TestCase):

--- a/exercises/practice/book-store/book_store_test.py
+++ b/exercises/practice/book-store/book_store_test.py
@@ -6,7 +6,7 @@ from book_store import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/book-store/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BookStoreTest(unittest.TestCase):

--- a/exercises/practice/bottle-song/bottle_song_test.py
+++ b/exercises/practice/bottle-song/bottle_song_test.py
@@ -4,7 +4,9 @@ from bottle_song import (
     recite,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BottleSongTest(unittest.TestCase):

--- a/exercises/practice/bottle-song/bottle_song_test.py
+++ b/exercises/practice/bottle-song/bottle_song_test.py
@@ -6,7 +6,7 @@ from bottle_song import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BottleSongTest(unittest.TestCase):

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -6,7 +6,7 @@ from bowling import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class BowlingTest(unittest.TestCase):

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -4,7 +4,9 @@ from bowling import (
     BowlingGame,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class BowlingTest(unittest.TestCase):

--- a/exercises/practice/change/change_test.py
+++ b/exercises/practice/change/change_test.py
@@ -4,7 +4,9 @@ from change import (
     find_fewest_coins,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/change/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ChangeTest(unittest.TestCase):

--- a/exercises/practice/change/change_test.py
+++ b/exercises/practice/change/change_test.py
@@ -6,7 +6,7 @@ from change import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/change/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ChangeTest(unittest.TestCase):

--- a/exercises/practice/circular-buffer/circular_buffer_test.py
+++ b/exercises/practice/circular-buffer/circular_buffer_test.py
@@ -6,7 +6,9 @@ from circular_buffer import (
     BufferFullException,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/circular-buffer/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class CircularBufferTest(unittest.TestCase):

--- a/exercises/practice/circular-buffer/circular_buffer_test.py
+++ b/exercises/practice/circular-buffer/circular_buffer_test.py
@@ -8,7 +8,7 @@ from circular_buffer import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/circular-buffer/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class CircularBufferTest(unittest.TestCase):

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -4,7 +4,9 @@ from clock import (
     Clock,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ClockTest(unittest.TestCase):

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -6,7 +6,7 @@ from clock import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ClockTest(unittest.TestCase):

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -6,7 +6,7 @@ from collatz_conjecture import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class CollatzConjectureTest(unittest.TestCase):

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -4,7 +4,9 @@ from collatz_conjecture import (
     steps,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class CollatzConjectureTest(unittest.TestCase):

--- a/exercises/practice/complex-numbers/complex_numbers_test.py
+++ b/exercises/practice/complex-numbers/complex_numbers_test.py
@@ -6,7 +6,9 @@ from complex_numbers import (
     ComplexNumber,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ComplexNumbersTest(unittest.TestCase):

--- a/exercises/practice/complex-numbers/complex_numbers_test.py
+++ b/exercises/practice/complex-numbers/complex_numbers_test.py
@@ -8,7 +8,7 @@ from complex_numbers import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ComplexNumbersTest(unittest.TestCase):

--- a/exercises/practice/connect/connect_test.py
+++ b/exercises/practice/connect/connect_test.py
@@ -4,7 +4,9 @@ from connect import (
     ConnectGame,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ConnectTest(unittest.TestCase):

--- a/exercises/practice/connect/connect_test.py
+++ b/exercises/practice/connect/connect_test.py
@@ -6,7 +6,7 @@ from connect import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ConnectTest(unittest.TestCase):

--- a/exercises/practice/crypto-square/crypto_square_test.py
+++ b/exercises/practice/crypto-square/crypto_square_test.py
@@ -6,7 +6,7 @@ from crypto_square import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/crypto-square/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class CryptoSquareTest(unittest.TestCase):

--- a/exercises/practice/crypto-square/crypto_square_test.py
+++ b/exercises/practice/crypto-square/crypto_square_test.py
@@ -4,7 +4,9 @@ from crypto_square import (
     cipher_text,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/crypto-square/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class CryptoSquareTest(unittest.TestCase):

--- a/exercises/practice/custom-set/custom_set_test.py
+++ b/exercises/practice/custom-set/custom_set_test.py
@@ -4,7 +4,9 @@ from custom_set import (
     CustomSet,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class CustomSetTest(unittest.TestCase):

--- a/exercises/practice/custom-set/custom_set_test.py
+++ b/exercises/practice/custom-set/custom_set_test.py
@@ -6,7 +6,7 @@ from custom_set import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class CustomSetTest(unittest.TestCase):

--- a/exercises/practice/darts/darts_test.py
+++ b/exercises/practice/darts/darts_test.py
@@ -6,7 +6,7 @@ from darts import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/darts/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DartsTest(unittest.TestCase):

--- a/exercises/practice/darts/darts_test.py
+++ b/exercises/practice/darts/darts_test.py
@@ -4,7 +4,9 @@ from darts import (
     score,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/darts/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DartsTest(unittest.TestCase):

--- a/exercises/practice/diamond/diamond_test.py
+++ b/exercises/practice/diamond/diamond_test.py
@@ -4,7 +4,9 @@ from diamond import (
     rows,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DiamondTest(unittest.TestCase):

--- a/exercises/practice/diamond/diamond_test.py
+++ b/exercises/practice/diamond/diamond_test.py
@@ -6,7 +6,7 @@ from diamond import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DiamondTest(unittest.TestCase):

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.py
@@ -8,7 +8,7 @@ from difference_of_squares import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/difference-of-squares/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DifferenceOfSquaresTest(unittest.TestCase):

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.py
@@ -6,7 +6,9 @@ from difference_of_squares import (
     sum_of_squares,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/difference-of-squares/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DifferenceOfSquaresTest(unittest.TestCase):

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -6,7 +6,9 @@ from diffie_hellman import (
     secret,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/diffie-hellman/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DiffieHellmanTest(unittest.TestCase):

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -8,7 +8,7 @@ from diffie_hellman import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/diffie-hellman/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DiffieHellmanTest(unittest.TestCase):

--- a/exercises/practice/dnd-character/dnd_character_test.py
+++ b/exercises/practice/dnd-character/dnd_character_test.py
@@ -7,7 +7,7 @@ from dnd_character import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/dnd-character/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DndCharacterTest(unittest.TestCase):

--- a/exercises/practice/dnd-character/dnd_character_test.py
+++ b/exercises/practice/dnd-character/dnd_character_test.py
@@ -5,7 +5,9 @@ from dnd_character import (
     modifier,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/dnd-character/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DndCharacterTest(unittest.TestCase):

--- a/exercises/practice/dominoes/dominoes_test.py
+++ b/exercises/practice/dominoes/dominoes_test.py
@@ -6,7 +6,7 @@ from dominoes import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/dominoes/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class DominoesTest(unittest.TestCase):

--- a/exercises/practice/dominoes/dominoes_test.py
+++ b/exercises/practice/dominoes/dominoes_test.py
@@ -4,7 +4,9 @@ from dominoes import (
     can_chain,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/dominoes/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class DominoesTest(unittest.TestCase):

--- a/exercises/practice/etl/etl_test.py
+++ b/exercises/practice/etl/etl_test.py
@@ -4,7 +4,9 @@ from etl import (
     transform,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class EtlTest(unittest.TestCase):

--- a/exercises/practice/etl/etl_test.py
+++ b/exercises/practice/etl/etl_test.py
@@ -6,7 +6,7 @@ from etl import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class EtlTest(unittest.TestCase):

--- a/exercises/practice/flatten-array/flatten_array_test.py
+++ b/exercises/practice/flatten-array/flatten_array_test.py
@@ -6,7 +6,7 @@ from flatten_array import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class FlattenArrayTest(unittest.TestCase):

--- a/exercises/practice/flatten-array/flatten_array_test.py
+++ b/exercises/practice/flatten-array/flatten_array_test.py
@@ -4,7 +4,9 @@ from flatten_array import (
     flatten,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class FlattenArrayTest(unittest.TestCase):

--- a/exercises/practice/food-chain/food_chain_test.py
+++ b/exercises/practice/food-chain/food_chain_test.py
@@ -6,7 +6,7 @@ from food_chain import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/food-chain/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class FoodChainTest(unittest.TestCase):

--- a/exercises/practice/food-chain/food_chain_test.py
+++ b/exercises/practice/food-chain/food_chain_test.py
@@ -4,7 +4,9 @@ from food_chain import (
     recite,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/food-chain/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class FoodChainTest(unittest.TestCase):

--- a/exercises/practice/forth/forth_test.py
+++ b/exercises/practice/forth/forth_test.py
@@ -7,7 +7,7 @@ from forth import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/forth/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ForthTest(unittest.TestCase):

--- a/exercises/practice/forth/forth_test.py
+++ b/exercises/practice/forth/forth_test.py
@@ -5,7 +5,9 @@ from forth import (
     StackUnderflowError,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/forth/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ForthTest(unittest.TestCase):

--- a/exercises/practice/gigasecond/gigasecond_test.py
+++ b/exercises/practice/gigasecond/gigasecond_test.py
@@ -5,7 +5,9 @@ from gigasecond import (
     add,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class GigasecondTest(unittest.TestCase):

--- a/exercises/practice/gigasecond/gigasecond_test.py
+++ b/exercises/practice/gigasecond/gigasecond_test.py
@@ -7,7 +7,7 @@ from gigasecond import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class GigasecondTest(unittest.TestCase):

--- a/exercises/practice/go-counting/go_counting_test.py
+++ b/exercises/practice/go-counting/go_counting_test.py
@@ -7,7 +7,9 @@ from go_counting import (
     NONE,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/go-counting/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class GoCountingTest(unittest.TestCase):

--- a/exercises/practice/go-counting/go_counting_test.py
+++ b/exercises/practice/go-counting/go_counting_test.py
@@ -9,7 +9,7 @@ from go_counting import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/go-counting/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class GoCountingTest(unittest.TestCase):

--- a/exercises/practice/grade-school/grade_school_test.py
+++ b/exercises/practice/grade-school/grade_school_test.py
@@ -6,7 +6,7 @@ from grade_school import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grade-school/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class GradeSchoolTest(unittest.TestCase):

--- a/exercises/practice/grade-school/grade_school_test.py
+++ b/exercises/practice/grade-school/grade_school_test.py
@@ -4,7 +4,9 @@ from grade_school import (
     School,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grade-school/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class GradeSchoolTest(unittest.TestCase):

--- a/exercises/practice/grains/grains_test.py
+++ b/exercises/practice/grains/grains_test.py
@@ -7,7 +7,7 @@ from grains import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class GrainsTest(unittest.TestCase):

--- a/exercises/practice/grains/grains_test.py
+++ b/exercises/practice/grains/grains_test.py
@@ -5,7 +5,9 @@ from grains import (
     total,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class GrainsTest(unittest.TestCase):

--- a/exercises/practice/grep/grep_test.py
+++ b/exercises/practice/grep/grep_test.py
@@ -4,7 +4,9 @@ from grep import (
     grep,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grep/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 import io
 from unittest import mock
 

--- a/exercises/practice/grep/grep_test.py
+++ b/exercises/practice/grep/grep_test.py
@@ -6,7 +6,7 @@ from grep import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grep/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 import io
 from unittest import mock
 

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -4,7 +4,9 @@ from hamming import (
     distance,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class HammingTest(unittest.TestCase):

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -6,7 +6,7 @@ from hamming import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class HammingTest(unittest.TestCase):

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -6,7 +6,7 @@ from high_scores import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/high-scores/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class HighScoresTest(unittest.TestCase):

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -4,7 +4,9 @@ from high_scores import (
     HighScores,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/high-scores/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class HighScoresTest(unittest.TestCase):

--- a/exercises/practice/house/house_test.py
+++ b/exercises/practice/house/house_test.py
@@ -4,7 +4,9 @@ from house import (
     recite,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/house/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class HouseTest(unittest.TestCase):

--- a/exercises/practice/house/house_test.py
+++ b/exercises/practice/house/house_test.py
@@ -6,7 +6,7 @@ from house import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/house/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class HouseTest(unittest.TestCase):

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.py
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.py
@@ -4,7 +4,9 @@ from isbn_verifier import (
     is_valid,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/isbn-verifier/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class IsbnVerifierTest(unittest.TestCase):

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.py
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.py
@@ -6,7 +6,7 @@ from isbn_verifier import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/isbn-verifier/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class IsbnVerifierTest(unittest.TestCase):

--- a/exercises/practice/isogram/isogram_test.py
+++ b/exercises/practice/isogram/isogram_test.py
@@ -6,7 +6,7 @@ from isogram import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/isogram/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class IsogramTest(unittest.TestCase):

--- a/exercises/practice/isogram/isogram_test.py
+++ b/exercises/practice/isogram/isogram_test.py
@@ -4,7 +4,9 @@ from isogram import (
     is_isogram,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/isogram/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class IsogramTest(unittest.TestCase):

--- a/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
+++ b/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
@@ -4,7 +4,9 @@ from killer_sudoku_helper import (
     combinations,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/killer-sudoku-helper/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class KillerSudokuHelperTest(unittest.TestCase):

--- a/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
+++ b/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
@@ -6,7 +6,7 @@ from killer_sudoku_helper import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/killer-sudoku-helper/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class KillerSudokuHelperTest(unittest.TestCase):

--- a/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
+++ b/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
@@ -6,7 +6,7 @@ from kindergarten_garden import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/kindergarten-garden/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class KindergartenGardenTest(unittest.TestCase):

--- a/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
+++ b/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
@@ -4,7 +4,9 @@ from kindergarten_garden import (
     Garden,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/kindergarten-garden/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class KindergartenGardenTest(unittest.TestCase):

--- a/exercises/practice/knapsack/knapsack_test.py
+++ b/exercises/practice/knapsack/knapsack_test.py
@@ -6,7 +6,7 @@ from knapsack import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/knapsack/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class KnapsackTest(unittest.TestCase):

--- a/exercises/practice/knapsack/knapsack_test.py
+++ b/exercises/practice/knapsack/knapsack_test.py
@@ -4,7 +4,9 @@ from knapsack import (
     maximum_value,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/knapsack/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class KnapsackTest(unittest.TestCase):

--- a/exercises/practice/largest-series-product/largest_series_product_test.py
+++ b/exercises/practice/largest-series-product/largest_series_product_test.py
@@ -6,7 +6,7 @@ from largest_series_product import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/largest-series-product/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class LargestSeriesProductTest(unittest.TestCase):

--- a/exercises/practice/largest-series-product/largest_series_product_test.py
+++ b/exercises/practice/largest-series-product/largest_series_product_test.py
@@ -4,7 +4,9 @@ from largest_series_product import (
     largest_product,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/largest-series-product/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class LargestSeriesProductTest(unittest.TestCase):

--- a/exercises/practice/leap/leap_test.py
+++ b/exercises/practice/leap/leap_test.py
@@ -4,7 +4,9 @@ from leap import (
     leap_year,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class LeapTest(unittest.TestCase):

--- a/exercises/practice/leap/leap_test.py
+++ b/exercises/practice/leap/leap_test.py
@@ -6,7 +6,7 @@ from leap import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class LeapTest(unittest.TestCase):

--- a/exercises/practice/ledger/ledger_test.py
+++ b/exercises/practice/ledger/ledger_test.py
@@ -5,7 +5,9 @@ from ledger import (
     create_entry,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/ledger/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class LedgerTest(unittest.TestCase):

--- a/exercises/practice/ledger/ledger_test.py
+++ b/exercises/practice/ledger/ledger_test.py
@@ -7,7 +7,7 @@ from ledger import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/ledger/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class LedgerTest(unittest.TestCase):

--- a/exercises/practice/linked-list/linked_list_test.py
+++ b/exercises/practice/linked-list/linked_list_test.py
@@ -4,7 +4,9 @@ from linked_list import (
     LinkedList,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/linked-list/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class LinkedListTest(unittest.TestCase):

--- a/exercises/practice/linked-list/linked_list_test.py
+++ b/exercises/practice/linked-list/linked_list_test.py
@@ -6,7 +6,7 @@ from linked_list import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/linked-list/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class LinkedListTest(unittest.TestCase):

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -13,7 +13,7 @@ from list_ops import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ListOpsTest(unittest.TestCase):

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -11,7 +11,9 @@ from list_ops import (
     map as list_ops_map,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ListOpsTest(unittest.TestCase):

--- a/exercises/practice/luhn/luhn_test.py
+++ b/exercises/practice/luhn/luhn_test.py
@@ -4,7 +4,9 @@ from luhn import (
     Luhn,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class LuhnTest(unittest.TestCase):

--- a/exercises/practice/luhn/luhn_test.py
+++ b/exercises/practice/luhn/luhn_test.py
@@ -6,7 +6,7 @@ from luhn import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class LuhnTest(unittest.TestCase):

--- a/exercises/practice/markdown/markdown_test.py
+++ b/exercises/practice/markdown/markdown_test.py
@@ -6,7 +6,7 @@ from markdown import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/markdown/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class MarkdownTest(unittest.TestCase):

--- a/exercises/practice/markdown/markdown_test.py
+++ b/exercises/practice/markdown/markdown_test.py
@@ -4,7 +4,9 @@ from markdown import (
     parse,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/markdown/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class MarkdownTest(unittest.TestCase):

--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -6,7 +6,7 @@ from matching_brackets import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/matching-brackets/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class MatchingBracketsTest(unittest.TestCase):

--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -4,7 +4,9 @@ from matching_brackets import (
     is_paired,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/matching-brackets/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class MatchingBracketsTest(unittest.TestCase):

--- a/exercises/practice/matrix/matrix_test.py
+++ b/exercises/practice/matrix/matrix_test.py
@@ -4,7 +4,9 @@ from matrix import (
     Matrix,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/matrix/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class MatrixTest(unittest.TestCase):

--- a/exercises/practice/matrix/matrix_test.py
+++ b/exercises/practice/matrix/matrix_test.py
@@ -6,7 +6,7 @@ from matrix import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/matrix/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class MatrixTest(unittest.TestCase):

--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -6,7 +6,9 @@ from meetup import (
     MeetupDayException,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/meetup/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class MeetupTest(unittest.TestCase):

--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -8,7 +8,7 @@ from meetup import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/meetup/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class MeetupTest(unittest.TestCase):

--- a/exercises/practice/minesweeper/minesweeper_test.py
+++ b/exercises/practice/minesweeper/minesweeper_test.py
@@ -6,7 +6,7 @@ from minesweeper import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/minesweeper/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class MinesweeperTest(unittest.TestCase):

--- a/exercises/practice/minesweeper/minesweeper_test.py
+++ b/exercises/practice/minesweeper/minesweeper_test.py
@@ -4,7 +4,9 @@ from minesweeper import (
     annotate,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/minesweeper/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class MinesweeperTest(unittest.TestCase):

--- a/exercises/practice/nth-prime/nth_prime_test.py
+++ b/exercises/practice/nth-prime/nth_prime_test.py
@@ -4,7 +4,9 @@ from nth_prime import (
     prime,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/nth-prime/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 def prime_range(n):

--- a/exercises/practice/nth-prime/nth_prime_test.py
+++ b/exercises/practice/nth-prime/nth_prime_test.py
@@ -6,7 +6,7 @@ from nth_prime import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/nth-prime/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 def prime_range(n):

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.py
@@ -6,7 +6,7 @@ from ocr_numbers import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/ocr-numbers/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class OcrNumbersTest(unittest.TestCase):

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.py
@@ -4,7 +4,9 @@ from ocr_numbers import (
     convert,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/ocr-numbers/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class OcrNumbersTest(unittest.TestCase):

--- a/exercises/practice/palindrome-products/palindrome_products_test.py
+++ b/exercises/practice/palindrome-products/palindrome_products_test.py
@@ -5,7 +5,9 @@ from palindrome_products import (
     smallest,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/palindrome-products/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PalindromeProductsTest(unittest.TestCase):

--- a/exercises/practice/palindrome-products/palindrome_products_test.py
+++ b/exercises/practice/palindrome-products/palindrome_products_test.py
@@ -7,7 +7,7 @@ from palindrome_products import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/palindrome-products/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PalindromeProductsTest(unittest.TestCase):

--- a/exercises/practice/pangram/pangram_test.py
+++ b/exercises/practice/pangram/pangram_test.py
@@ -6,7 +6,7 @@ from pangram import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pangram/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PangramTest(unittest.TestCase):

--- a/exercises/practice/pangram/pangram_test.py
+++ b/exercises/practice/pangram/pangram_test.py
@@ -4,7 +4,9 @@ from pangram import (
     is_pangram,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pangram/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PangramTest(unittest.TestCase):

--- a/exercises/practice/pascals-triangle/pascals_triangle_test.py
+++ b/exercises/practice/pascals-triangle/pascals_triangle_test.py
@@ -7,7 +7,7 @@ from pascals_triangle import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pascals-triangle/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 TRIANGLE = [
     [1],

--- a/exercises/practice/pascals-triangle/pascals_triangle_test.py
+++ b/exercises/practice/pascals-triangle/pascals_triangle_test.py
@@ -5,7 +5,9 @@ from pascals_triangle import (
     rows,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pascals-triangle/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 TRIANGLE = [
     [1],

--- a/exercises/practice/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/practice/perfect-numbers/perfect_numbers_test.py
@@ -6,7 +6,7 @@ from perfect_numbers import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PerfectNumbersTest(unittest.TestCase):

--- a/exercises/practice/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/practice/perfect-numbers/perfect_numbers_test.py
@@ -4,7 +4,9 @@ from perfect_numbers import (
     classify,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PerfectNumbersTest(unittest.TestCase):

--- a/exercises/practice/phone-number/phone_number_test.py
+++ b/exercises/practice/phone-number/phone_number_test.py
@@ -6,7 +6,7 @@ from phone_number import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/phone-number/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PhoneNumberTest(unittest.TestCase):

--- a/exercises/practice/phone-number/phone_number_test.py
+++ b/exercises/practice/phone-number/phone_number_test.py
@@ -4,7 +4,9 @@ from phone_number import (
     PhoneNumber,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/phone-number/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PhoneNumberTest(unittest.TestCase):

--- a/exercises/practice/pig-latin/pig_latin_test.py
+++ b/exercises/practice/pig-latin/pig_latin_test.py
@@ -6,7 +6,7 @@ from pig_latin import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pig-latin/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PigLatinTest(unittest.TestCase):

--- a/exercises/practice/pig-latin/pig_latin_test.py
+++ b/exercises/practice/pig-latin/pig_latin_test.py
@@ -4,7 +4,9 @@ from pig_latin import (
     translate,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pig-latin/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PigLatinTest(unittest.TestCase):

--- a/exercises/practice/poker/poker_test.py
+++ b/exercises/practice/poker/poker_test.py
@@ -6,7 +6,7 @@ from poker import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/poker/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PokerTest(unittest.TestCase):

--- a/exercises/practice/poker/poker_test.py
+++ b/exercises/practice/poker/poker_test.py
@@ -4,7 +4,9 @@ from poker import (
     best_hands,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/poker/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PokerTest(unittest.TestCase):

--- a/exercises/practice/pov/pov_test.py
+++ b/exercises/practice/pov/pov_test.py
@@ -6,7 +6,7 @@ from pov import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pov/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PovTest(unittest.TestCase):

--- a/exercises/practice/pov/pov_test.py
+++ b/exercises/practice/pov/pov_test.py
@@ -4,7 +4,9 @@ from pov import (
     Tree,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pov/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PovTest(unittest.TestCase):

--- a/exercises/practice/prime-factors/prime_factors_test.py
+++ b/exercises/practice/prime-factors/prime_factors_test.py
@@ -6,7 +6,7 @@ from prime_factors import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/prime-factors/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PrimeFactorsTest(unittest.TestCase):

--- a/exercises/practice/prime-factors/prime_factors_test.py
+++ b/exercises/practice/prime-factors/prime_factors_test.py
@@ -4,7 +4,9 @@ from prime_factors import (
     factors,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/prime-factors/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PrimeFactorsTest(unittest.TestCase):

--- a/exercises/practice/protein-translation/protein_translation_test.py
+++ b/exercises/practice/protein-translation/protein_translation_test.py
@@ -6,7 +6,7 @@ from protein_translation import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/protein-translation/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ProteinTranslationTest(unittest.TestCase):

--- a/exercises/practice/protein-translation/protein_translation_test.py
+++ b/exercises/practice/protein-translation/protein_translation_test.py
@@ -4,7 +4,9 @@ from protein_translation import (
     proteins,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/protein-translation/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ProteinTranslationTest(unittest.TestCase):

--- a/exercises/practice/proverb/proverb_test.py
+++ b/exercises/practice/proverb/proverb_test.py
@@ -4,7 +4,9 @@ from proverb import (
     proverb,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/proverb/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/proverb/proverb_test.py
+++ b/exercises/practice/proverb/proverb_test.py
@@ -6,7 +6,7 @@ from proverb import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/proverb/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
@@ -4,7 +4,9 @@ from pythagorean_triplet import (
     triplets_with_sum,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pythagorean-triplet/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class PythagoreanTripletTest(unittest.TestCase):

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
@@ -6,7 +6,7 @@ from pythagorean_triplet import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pythagorean-triplet/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class PythagoreanTripletTest(unittest.TestCase):

--- a/exercises/practice/queen-attack/queen_attack_test.py
+++ b/exercises/practice/queen-attack/queen_attack_test.py
@@ -6,7 +6,7 @@ from queen_attack import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/queen-attack/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class QueenAttackTest(unittest.TestCase):

--- a/exercises/practice/queen-attack/queen_attack_test.py
+++ b/exercises/practice/queen-attack/queen_attack_test.py
@@ -4,7 +4,9 @@ from queen_attack import (
     Queen,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/queen-attack/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class QueenAttackTest(unittest.TestCase):

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
@@ -5,7 +5,9 @@ from rail_fence_cipher import (
     encode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rail-fence-cipher/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RailFenceCipherTest(unittest.TestCase):

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
@@ -7,7 +7,7 @@ from rail_fence_cipher import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rail-fence-cipher/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RailFenceCipherTest(unittest.TestCase):

--- a/exercises/practice/raindrops/raindrops_test.py
+++ b/exercises/practice/raindrops/raindrops_test.py
@@ -4,7 +4,9 @@ from raindrops import (
     convert,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/raindrops/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RaindropsTest(unittest.TestCase):

--- a/exercises/practice/raindrops/raindrops_test.py
+++ b/exercises/practice/raindrops/raindrops_test.py
@@ -6,7 +6,7 @@ from raindrops import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/raindrops/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RaindropsTest(unittest.TestCase):

--- a/exercises/practice/rational-numbers/rational_numbers_test.py
+++ b/exercises/practice/rational-numbers/rational_numbers_test.py
@@ -5,7 +5,9 @@ from rational_numbers import (
     Rational,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rational-numbers/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RationalNumbersTest(unittest.TestCase):

--- a/exercises/practice/rational-numbers/rational_numbers_test.py
+++ b/exercises/practice/rational-numbers/rational_numbers_test.py
@@ -7,7 +7,7 @@ from rational_numbers import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rational-numbers/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RationalNumbersTest(unittest.TestCase):

--- a/exercises/practice/react/react_test.py
+++ b/exercises/practice/react/react_test.py
@@ -9,7 +9,7 @@ from react import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/react/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ReactTest(unittest.TestCase):

--- a/exercises/practice/react/react_test.py
+++ b/exercises/practice/react/react_test.py
@@ -7,7 +7,9 @@ from react import (
     ComputeCell,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/react/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ReactTest(unittest.TestCase):

--- a/exercises/practice/rectangles/rectangles_test.py
+++ b/exercises/practice/rectangles/rectangles_test.py
@@ -6,7 +6,7 @@ from rectangles import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RectanglesTest(unittest.TestCase):

--- a/exercises/practice/rectangles/rectangles_test.py
+++ b/exercises/practice/rectangles/rectangles_test.py
@@ -4,7 +4,9 @@ from rectangles import (
     rectangles,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RectanglesTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
@@ -6,7 +6,7 @@ from resistor_color_duo import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-duo/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ResistorColorDuoTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
@@ -4,7 +4,9 @@ from resistor_color_duo import (
     value,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-duo/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ResistorColorDuoTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
@@ -6,7 +6,7 @@ from resistor_color_trio import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ResistorColorTrioTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
@@ -4,7 +4,9 @@ from resistor_color_trio import (
     label,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ResistorColorTrioTest(unittest.TestCase):

--- a/exercises/practice/resistor-color/resistor_color_test.py
+++ b/exercises/practice/resistor-color/resistor_color_test.py
@@ -5,7 +5,9 @@ from resistor_color import (
     colors,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ResistorColorTest(unittest.TestCase):

--- a/exercises/practice/resistor-color/resistor_color_test.py
+++ b/exercises/practice/resistor-color/resistor_color_test.py
@@ -7,7 +7,7 @@ from resistor_color import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ResistorColorTest(unittest.TestCase):

--- a/exercises/practice/rest-api/rest_api_test.py
+++ b/exercises/practice/rest-api/rest_api_test.py
@@ -6,7 +6,7 @@ from rest_api import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rest-api/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 import json
 
 

--- a/exercises/practice/rest-api/rest_api_test.py
+++ b/exercises/practice/rest-api/rest_api_test.py
@@ -4,7 +4,9 @@ from rest_api import (
     RestAPI,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rest-api/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 import json
 
 

--- a/exercises/practice/reverse-string/reverse_string_test.py
+++ b/exercises/practice/reverse-string/reverse_string_test.py
@@ -6,7 +6,7 @@ from reverse_string import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ReverseStringTest(unittest.TestCase):

--- a/exercises/practice/reverse-string/reverse_string_test.py
+++ b/exercises/practice/reverse-string/reverse_string_test.py
@@ -4,7 +4,9 @@ from reverse_string import (
     reverse,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ReverseStringTest(unittest.TestCase):

--- a/exercises/practice/rna-transcription/rna_transcription_test.py
+++ b/exercises/practice/rna-transcription/rna_transcription_test.py
@@ -6,7 +6,7 @@ from rna_transcription import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rna-transcription/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RnaTranscriptionTest(unittest.TestCase):

--- a/exercises/practice/rna-transcription/rna_transcription_test.py
+++ b/exercises/practice/rna-transcription/rna_transcription_test.py
@@ -4,7 +4,9 @@ from rna_transcription import (
     to_rna,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rna-transcription/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RnaTranscriptionTest(unittest.TestCase):

--- a/exercises/practice/robot-simulator/robot_simulator_test.py
+++ b/exercises/practice/robot-simulator/robot_simulator_test.py
@@ -8,7 +8,9 @@ from robot_simulator import (
     WEST,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/robot-simulator/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RobotSimulatorTest(unittest.TestCase):

--- a/exercises/practice/robot-simulator/robot_simulator_test.py
+++ b/exercises/practice/robot-simulator/robot_simulator_test.py
@@ -10,7 +10,7 @@ from robot_simulator import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/robot-simulator/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RobotSimulatorTest(unittest.TestCase):

--- a/exercises/practice/roman-numerals/roman_numerals_test.py
+++ b/exercises/practice/roman-numerals/roman_numerals_test.py
@@ -6,7 +6,7 @@ from roman_numerals import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/roman-numerals/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 class RomanNumeralsTest(unittest.TestCase):
     def test_1_is_i(self):
         self.assertEqual(roman(1), "I")

--- a/exercises/practice/roman-numerals/roman_numerals_test.py
+++ b/exercises/practice/roman-numerals/roman_numerals_test.py
@@ -4,7 +4,9 @@ from roman_numerals import (
     roman,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/roman-numerals/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 class RomanNumeralsTest(unittest.TestCase):
     def test_1_is_i(self):
         self.assertEqual(roman(1), "I")

--- a/exercises/practice/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/practice/rotational-cipher/rotational_cipher_test.py
@@ -4,7 +4,9 @@ from rotational_cipher import (
     rotate,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rotational-cipher/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RotationalCipherTest(unittest.TestCase):

--- a/exercises/practice/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/practice/rotational-cipher/rotational_cipher_test.py
@@ -6,7 +6,7 @@ from rotational_cipher import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rotational-cipher/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RotationalCipherTest(unittest.TestCase):

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.py
@@ -7,7 +7,7 @@ from run_length_encoding import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/run-length-encoding/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RunLengthEncodingTest(unittest.TestCase):

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.py
@@ -5,7 +5,9 @@ from run_length_encoding import (
     decode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/run-length-encoding/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RunLengthEncodingTest(unittest.TestCase):

--- a/exercises/practice/saddle-points/saddle_points_test.py
+++ b/exercises/practice/saddle-points/saddle_points_test.py
@@ -11,7 +11,9 @@ from saddle_points import (
     saddle_points,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/saddle-points/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 def sorted_points(point_list):

--- a/exercises/practice/saddle-points/saddle_points_test.py
+++ b/exercises/practice/saddle-points/saddle_points_test.py
@@ -13,7 +13,7 @@ from saddle_points import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/saddle-points/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 def sorted_points(point_list):

--- a/exercises/practice/satellite/satellite_test.py
+++ b/exercises/practice/satellite/satellite_test.py
@@ -6,7 +6,7 @@ from satellite import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/satellite/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SatelliteTest(unittest.TestCase):

--- a/exercises/practice/satellite/satellite_test.py
+++ b/exercises/practice/satellite/satellite_test.py
@@ -4,7 +4,9 @@ from satellite import (
     tree_from_traversals,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/satellite/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SatelliteTest(unittest.TestCase):

--- a/exercises/practice/say/say_test.py
+++ b/exercises/practice/say/say_test.py
@@ -6,7 +6,7 @@ from say import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/say/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SayTest(unittest.TestCase):

--- a/exercises/practice/say/say_test.py
+++ b/exercises/practice/say/say_test.py
@@ -4,7 +4,9 @@ from say import (
     say,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/say/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SayTest(unittest.TestCase):

--- a/exercises/practice/scale-generator/scale_generator_test.py
+++ b/exercises/practice/scale-generator/scale_generator_test.py
@@ -6,7 +6,7 @@ from scale_generator import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/scale-generator/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ScaleGeneratorTest(unittest.TestCase):

--- a/exercises/practice/scale-generator/scale_generator_test.py
+++ b/exercises/practice/scale-generator/scale_generator_test.py
@@ -4,7 +4,9 @@ from scale_generator import (
     Scale,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/scale-generator/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ScaleGeneratorTest(unittest.TestCase):

--- a/exercises/practice/scrabble-score/scrabble_score_test.py
+++ b/exercises/practice/scrabble-score/scrabble_score_test.py
@@ -4,7 +4,9 @@ from scrabble_score import (
     score,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/scrabble-score/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ScrabbleScoreTest(unittest.TestCase):

--- a/exercises/practice/scrabble-score/scrabble_score_test.py
+++ b/exercises/practice/scrabble-score/scrabble_score_test.py
@@ -6,7 +6,7 @@ from scrabble_score import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/scrabble-score/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ScrabbleScoreTest(unittest.TestCase):

--- a/exercises/practice/secret-handshake/secret_handshake_test.py
+++ b/exercises/practice/secret-handshake/secret_handshake_test.py
@@ -6,7 +6,7 @@ from secret_handshake import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/secret-handshake/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SecretHandshakeTest(unittest.TestCase):

--- a/exercises/practice/secret-handshake/secret_handshake_test.py
+++ b/exercises/practice/secret-handshake/secret_handshake_test.py
@@ -4,7 +4,9 @@ from secret_handshake import (
     commands,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/secret-handshake/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SecretHandshakeTest(unittest.TestCase):

--- a/exercises/practice/series/series_test.py
+++ b/exercises/practice/series/series_test.py
@@ -4,7 +4,9 @@ from series import (
     slices,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/series/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SeriesTest(unittest.TestCase):

--- a/exercises/practice/series/series_test.py
+++ b/exercises/practice/series/series_test.py
@@ -6,7 +6,7 @@ from series import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/series/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SeriesTest(unittest.TestCase):

--- a/exercises/practice/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/practice/sgf-parsing/sgf_parsing_test.py
@@ -5,7 +5,9 @@ from sgf_parsing import (
     SgfTree,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sgf-parsing/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SgfParsingTest(unittest.TestCase):

--- a/exercises/practice/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/practice/sgf-parsing/sgf_parsing_test.py
@@ -7,7 +7,7 @@ from sgf_parsing import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sgf-parsing/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SgfParsingTest(unittest.TestCase):

--- a/exercises/practice/sieve/sieve_test.py
+++ b/exercises/practice/sieve/sieve_test.py
@@ -4,7 +4,9 @@ from sieve import (
     primes,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sieve/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SieveTest(unittest.TestCase):

--- a/exercises/practice/sieve/sieve_test.py
+++ b/exercises/practice/sieve/sieve_test.py
@@ -6,7 +6,7 @@ from sieve import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sieve/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SieveTest(unittest.TestCase):

--- a/exercises/practice/simple-cipher/simple_cipher_test.py
+++ b/exercises/practice/simple-cipher/simple_cipher_test.py
@@ -7,7 +7,7 @@ from simple_cipher import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/simple-cipher/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class RandomKeyCipherTest(unittest.TestCase):

--- a/exercises/practice/simple-cipher/simple_cipher_test.py
+++ b/exercises/practice/simple-cipher/simple_cipher_test.py
@@ -5,7 +5,9 @@ from simple_cipher import (
     Cipher,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/simple-cipher/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class RandomKeyCipherTest(unittest.TestCase):

--- a/exercises/practice/space-age/space_age_test.py
+++ b/exercises/practice/space-age/space_age_test.py
@@ -4,7 +4,9 @@ from space_age import (
     SpaceAge,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SpaceAgeTest(unittest.TestCase):

--- a/exercises/practice/space-age/space_age_test.py
+++ b/exercises/practice/space-age/space_age_test.py
@@ -6,7 +6,7 @@ from space_age import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SpaceAgeTest(unittest.TestCase):

--- a/exercises/practice/spiral-matrix/spiral_matrix_test.py
+++ b/exercises/practice/spiral-matrix/spiral_matrix_test.py
@@ -4,7 +4,9 @@ from spiral_matrix import (
     spiral_matrix,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/spiral-matrix/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SpiralMatrixTest(unittest.TestCase):

--- a/exercises/practice/spiral-matrix/spiral_matrix_test.py
+++ b/exercises/practice/spiral-matrix/spiral_matrix_test.py
@@ -6,7 +6,7 @@ from spiral_matrix import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/spiral-matrix/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SpiralMatrixTest(unittest.TestCase):

--- a/exercises/practice/square-root/square_root_test.py
+++ b/exercises/practice/square-root/square_root_test.py
@@ -4,7 +4,9 @@ from square_root import (
     square_root,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/square-root/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SquareRootTest(unittest.TestCase):

--- a/exercises/practice/square-root/square_root_test.py
+++ b/exercises/practice/square-root/square_root_test.py
@@ -6,7 +6,7 @@ from square_root import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/square-root/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SquareRootTest(unittest.TestCase):

--- a/exercises/practice/sublist/sublist_test.py
+++ b/exercises/practice/sublist/sublist_test.py
@@ -10,7 +10,7 @@ from sublist import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sublist/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SublistTest(unittest.TestCase):

--- a/exercises/practice/sublist/sublist_test.py
+++ b/exercises/practice/sublist/sublist_test.py
@@ -8,7 +8,9 @@ from sublist import (
     UNEQUAL,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sublist/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SublistTest(unittest.TestCase):

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
@@ -6,7 +6,7 @@ from sum_of_multiples import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sum-of-multiples/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class SumOfMultiplesTest(unittest.TestCase):

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
@@ -4,7 +4,9 @@ from sum_of_multiples import (
     sum_of_multiples,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sum-of-multiples/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class SumOfMultiplesTest(unittest.TestCase):

--- a/exercises/practice/tournament/tournament_test.py
+++ b/exercises/practice/tournament/tournament_test.py
@@ -6,7 +6,7 @@ from tournament import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/tournament/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class TournamentTest(unittest.TestCase):

--- a/exercises/practice/tournament/tournament_test.py
+++ b/exercises/practice/tournament/tournament_test.py
@@ -4,7 +4,9 @@ from tournament import (
     tally,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/tournament/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class TournamentTest(unittest.TestCase):

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -6,7 +6,7 @@ from transpose import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class TransposeTest(unittest.TestCase):

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -4,7 +4,9 @@ from transpose import (
     transpose,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class TransposeTest(unittest.TestCase):

--- a/exercises/practice/triangle/triangle_test.py
+++ b/exercises/practice/triangle/triangle_test.py
@@ -8,7 +8,7 @@ from triangle import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/triangle/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class EquilateralTriangleTest(unittest.TestCase):

--- a/exercises/practice/triangle/triangle_test.py
+++ b/exercises/practice/triangle/triangle_test.py
@@ -6,7 +6,9 @@ from triangle import (
     scalene,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/triangle/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class EquilateralTriangleTest(unittest.TestCase):

--- a/exercises/practice/twelve-days/twelve_days_test.py
+++ b/exercises/practice/twelve-days/twelve_days_test.py
@@ -6,7 +6,7 @@ from twelve_days import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/twelve-days/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/twelve-days/twelve_days_test.py
+++ b/exercises/practice/twelve-days/twelve_days_test.py
@@ -4,7 +4,9 @@ from twelve_days import (
     recite,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/twelve-days/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -6,7 +6,7 @@ from two_bucket import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class TwoBucketTest(unittest.TestCase):

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -4,7 +4,9 @@ from two_bucket import (
     measure,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class TwoBucketTest(unittest.TestCase):

--- a/exercises/practice/two-fer/two_fer_test.py
+++ b/exercises/practice/two-fer/two_fer_test.py
@@ -4,7 +4,9 @@ from two_fer import (
     two_fer,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class TwoFerTest(unittest.TestCase):

--- a/exercises/practice/two-fer/two_fer_test.py
+++ b/exercises/practice/two-fer/two_fer_test.py
@@ -6,7 +6,7 @@ from two_fer import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class TwoFerTest(unittest.TestCase):

--- a/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
@@ -7,7 +7,7 @@ from variable_length_quantity import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/variable-length-quantity/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class VariableLengthQuantityTest(unittest.TestCase):

--- a/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
@@ -5,7 +5,9 @@ from variable_length_quantity import (
     encode,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/variable-length-quantity/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class VariableLengthQuantityTest(unittest.TestCase):

--- a/exercises/practice/word-count/word_count_test.py
+++ b/exercises/practice/word-count/word_count_test.py
@@ -6,7 +6,7 @@ from word_count import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class WordCountTest(unittest.TestCase):

--- a/exercises/practice/word-count/word_count_test.py
+++ b/exercises/practice/word-count/word_count_test.py
@@ -4,7 +4,9 @@ from word_count import (
     count_words,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class WordCountTest(unittest.TestCase):

--- a/exercises/practice/word-search/word_search_test.py
+++ b/exercises/practice/word-search/word_search_test.py
@@ -5,7 +5,9 @@ from word_search import (
     Point,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/word-search/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class WordSearchTest(unittest.TestCase):

--- a/exercises/practice/word-search/word_search_test.py
+++ b/exercises/practice/word-search/word_search_test.py
@@ -7,7 +7,7 @@ from word_search import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/word-search/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class WordSearchTest(unittest.TestCase):

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -6,7 +6,7 @@ from wordy import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class WordyTest(unittest.TestCase):

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -4,7 +4,9 @@ from wordy import (
     answer,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class WordyTest(unittest.TestCase):

--- a/exercises/practice/yacht/yacht_test.py
+++ b/exercises/practice/yacht/yacht_test.py
@@ -2,7 +2,9 @@ import unittest
 
 import yacht
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/yacht/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class YachtTest(unittest.TestCase):

--- a/exercises/practice/yacht/yacht_test.py
+++ b/exercises/practice/yacht/yacht_test.py
@@ -4,7 +4,7 @@ import yacht
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/yacht/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class YachtTest(unittest.TestCase):

--- a/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
@@ -7,7 +7,7 @@ from zebra_puzzle import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/zebra-puzzle/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ZebraPuzzleTest(unittest.TestCase):

--- a/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
@@ -5,7 +5,9 @@ from zebra_puzzle import (
     owns_zebra,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/zebra-puzzle/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ZebraPuzzleTest(unittest.TestCase):

--- a/exercises/practice/zipper/zipper_test.py
+++ b/exercises/practice/zipper/zipper_test.py
@@ -6,7 +6,7 @@ from zipper import (
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/zipper/canonical-data.json
-# File last updated on 2023-07-14 21:54:35.742096+00:00
+# File last updated on 2023-07-14
 
 
 class ZipperTest(unittest.TestCase):

--- a/exercises/practice/zipper/zipper_test.py
+++ b/exercises/practice/zipper/zipper_test.py
@@ -4,7 +4,9 @@ from zipper import (
     Zipper,
 )
 
-# Tests adapted from `problem-specifications//canonical-data.json`
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/zipper/canonical-data.json
+# File last updated on 2023-07-14 21:54:35.742096+00:00
 
 
 class ZipperTest(unittest.TestCase):


### PR DESCRIPTION
Per discussion on the [forum](http://forum.exercism.org/t/tests-adapted-from-prob-specs-message-in-tests/4761)
@ErikSchierboom @glennj  - please feel free to edit/discuss/comment as you see fit.

**`Note`**:  This will fail CI until all the regenerated test files are added into it.

This change, should we commit it and re-generate the test files, will show up for every practice exercise **except**:

- Robot Name
- Bank Account
- Hangman
- Simple Linke List
- Tree Building
- Ledger
- Paas/io
- Dot DSL

Which need a JinJa2 template, canonical-data.json, or both.


Partial sample re-generated test file:

```python
import unittest

from word_count import (
    count_words,
)

# These tests are auto-generated with test data from:
# https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
# File last updated on 2023-03-23

class WordCountTest(unittest.TestCase):
    def test_count_one_word(self):
        self.assertEqual(count_words("word"), {"word": 1})

    def test_count_one_of_each_word(self):
        self.assertEqual(count_words("one of each"), {"one": 1, "of": 1, "each": 1})

    def test_multiple_occurrences_of_a_word(self):
        self.assertEqual(
            count_words("one fish two fish red fish blue fish"),
            {"one": 1, "fish": 4, "two": 1, "red": 1, "blue": 1},
        )

    def test_handles_cramped_lists(self):
        self.assertEqual(count_words("one,two,three"), {"one": 1, "two": 1, "three": 1})

    def test_handles_expanded_lists(self):
        self.assertEqual(
            count_words("one,\ntwo,\nthree"), {"one": 1, "two": 1, "three": 1}
        )

    def test_ignore_punctuation(self):
        self.assertEqual(
            count_words("car: carpet as java: javascript!!&@$%^&"),
            {"car": 1, "carpet": 1, "as": 1, "java": 1, "javascript": 1},
        )

        ...

```