### PR TITLE
[Palindrome Products] Removed Numbers Concept Exercise from Practices Array

### DIFF
--- a/config.json
+++ b/config.json
@@ -1441,7 +1441,7 @@
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "fa795dcc-d390-4e98-880c-6e8e638485e3",
-        "practices": ["functions", "function-arguments", "numbers"],
+        "practices": ["functions", "function-arguments"],
         "prerequisites": [
           "basics",
           "bools",


### PR DESCRIPTION
Per discussion with @ErikSchierboom - since the naive solution to `Palindrome Products` often times out tests & the numbers concept appears very early in the track, we thought it best to remove this associated practice exercise from the progression.

**Replacement TBD**, but we do have 6 other practice exercises associated, so it's ok to remove and not replace for now.