### PR TITLE
[Track Documents] Updated for Python 3.10 --> 3.11.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,13 @@ Please read this [community blog post](https://exercism.org/blog/freeing-our-mai
 **`exercism/Python`** is one of many programming language tracks on [exercism(dot)org][exercism-website].  
 This repo holds all the instructions, tests, code, & support files for Python _exercises_ currently under development or implemented & available for students.
 
-🌟 &nbsp;&nbsp;Track exercises support Python `3.7` - `3.10.6`.
+🌟 &nbsp;&nbsp;Track exercises support Python `3.7` - `3.11.2`.
 Exceptions to this support are noted where they occur.  
- 🌟 &nbsp;&nbsp;Track tooling (_test-runner, representer, analyzer, and Continuous Integration_) runs on Python `3.10.6`.
+🌟 &nbsp;&nbsp;Track tooling (_test-runner, representer, analyzer, and Continuous Integration_) runs on Python `3.11.2`.
 
-Exercises are grouped into **concept** exercises which teach the [Python syllabus][python-syllabus], and **practice** exercises, which are unlocked by progressing in the syllabus tree &nbsp;🌴 &nbsp;.  
-Concept exercises are constrained to a small set of language or syntax features.  
-Practice exercises are open-ended, and can be used to practice concepts learned, try out new techniques, and _play_.  
-These two exercise groupings can be found in the track [config.json][config-json], and under the `python/exercises` directory.
+Exercises are grouped into **concept** exercises which teach the [Python syllabus][python-syllabus], and **practice** exercises, which are unlocked by progressing in the syllabus tree &nbsp;🌴&nbsp;.
+Concept exercises are constrained to a small set of language or syntax features.
+Practice exercises are open-ended, and can be used to practice concepts learned, try out new techniques, and _play_. These two exercise groupings can be found in the track [config.json][config-json], and under the `python/exercises` directory.
 
 <br>
 
@@ -430,3 +429,5 @@ configlet generate <path/to/track> --spec-path path/to/problem/specifications
 [version-tagged-language-features]: https://docs.python.org/3/library/stdtypes.html#dict.popitem
 [website-contributing-section]: https://exercism.org/docs/building
 [yapf]: https://github.com/google/yapf
+
+[config-json]: https://github.com/exercism/python/blob/main/config.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <p vertical-align="middle"><h1>Exercism Python Track</h1></p>
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Discourse topics](https://img.shields.io/discourse/topics?color=8A08E6&label=Connect%20&labelColor=FFDF58&logo=Discourse&logoColor=8A08E6&server=https%3A%2F%2Fforum.exercism.org&style=social)](https://forum.exercism.org)
-&nbsp;&nbsp;[![Exercism_II](https://img.shields.io/badge/Exercism--Built-9101FF?logo=python&logoColor=FFDF58&labelColor=3D7AAB&label=Python%203.10%20Powered)](https://exercism.org)
+&nbsp;&nbsp;[![Exercism_II](https://img.shields.io/badge/Exercism--Built-9101FF?logo=python&logoColor=FFDF58&labelColor=3D7AAB&label=Python%203.11%20Powered)](https://exercism.org)
 &nbsp;&nbsp;[![Exercism_III](https://img.shields.io/badge/PAUSED-C73D4E?labelColor=3D454D&label=Contributions)](https://exercism.org/blog/freeing-our-maintainers)
 &nbsp; [![Build Status](https://github.com/exercism/python/workflows/Exercises%20check/badge.svg)](https://github.com/exercism/python/actions?query=workflow%3A%22Exercises+check%22)
 
@@ -17,11 +17,13 @@ Hi. &nbsp;👋🏽 &nbsp;👋 &nbsp;**We are happy you are here.**&nbsp; 🎉&nb
 **`exercism/Python`** is one of many programming language tracks on [exercism(dot)org][exercism-website].
 This repo holds all the instructions, tests, code, & support files for Python _exercises_ currently under development or implemented & available for students.
 
-🌟 &nbsp;&nbsp;Track exercises support Python `3.7` - `3.10.6`.
+🌟 &nbsp;&nbsp;Track exercises support Python `3.7` - `3.11.2`.
 Exceptions to this support are noted where they occur.  
- 🌟 &nbsp;&nbsp;Track tooling (_test-runner, representer, analyzer, and Continuous Integration_) runs on Python `3.10.6`.
+🌟 &nbsp;&nbsp;Track tooling (_test-runner, representer, analyzer, and Continuous Integration_) runs on Python `3.11.2`.
 
-Exercises are grouped into **concept** exercises which teach the [Python syllabus][python-syllabus], and **practice** exercises, which are unlocked by progressing in the syllabus tree &nbsp;🌴 &nbsp;. Concept exercises are constrained to a small set of language or syntax features. Practice exercises are open-ended, and can be used to practice concepts learned, try out new techniques, and _play_. These two exercise groupings can be found in the track [config.json][config-json], and under the `python/exercises` directory.
+Exercises are grouped into **concept** exercises which teach the [Python syllabus][python-syllabus], and **practice** exercises, which are unlocked by progressing in the syllabus tree &nbsp;🌴&nbsp;.
+Concept exercises are constrained to a small set of language or syntax features.
+Practice exercises are open-ended, and can be used to practice concepts learned, try out new techniques, and _play_. These two exercise groupings can be found in the track [config.json][config-json], and under the `python/exercises` directory.
 
 <br><br>
 
@@ -43,24 +45,25 @@ It might also be helpful to look at [Being a Good Community Member][being-a-good
 
 We&nbsp;💛&nbsp;💙 &nbsp; our community.  
 **`But our maintainers are not accepting community contributions at this time.`**  
-Please read this [community blog post](https://exercism.org/blog/freeing-our-maintainers) for details.
+Please read this [community blog post][freeing-maintainers] for details.
 
 <br>
-<img align="left" width="95" height="85" src="https://github.com/exercism/website-icons/blob/main/exercises/boutique-suggestions.svg">
+<img align="left" width="95" height="90" src="https://github.com/exercism/website-icons/blob/main/exercises/boutique-suggestions.svg">
 
 Here to suggest a new feature or new exercise?? **Hooray!** &nbsp;🎉 &nbsp;  
-We'd love if you did that via our [Exercism Community Forum](https://forum.exercism.org/). Please keep in mind [Chesterton's Fence][chestertons-fence].  
+We'd love if you did that via our [Exercism Community Forum](https://forum.exercism.org/).  
+Please read [Suggesting Exercise Improvements][suggesting-improvements] & [Chesterton's Fence][chestertons-fence].  
 _Thoughtful suggestions will likely result faster & more enthusiastic responses from volunteers._
 
 <br>
-
 <img align="left" width="85" height="80" src="https://github.com/exercism/website-icons/blob/main/exercises/word-search.svg">
 
 ✨&nbsp;🦄&nbsp; _**Want to jump directly into Exercism specifications & detail?**_  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Structure][exercism-track-structure] **|** [Tasks][exercism-tasks] **|** [Concepts][exercism-concepts] **|** [Concept Exercises][concept-exercises] **|** [Practice Exercises][practice-exercises] **|** [Presentation][exercise-presentation]  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Writing Style Guide][exercism-writing-style] **|** [Markdown Specification][exercism-markdown-specification] (_✨ version in [contributing][website-contributing-section] on exercism.org_)
 
-<br><br>
+<br>
+<br>
 
 ## Python Software and Documentation
 
@@ -94,10 +97,12 @@ This repository uses the [MIT License](/LICENSE).
 [exercism-track-structure]: https://github.com/exercism/docs/tree/main/building/tracks
 [exercism-website]: https://exercism.org/
 [exercism-writing-style]: https://github.com/exercism/docs/blob/main/building/markdown/style-guide.md
+[freeing-maintainers]: https://exercism.org/blog/freeing-our-maintainers
 [practice-exercises]: https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md
 [prs]: https://github.com/exercism/docs/blob/main/community/good-member/pull-requests.md
 [psf-license]: https://docs.python.org/3/license.html#psf-license
 [python-syllabus]: https://exercism.org/tracks/python/concepts
+[suggesting-improvements]: https://github.com/exercism/docs/blob/main/community/good-member/suggesting-exercise-improvements.md
 [the-words-that-we-use]: https://github.com/exercism/docs/blob/main/community/good-member/words.md
 [website-contributing-section]: https://exercism.org/docs/building
 [zero-clause-bsd]: https://docs.python.org/3/license.html#zero-clause-bsd-license-for-code-in-the-python-release-documentation

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -20,13 +20,14 @@ Code can be written and executed from the command line, in an interactive interp
 The [zen of Python (PEP 20)][the zen of python] and [What is Pythonic?][what is pythonic] lay out additional philosophies and perspectives on the language.
 
 
-This track currently uses `Python 3.9.0`.
+Tests and tooling for this track currently support `3.7` - `3.10.6` (_tests_) and [`Python 3.11`][311-new-features] (_tooling_).
 It is highly recommended that students upgrade to at least `Python 3.8`, as some features used by this track may not be supported in earlier versions.
-That being said, most exercises can be completed using Python 3.7, and many can be worked in Python 3.6.
-We will note when a feature is only available in a certain version.
+That being said, most of the exercises will work with `Python 3.6+`, and many are compatible with `Python 2.7+`.
+But we don't guarantee support for versions not listed under [Active Python Releases][active-python-releases].
+We will try to note when a feature is only available in a certain version.
 
 
-Complete documentation for the current release of Python (3.9.7) can be found at [docs.python.org][python docs].
+Complete documentation for the current release of Python (3.11.2) can be found at [docs.python.org][python docs].
 
 - [Python Tutorial][python tutorial]
 - [Python Library Reference][python library reference]
@@ -36,6 +37,9 @@ Complete documentation for the current release of Python (3.9.7) can be found at
 - [Python Glossary of Terms][python glossary of terms]
 
 
+
+[311-new-features]: https://docs.python.org/3/whatsnew/3.11.html
+[active-python-releases]: https://www.python.org/downloads/
 [duck typing]: https://en.wikipedia.org/wiki/Duck_typing
 [dynamic typing in python]: https://stackoverflow.com/questions/11328920/is-python-strongly-typed
 [editors for python]: https://djangostars.com/blog/python-ide/

--- a/docs/GENERATOR.md
+++ b/docs/GENERATOR.md
@@ -1,7 +1,8 @@
 # Exercism Python Track Test Generator
 
-The Python track uses a generator script and [Jinja2] templates for
-creating test files from the canonical data.
+The Python track uses a generator script and [Jinja2][Jinja2] templates for
+creating test files from Exercism's  [canonical data][canonical data].
+
 
 ## Table of Contents
 
@@ -15,13 +16,15 @@ creating test files from the canonical data.
   * [Learning Jinja](#learning-jinja)
   * [Creating a templates](#creating-a-templates)
 
+
 ## Script Usage
 
-Test generation requires a local copy of the [problem-specifications] repository.
+Test generation requires a local copy of the [problem-specifications][problem-specifications] repository.
 The script should be run from the root `python` directory, in order to correctly
 access the exercises.
 
 Run `bin/generate_tests.py --help` for usage information.
+
 
 ## Test Templates
 
@@ -41,6 +44,7 @@ Additionally, the following template filters are added for convenience:
 - `camel_case`: Converts a string to CamelCase (ex: `{{ "snake_case_string" | camel_case }}` -> `SnakeCaseString` )
 - `error_case`: Checks if a test case expects an error to be thrown (ex: `{% for case in cases%}{% if case is error_case}`)
 - `regex_replace`: Regex string replacement (ex: `{{ "abc123" | regex_replace("\\d", "D") }}` -> `abcDDD`)
+
 
 ### Conventions
 
@@ -63,6 +67,7 @@ files.
 # Additional tests for this track
 ```
 
+
 ### Layout
 
 Most templates will look something like this:
@@ -83,6 +88,7 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
 {{ macros.footer() }}
 ```
 
+
 ### Overriding Imports
 
 The names imported in `macros.header()` may be overridden by adding
@@ -91,6 +97,7 @@ a list of alternate names to import (ex:`clock`):
 ```Jinja2
 {{ macros.header(["Clock"])}}
 ```
+
 
 ### Ignoring Properties
 
@@ -101,6 +108,7 @@ are not tested in this track. The `header` macro also accepts an
 ```Jinja2
 {{ macros.header(ignore=["scores"]) }}
 ```
+
 
 ## Learning Jinja
 
@@ -127,8 +135,9 @@ Additional Resources:
 
 
 
+[Jinja Documentation]: https://jinja.palletsprojects.com/en/3.1.x/
 [Jinja2]: https://palletsprojects.com/p/jinja/
-[Jinja Documentation]: https://jinja.palletsprojects.com/en/2.10.x/
 [Primer on Jinja Templating]: https://realpython.com/primer-on-jinja-templating/
 [Python Jinja tutorial]: http://zetcode.com/python/jinja/
+[canonical data]: https://github.com/exercism/problem-specifications/tree/main/exercises
 [problem-specifications]: https://github.com/exercism/problem-specifications

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ Finally, these posts by Brett Cannon [A quick-and-dirty guide][quick-and-dirty] 
 
 **Note for MacOS users:**  prior to MacOS Monterey (12.3), `Python 2.7` came pre-installed with the operating system.
 Using `Python 2.7` with Exercism or most other programs is not recommended.
-You should instead install Python 3 via one of the methods detailed below.
+You should instead install [Python 3][Python-three downloads] via one of the methods detailed below.
 As of MacOS Monterey (12.3), no version of Python will be pre-installed via MacOS.
 
 Some quick links into the documentation by operating system:
@@ -18,12 +18,18 @@ Some quick links into the documentation by operating system:
    We recommend reviewing some of the methods outlined in the Real Python article [Installing Python][installing-python] or the articles by Brett Cannon linked above.
 
 
-Exercism tests and tooling currently support `Python 3.8` (_tests_) and `Python 3.9` (_tooling_).
-This means that the [newest features of Python `3.10`][310-new-features] are **not** currently supported.
-Please refer to the [Python 3.9.x documentation][3.9 docs] for what is currently supported.
+Exercism tests and tooling currently support `3.7` - `3.10.6` (_tests_) and [`Python 3.11`][311-new-features] (_tooling_).
+Exceptions to this support are noted where they occur.
+Most of the exercises will work with `Python 3.6+`, and many are compatible with `Python 2.7+`.
+But we don't guarantee support for versions not listed under [Active Python Releases][active-python-releases].
 
-[3.9 docs]: https://docs.python.org/3.9/
-[310-new-features]: https://docs.python.org/3/whatsnew/3.10.html
+
+Please refer to the [Python 3.11.x documentation][3.11 docs] for what is currently supported.
+
+[3.11 docs]: https://docs.python.org/3.11/
+[311-new-features]: https://docs.python.org/3/whatsnew/3.11.html
+[Python-three downloads]: https://www.python.org/downloads/
+[active-python-releases]: https://www.python.org/downloads/
 [helpful guide]: https://realpython.com/installing-python/
 [installing-python]: https://realpython.com/installing-python/#what-your-options-are_1
 [macos]: https://docs.python.org/3/using/mac.html

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -21,12 +21,13 @@ Below you will find some additional jumping-off places to start your learning jo
 - [Think Python][Think Python]
 - [Python for Non-Programmers][python-for-non-programmers]
 - [Python 4 Everyone][python4everyone]
-- [Introduction to Computer Science and Programming in Python (MIT)][mitocw600]
 - [Googles Python Class][googles python class]
 - [Microsoft's Python Learning Path][MS Python]
-- [PyCharm EDU **IDE** and **Courses**][pycharm edu] (_paid_)
+- [Introduction to Computer Science and Programming in Python (MIT)][mitocw600]
+- [Harvard CS50P][CS50P]
 
 
+[CS50P]: https://pll.harvard.edu/course/cs50s-introduction-programming-python?delta=0
 [Learn X in Y minutes]: https://learnxinyminutes.com/docs/python3/
 [MS Python]: https://docs.microsoft.com/en-us/learn/paths/python-language/
 [Python Documentation Tutorial]: https://docs.python.org/3/tutorial/index.html

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -272,5 +272,5 @@ export PATH=”$PATH:{python_directory}}”
 [python command line]: https://docs.python.org/3/using/cmdline.html
 [python-m-pip]: https://snarky.ca/why-you-should-use-python-m-pip/
 [quick-and-dirty]: https://snarky.ca/a-quick-and-dirty-guide-on-how-to-install-packages-for-python/
-[tutorial from pycqa.org]: https://pylint.pycqa.org/en/latest/tutorial.html
+[tutorial from pycqa.org]: https://pylint.pycqa.org/en/v2.17.2/tutorial.html
 [working with custom markers]: https://docs.pytest.org/en/6.2.x/example/markers.html#working-with-custom-markers

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -3,6 +3,7 @@
 Below are some resources for getting help if you run into trouble:
 
 - [The PSF](https://www.python.org) hosts Python downloads, documentation, and community resources.
+- [The Exercism Community on Discord](https://exercism.org/r/discord)
 - [Python Community on Discord](https://pythondiscord.com/) is a very helpful and active community.
 - [/r/learnpython/](https://www.reddit.com/r/learnpython/) is a subreddit designed for Python learners.
 - [#python on Libera.chat](https://www.python.org/community/irc/) this is where the core developers for the language hang out and get work done.


### PR DESCRIPTION
**`Do Not Merge Until the Python` [Test Runner](https://github.com/exercism/python-test-runner), [Analyzer](https://github.com/exercism/python-analyzer/pull/63), & [Representer](https://github.com/exercism/python-representer/pull/41) `are Updated to use Python 3.11.2`**

Hope I caught all references.

- [x] `CONTRIBUTING.md`
- [x] `README.md` -- added a link to "Suggesting Exercise Changes"
- [x] `/docs/ABOUT.md`
- [x] `/docs/GENERATOR.md`
- [x] `/docs/INSTALLATION.md` -- added links to the PSF downloads page
- [x] `/docs/LEARNING.md` -- added link to Harvards CS50P
- [x] `/docs/TESTS.md`
- [x] `/shared/.docs/help.md` -- added a link to the Exercism Discord channel.