### PR TITLE
[Tests.toml] Synced Deprecated Exercises.

### DIFF
--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -1,0 +1,35 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64d97c14-36dd-44a8-9621-2cecebd6ed23]
+description = "accumulate empty"
+include = false
+
+[00008ed2-4651-4929-8c08-8b4dbd70872e]
+description = "accumulate squares"
+include = false
+
+[551016da-4396-4cae-b0ec-4c3a1a264125]
+description = "accumulate upcases"
+include = false
+
+[cdf95597-b6ec-4eac-a838-3480d13d0d05]
+description = "accumulate reversed strings"
+include = false
+
+[bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
+description = "accumulate recursively"
+include = false
+
+[0b357334-4cad-49e1-a741-425202edfc7c]
+description = "accumulate recursively"
+include = false
+reimplements = "bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb"

--- a/exercises/practice/parallel-letter-frequency/.meta/tests.toml
+++ b/exercises/practice/parallel-letter-frequency/.meta/tests.toml
@@ -1,0 +1,62 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c054d642-c1fa-4234-8007-9339f2337886]
+description = "no texts"
+include = false
+
+[818031be-49dc-4675-b2f9-c4047f638a2a]
+description = "one text with one letter"
+include = false
+
+[c0b81d1b-940d-4cea-9f49-8445c69c17ae]
+description = "one text with multiple letters"
+include = false
+
+[708ff1e0-f14a-43fd-adb5-e76750dcf108]
+description = "two texts with one letter"
+include = false
+
+[1b5c28bb-4619-4c9d-8db9-a4bb9c3bdca0]
+description = "two texts with multiple letters"
+include = false
+
+[6366e2b8-b84c-4334-a047-03a00a656d63]
+description = "ignore letter casing"
+include = false
+
+[92ebcbb0-9181-4421-a784-f6f5aa79f75b]
+description = "ignore whitespace"
+include = false
+
+[bc5f4203-00ce-4acc-a5fa-f7b865376fd9]
+description = "ignore punctuation"
+include = false
+
+[68032b8b-346b-4389-a380-e397618f6831]
+description = "ignore numbers"
+include = false
+
+[aa9f97ac-3961-4af1-88e7-6efed1bfddfd]
+description = "Unicode letters"
+include = false
+
+[7b1da046-701b-41fc-813e-dcfb5ee51813]
+description = "combination of lower- and uppercase letters, punctuation and white space"
+include = false
+
+[4727f020-df62-4dcf-99b2-a6e58319cb4f]
+description = "large texts"
+include = false
+
+[adf8e57b-8e54-4483-b6b8-8b32c115884c]
+description = "many small texts"
+include = false

--- a/exercises/practice/strain/.meta/tests.toml
+++ b/exercises/practice/strain/.meta/tests.toml
@@ -1,0 +1,66 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[26af8c32-ba6a-4eb3-aa0a-ebd8f136e003]
+description = "keep on empty list returns empty list"
+include = false
+
+[f535cb4d-e99b-472a-bd52-9fa0ffccf454]
+description = "keeps everything"
+include = false
+
+[950b8e8e-f628-42a8-85e2-9b30f09cde38]
+description = "keeps nothing"
+include = false
+
+[92694259-6e76-470c-af87-156bdf75018a]
+description = "keeps first and last"
+include = false
+
+[938f7867-bfc7-449e-a21b-7b00cbb56994]
+description = "keeps neither first nor last"
+include = false
+
+[8908e351-4437-4d2b-a0f7-770811e48816]
+description = "keeps strings"
+include = false
+
+[2728036b-102a-4f1e-a3ef-eac6160d876a]
+description = "keeps lists"
+include = false
+
+[ef16beb9-8d84-451a-996a-14e80607fce6]
+description = "discard on empty list returns empty list"
+include = false
+
+[2f42f9bc-8e06-4afe-a222-051b5d8cd12a]
+description = "discards everything"
+include = false
+
+[ca990fdd-08c2-4f95-aa50-e0f5e1d6802b]
+description = "discards nothing"
+include = false
+
+[71595dae-d283-48ca-a52b-45fa96819d2f]
+description = "discards first and last"
+include = false
+
+[ae141f79-f86d-4567-b407-919eaca0f3dd]
+description = "discards neither first nor last"
+include = false
+
+[daf25b36-a59f-4f29-bcfe-302eb4e43609]
+description = "discards strings"
+include = false
+
+[a38d03f9-95ad-4459-80d1-48e937e4acaf]
+description = "discards lists"
+include = false


### PR DESCRIPTION
These exercises are deprecated for the track, so the `tests.toml` files have been updated to exclude all "new" tests.  The thought being that if we un-deprecated these exercises, they'd be in the old state, and we could see where they'd need changes.

- new file:   exercises/practice/accumulate/.meta/tests.toml
- new file:   exercises/practice/parallel-letter-frequency/.meta/tests.toml
- new file:   exercises/practice/strain/.meta/tests.toml