### PR TITLE
[list-ops]: change `//` to `/` and swap `foldr` arg order

### DIFF
--- a/exercises/practice/list-ops/.meta/additional_tests.json
+++ b/exercises/practice/list-ops/.meta/additional_tests.json
@@ -6,7 +6,7 @@
       "input": {
         "list": ["e", "x", "e", "r", "c", "i", "s", "m"],
         "initial": "!",
-        "function": "(x, y) -> x + y"
+        "function": "(acc, el) -> el + acc"
       },
       "expected": "exercism!"
     },

--- a/exercises/practice/list-ops/.meta/example.py
+++ b/exercises/practice/list-ops/.meta/example.py
@@ -29,7 +29,7 @@ def foldr(function, list, initial):
     if len(list) == 0:
         return initial
     else:
-        return function(foldr(function, list[1:], initial), list[0])
+        return function(list[0], foldr(function, list[1:], initial))
 
 
 def reverse(list):

--- a/exercises/practice/list-ops/.meta/example.py
+++ b/exercises/practice/list-ops/.meta/example.py
@@ -29,7 +29,7 @@ def foldr(function, list, initial):
     if len(list) == 0:
         return initial
     else:
-        return function(list[0], foldr(function, list[1:], initial))
+        return function(foldr(function, list[1:], initial), list[0])
 
 
 def reverse(list):

--- a/exercises/practice/list-ops/.meta/template.j2
+++ b/exercises/practice/list-ops/.meta/template.j2
@@ -2,7 +2,6 @@
 {% macro lambdify(function) -%}
     {% set function = function.replace("(", "", 1).replace(")", "", 1).replace(" ->", ":") %}
     {% set function = function.replace("modulo", "%") %}
-    {% set function = function.replace("/", "//") %}
     lambda {{function}}
 {%- endmacro %}
 

--- a/exercises/practice/list-ops/.meta/template.j2
+++ b/exercises/practice/list-ops/.meta/template.j2
@@ -1,4 +1,10 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{% macro swap_args(function) -%}
+    {% set function = function.replace("(acc, el)", "(el, acc)") %}
+    {% set function = function.replace("(x, y)", "(y, x)") %}
+    {{function}}
+{%- endmacro %}
+
 {% macro lambdify(function) -%}
     {% set function = function.replace("(", "", 1).replace(")", "", 1).replace(" ->", ":") %}
     {% set function = function.replace("modulo", "%") %}
@@ -29,8 +35,10 @@
             {{ lambdify(input["function"]) }}, {{ input["list"] }}
     {%- elif case["property"] == "length" or case["property"] == "reverse" -%}
             {{ input["list"] }}
-    {%- elif case["property"] == "foldl" or case["property"] == "foldr" -%}
+    {%- elif case["property"] == "foldl" -%}
             {{ lambdify(input["function"]) }}, {{ input["list"] }}, {{ stringify(input["initial"]) }}
+    {%- elif case["property"] == "foldr" -%}
+            {{ lambdify(swap_args(input["function"])) }}, {{ input["list"] }}, {{ stringify(input["initial"]) }}
     {%- endif -%}
             ),
             {{ stringify(case["expected"]) }}

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -71,7 +71,6 @@ reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
 [d7fcad99-e88e-40e1-a539-4c519681f390]
 description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
 reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
-include = false
 
 [aeb576b9-118e-4a57-a451-db49fac20fdc]
 description = "folds (reduces) the given list from the right with a function -> empty list"
@@ -96,7 +95,6 @@ reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
 [8066003b-f2ff-437e-9103-66e6df474844]
 description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
 reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
-include = false
 
 [94231515-050e-4841-943d-d4488ab4ee30]
 description = "reverse the elements of the list -> empty list"

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -63,11 +63,17 @@ class ListOpsTest(unittest.TestCase):
     def test_foldl_direction_independent_function_applied_to_non_empty_list(self):
         self.assertEqual(foldl(lambda acc, el: el + acc, [1, 2, 3, 4], 5), 15)
 
+    def test_foldl_direction_dependent_function_applied_to_non_empty_list(self):
+        self.assertEqual(foldl(lambda acc, el: el / acc, [1, 2, 3, 4], 24), 64)
+
     def test_foldr_empty_list(self):
         self.assertEqual(foldr(lambda acc, el: el * acc, [], 2), 2)
 
     def test_foldr_direction_independent_function_applied_to_non_empty_list(self):
         self.assertEqual(foldr(lambda acc, el: el + acc, [1, 2, 3, 4], 5), 15)
+
+    def test_foldr_direction_dependent_function_applied_to_non_empty_list(self):
+        self.assertEqual(foldr(lambda acc, el: el / acc, [1, 2, 3, 4], 24), 9)
 
     def test_reverse_empty_list(self):
         self.assertEqual(reverse([]), [])
@@ -84,7 +90,9 @@ class ListOpsTest(unittest.TestCase):
 
     def test_foldr_foldr_add_string(self):
         self.assertEqual(
-            foldr(lambda x, y: x + y, ["e", "x", "e", "r", "c", "i", "s", "m"], "!"),
+            foldr(
+                lambda acc, el: el + acc, ["e", "x", "e", "r", "c", "i", "s", "m"], "!"
+            ),
             "exercism!",
         )
 

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -67,13 +67,13 @@ class ListOpsTest(unittest.TestCase):
         self.assertEqual(foldl(lambda acc, el: el / acc, [1, 2, 3, 4], 24), 64)
 
     def test_foldr_empty_list(self):
-        self.assertEqual(foldr(lambda acc, el: el * acc, [], 2), 2)
+        self.assertEqual(foldr(lambda el, acc: el * acc, [], 2), 2)
 
     def test_foldr_direction_independent_function_applied_to_non_empty_list(self):
-        self.assertEqual(foldr(lambda acc, el: el + acc, [1, 2, 3, 4], 5), 15)
+        self.assertEqual(foldr(lambda el, acc: el + acc, [1, 2, 3, 4], 5), 15)
 
     def test_foldr_direction_dependent_function_applied_to_non_empty_list(self):
-        self.assertEqual(foldr(lambda acc, el: el / acc, [1, 2, 3, 4], 24), 9)
+        self.assertEqual(foldr(lambda el, acc: el / acc, [1, 2, 3, 4], 24), 9)
 
     def test_reverse_empty_list(self):
         self.assertEqual(reverse([]), [])
@@ -91,7 +91,7 @@ class ListOpsTest(unittest.TestCase):
     def test_foldr_foldr_add_string(self):
         self.assertEqual(
             foldr(
-                lambda acc, el: el + acc, ["e", "x", "e", "r", "c", "i", "s", "m"], "!"
+                lambda el, acc: el + acc, ["e", "x", "e", "r", "c", "i", "s", "m"], "!"
             ),
             "exercism!",
         )


### PR DESCRIPTION
[Related Forum Discussion here](https://forum.exercism.org/t/bug-in-python-list-ops-test/4835/31).