### PR TITLE
Removed footer macro and regenerated test file

### DIFF
--- a/exercises/practice/all-your-base/.meta/template.j2
+++ b/exercises/practice/all-your-base/.meta/template.j2
@@ -1,32 +1,30 @@
 {%- import "generator_macros.j2" as macros with context -%}
 
 {%- macro func_call(case) -%}
-    {{ case["property"] }}(
-        {% for arg in case["input"].values() %}
-            {{ arg }}{{- "," if not loop.last }}
-        {% endfor %}
-    )
+{{ case["property"] }}(
+{% for arg in case["input"].values() %}
+{{ arg }}{{- "," if not loop.last }}
+{% endfor %}
+)
 {%- endmacro -%}
 
 {%- macro test_case(case) -%}
-    {%- set expected = case["expected"] -%}
-    {%- set exp_error = expected["error"] -%}
-    def test_{{ case["description"] | to_snake }}(self):
-    {%- if case is error_case %}
-        with self.assertRaises(ValueError) as err:
-            {{ func_call(case) }}
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "{{ exp_error }}")
-    {%- else %}
-        self.assertEqual({{ func_call(case) }}, {{ expected }})
-    {%- endif %}
+{%- set expected = case["expected"] -%}
+{%- set exp_error = expected["error"] -%}
+def test_{{ case["description"] | to_snake }}(self):
+{%- if case is error_case %}
+with self.assertRaises(ValueError) as err:
+{{ func_call(case) }}
+self.assertEqual(type(err.exception), ValueError)
+self.assertEqual(err.exception.args[0], "{{ exp_error }}")
+{%- else %}
+self.assertEqual({{ func_call(case) }}, {{ expected }})
+{%- endif %}
 {% endmacro %}
 
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
-    {% for case in cases -%}
-    {{ test_case(case) }}
-    {% endfor -%}
-
-{{ macros.footer() }}
+{% for case in cases -%}
+{{ test_case(case) }}
+{% endfor -%}

--- a/exercises/practice/armstrong-numbers/.meta/template.j2
+++ b/exercises/practice/armstrong-numbers/.meta/template.j2
@@ -2,13 +2,11 @@
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
-    {% for case in cases -%}
-    def test_{{ case["description"] | to_snake }}(self):
-        self.assertIs(
-            {{ case["property"] | to_snake }}({{ case["input"]["number"] }}),
-            {{ case["expected"] }}
-        )
+{% for case in cases -%}
+def test_{{ case["description"] | to_snake }}(self):
+self.assertIs(
+{{ case["property"] | to_snake }}({{ case["input"]["number"] }}),
+{{ case["expected"] }}
+)
 
-    {% endfor %}
-
-{{ macros.footer() }}
+{% endfor %}

--- a/exercises/practice/atbash-cipher/.meta/template.j2
+++ b/exercises/practice/atbash-cipher/.meta/template.j2
@@ -2,14 +2,12 @@
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
-    {% for case in cases -%}
-    {% for subcase in case["cases"] -%}
-    def test_{{ subcase["description"] | to_snake }}(self):
-        {% set value = subcase["input"]["phrase"] -%}
-        {% set expected = subcase["expected"] -%}
-        self.assertEqual({{ subcase["property"] }}("{{ value }}"), "{{ expected }}")
-    {% endfor %}
+{% for case in cases -%}
+{% for subcase in case["cases"] -%}
+def test_{{ subcase["description"] | to_snake }}(self):
+{% set value = subcase["input"]["phrase"] -%}
+{% set expected = subcase["expected"] -%}
+self.assertEqual({{ subcase["property"] }}("{{ value }}"), "{{ expected }}")
+{% endfor %}
 
-    {% endfor %}
-
-{{ macros.footer() }}
+{% endfor %}

--- a/exercises/practice/beer-song/.meta/template.j2
+++ b/exercises/practice/beer-song/.meta/template.j2
@@ -2,22 +2,19 @@
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
-    {% for case in cases -%}
-    {% for subcase in case["cases"] -%}
-    {% for subsubcase in subcase["cases"] -%}
-    def test_{{ subsubcase["description"] | to_snake }}(self):
-        {% set start = subsubcase["input"]["startBottles"] -%}
-        {% set take = subsubcase["input"]["takeDown"] -%}
-        expected = {{ subsubcase["expected"] }}
-        {%- if take == 1 %}
-        self.assertEqual({{ subsubcase["property"] }}(start={{ start}}), expected)
-        {% else %}
-        self.assertEqual({{ subsubcase["property"] }}(start={{ start}}, take={{ take }}), expected)
-        {% endif %}
+{% for case in cases -%}
+{% for subcase in case["cases"] -%}
+{% for subsubcase in subcase["cases"] -%}
+def test_{{ subsubcase["description"] | to_snake }}(self):
+{% set start = subsubcase["input"]["startBottles"] -%}
+{% set take = subsubcase["input"]["takeDown"] -%}
+expected = {{ subsubcase["expected"] }}
+{%- if take == 1 %}
+self.assertEqual({{ subsubcase["property"] }}(start={{ start}}), expected)
+{% else %}
+self.assertEqual({{ subsubcase["property"] }}(start={{ start}}, take={{ take }}), expected)
+{% endif %}
 
-    {% endfor %}
-    {% endfor %}
-    {% endfor %}
-
-
-{{ macros.footer() }}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/exercises/practice/binary-search-tree/.meta/template.j2
+++ b/exercises/practice/binary-search-tree/.meta/template.j2
@@ -5,64 +5,61 @@
 None
 {%- else -%}
 TreeNode("{{ tree_obj["data"] }}",
-    {{- build_tree(tree_obj["left"]) -}},
-    {{- build_tree(tree_obj["right"]) -}})
+{{- build_tree(tree_obj["left"]) -}},
+{{- build_tree(tree_obj["right"]) -}})
 {%- endif -%}
 {%- endmacro -%}
 
 {%- macro test_case(case) %}
-    def test_{{ case["description"] | to_snake }}(self):
-    {%- set prop = case["property"] -%}
-    {%- set tree_data = case["input"]["treeData"] -%}
-    {%- set expected = case["expected"] -%}
-    {%- if expected is mapping %}
-        {%- set assertion = "assertTreeEqual" %}
-        expected = {{ build_tree(expected) }}
-    {%- else %}
-        {%- set assertion = "assertEqual" %}
-        expected = {{ expected }}
-    {%- endif %}
-        self.{{ assertion }}(BinarySearchTree({{ tree_data }}).{{ prop | to_snake }}(),expected)
+def test_{{ case["description"] | to_snake }}(self):
+{%- set prop = case["property"] -%}
+{%- set tree_data = case["input"]["treeData"] -%}
+{%- set expected = case["expected"] -%}
+{%- if expected is mapping %}
+{%- set assertion = "assertTreeEqual" %}
+expected = {{ build_tree(expected) }}
+{%- else %}
+{%- set assertion = "assertEqual" %}
+expected = {{ expected }}
+{%- endif %}
+self.{{ assertion }}(BinarySearchTree({{ tree_data }}).{{ prop | to_snake }}(),expected)
 {%- endmacro -%}
 
 {{ macros.header (imports=["BinarySearchTree", "TreeNode"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
 {%- for case in cases %}
-    {%- if "cases" in case %}
-        {%- for subcase in case["cases"] %}
-            {{ test_case(subcase) }}
-        {%- endfor %}
-    {%- else -%}
-        {{ test_case(case) }}
-    {%- endif %}
+{%- if "cases" in case %}
+{%- for subcase in case["cases"] %}
+{{ test_case(subcase) }}
+{%- endfor %}
+{%- else -%}
+{{ test_case(case) }}
+{%- endif %}
 {%- endfor %}
 
-   # Utilities
-    def assertTreeEqual(self, tree_one, tree_two):
-        try:
-            self.compare_tree(tree_one, tree_two)
-        except AssertionError:
-            raise AssertionError("{} != {}".format(tree_one, tree_two))
+# Utilities
+def assertTreeEqual(self, tree_one, tree_two):
+try:
+self.compare_tree(tree_one, tree_two)
+except AssertionError:
+raise AssertionError("{} != {}".format(tree_one, tree_two))
 
-    def compare_tree(self, tree_one, tree_two):
-        self.assertEqual(tree_one.data, tree_two.data)
+def compare_tree(self, tree_one, tree_two):
+self.assertEqual(tree_one.data, tree_two.data)
 
-        # Compare left tree nodes
-        if tree_one.left and tree_two.left:
-            self.compare_tree(tree_one.left, tree_two.left)
-        elif tree_one.left is None and tree_two.left is None:
-            pass
-        else:
-            raise AssertionError
+# Compare left tree nodes
+if tree_one.left and tree_two.left:
+self.compare_tree(tree_one.left, tree_two.left)
+elif tree_one.left is None and tree_two.left is None:
+pass
+else:
+raise AssertionError
 
-        # Compare right tree nodes
-        if tree_one.right and tree_two.right:
-            self.compare_tree(tree_one.right, tree_two.right)
-        elif tree_one.right is None and tree_two.right is None:
-            pass
-        else:
-            raise AssertionError
-
-
-{{ macros.footer() }}
+# Compare right tree nodes
+if tree_one.right and tree_two.right:
+self.compare_tree(tree_one.right, tree_two.right)
+elif tree_one.right is None and tree_two.right is None:
+pass
+else:
+raise AssertionError


### PR DESCRIPTION
All tests passed with new test files.

When I save the template.j2 files it auto formats and removes the indents. It seems to work without being indented though.

Let me know if you would like me to change this.