### PR TITLE
Fix formatting issue

### DIFF
--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -43,5 +43,6 @@ jump, double blink
 
 ~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
-[intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
 ~~~~
+
+[intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa


### PR DESCRIPTION
This doesn't have a forum post associated, as it's a basic typo correction. The note currently looks like this:
<img width="640" alt="image" src="https://github.com/exercism/python/assets/62411302/fca4f5bc-7653-4f19-8931-acc9cfe883f6">

I believe by changing this it should be formatted correctly. If perhaps you use an automated system and this PR never gets looked at, I'll open a topic on the forum about it.