### PR TITLE
[New Practice Exercise]:  Global Meetup Basic draft

### DIFF
--- a/concepts/binary-octal-hexadecimal/about.md
+++ b/concepts/binary-octal-hexadecimal/about.md
@@ -194,7 +194,6 @@ As with binary and octal, Python will automatically convert hexadecimal literals
 As with binary and octal - hexidecimal literals **are ints**, and you can perform all integer operations.  
 Prefixing a non-hexidecimal number with `0x` will raise a `SyntaxError`.
 
-### Representing hexadecimal numbers
 
 ###  Converting to and from Hexadecimal Representation
 

--- a/concepts/binary-octal-hexadecimal/about.md
+++ b/concepts/binary-octal-hexadecimal/about.md
@@ -133,7 +133,6 @@ For example, `bit_count()` on '0b11011' will return 4:
 ```python
 >>> 0b11011.bit_count()
 4
-
 ~~~~exercism/note
 If you are working locally, `bit_count()` requires at least Python 3.10.
 The Exercism online editor currently supports all features through Python 3.11.

--- a/config.json
+++ b/config.json
@@ -1081,13 +1081,10 @@
         "slug": "global-meeting",
         "name": "Global Meeting",
         "uuid": "795edb33-ec92-43c5-8cd9-147af4d56f5d",
-        "practices": ["datetime", "date-formatting"],
         "prerequisites": [
           "basics",
           "bools",
           "conditionals",
-          "classes",
-          "datetime",
           "dictionaries",
           "loops"
         ],

--- a/config.json
+++ b/config.json
@@ -1063,6 +1063,22 @@
         "difficulty": 3
       },
       {
+        "slug": "global-meeting",
+        "name": "Global Meeting",
+        "uuid": "795edb33-ec92-43c5-8cd9-147af4d56f5d",
+        "practices": ["datetime", "date-formatting"],
+        "prerequisites": [
+          "basics",
+          "bools",
+          "conditionals",
+          "classes",
+          "datetime",
+          "dictionaries",
+          "loops"
+        ],
+        "difficulty": 3
+      },
+      {
         "slug": "kindergarten-garden",
         "name": "Kindergarten Garden",
         "uuid": "42a2916c-ef03-44ac-b6d8-7eda375352c2",

--- a/config.json
+++ b/config.json
@@ -1091,7 +1091,7 @@
           "dictionaries",
           "loops"
         ],
-        "difficulty": 3
+        "difficulty": 4
       },
       {
         "slug": "kindergarten-garden",

--- a/config.json
+++ b/config.json
@@ -1081,6 +1081,7 @@
         "slug": "global-meeting",
         "name": "Global Meeting",
         "uuid": "795edb33-ec92-43c5-8cd9-147af4d56f5d",
+        "practices": [],
         "prerequisites": [
           "basics",
           "bools",

--- a/exercises/practice/global-meeting/.docs/instructions.append.md
+++ b/exercises/practice/global-meeting/.docs/instructions.append.md
@@ -1,0 +1,45 @@
+# Instruction append
+Here's an example of what's expected:
+```python
+>>> meeting_time("06/21/2023", {
+        110: (5.5, "08:00 AM", "05:00 PM"),
+        111: (-10, "12:00 PM", "09:00 PM"),
+        112: (3, "04:00 AM", "01:00 PM"),
+        113: (-4, "04:00 PM", "01:00 AM")
+    })
+{
+    "03:00 AM": {
+        110: "06/21/2023 08:30 AM",
+        111: "06/20/2023 05:00 PM",
+        112: "06/21/2023 06:00 AM",
+        113: "06/20/2023 11:00 PM",
+    },
+    "4:00 AM": {
+        110: "06/21/2023 09:30 AM",
+        111: "06/20/2023 06:00 PM",
+        112: "06/21/2023 07:00 AM",
+        113: "06/21/2023 12:00 AM",
+    },
+}
+```
+
+## Errors
+Admittedly, you're a little eccentric. 
+You might provide working hours that are more or less than 9 - in which case you want the program to call out your error:
+```
+>>> meeting_time({
+        201: [2, (5, 15)],
+        202: [5, (13, 22)],
+    })
+ValueError: some employees are working for more or less than 9 hours 
+```
+
+If there's no possible meeting period, then you have to reshuffle teams.
+Until then, your code should raise an error:
+```
+>>> meeting_time({
+        201: [5, (5, 14)],
+        202: [2, (13, 22)],
+    })
+ValueError: there's no possible meeting time for the provided employees
+```

--- a/exercises/practice/global-meeting/.docs/instructions.append.md
+++ b/exercises/practice/global-meeting/.docs/instructions.append.md
@@ -23,9 +23,19 @@ Here's an example of what's expected:
 }
 ```
 
-## Errors
+## Exception messages
+
+Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tutorial/errors.html#raising-exceptions). 
+When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. 
+This makes your code more readable and helps significantly with debugging. For situations where you know that the error source will be a certain type, you can choose to raise one of the [built in error types](https://docs.python.org/3/library/exceptions.html#base-classes), but should still include a meaningful message.
+
+
+
+
 Admittedly, you're a little eccentric. 
 You might provide working hours that are more or less than 9 - in which case you want the program to call out your error:
+
+To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
 ```
 >>> meeting_time({
         201: [2, (5, 15)],

--- a/exercises/practice/global-meeting/.docs/instructions.md
+++ b/exercises/practice/global-meeting/.docs/instructions.md
@@ -5,39 +5,9 @@ Your task is to find out a time in which a set of your employees are working so 
 Company policy allows employees to choose their own 9 hours of working time, inclusive of an hour of break, and you don't mind if people are eating during the meeting.
 
 
-Take in a dictionary of employee IDs with their time zones and working hours, and return all possible meeting times in UTC.
+Take in a collection of employee IDs with their time zones and working hours, and return a collection of all possible meeting times, each of which should contain the local time and date for all employees.
 Note that the meeting should start and end corresponding with a UTC hour - that is, a meeting can't start at say, 3:30 UTC.
 
-Time zones are stored as a number which represents the difference from UTC.
+Time zones are represented as UTC offsets.
 
 All possible meeting start times must be reported.
-```python
->>> meeting_time({
-        110: [5.5, (9, 17)],
-        111: [-10, (12, 21)],
-        112: [3, (4, 13)],
-        113: [-4, (15, 0)]
-    })
-[3]
-```
-
-## Errors
-Admittedly, you're a little eccentric. 
-You might provide working hours that are more or less than 9 - in which case you want the program to call out your error:
-```
->>> meeting_time({
-        201: [2, (5, 15)],
-        202: [5, (13, 22)],
-    })
-ValueError: some employees are working for more or less than 9 hours 
-```
-
-If there's no possible meeting period, then you have to reshuffle teams.
-Until then, your code should raise an error:
-```
->>> meeting_time({
-        201: [5, (5, 14)],
-        202: [2, (13, 22)],
-    })
-ValueError: there's no possible meeting time for the provided employees
-```

--- a/exercises/practice/global-meeting/.docs/instructions.md
+++ b/exercises/practice/global-meeting/.docs/instructions.md
@@ -2,12 +2,16 @@
 
 Your task is to find out a time in which a set of your employees are working so that you can have an hour-long meeting.
 
-Company policy allows employees to choose their own 9 hours of working time, inclusive of an hour of break, and you don't mind if people are eating during the meeting.
+Company policy allows employees to choose their own 9 hours of working time, inclusive of an hour break.
+This is an important meeting, so if people need to attend during their break, the company will let them take an extra break/hour on another day within the month.
 
 
-Take in a collection of employee IDs with their time zones and working hours, and return a collection of all possible meeting times, each of which should contain the local time and date for all employees.
-Note that the meeting should start and end corresponding with a UTC hour - that is, a meeting can't start at say, 3:30 UTC.
+Given a collection of employee IDs with their time zones and working hours, return a collection of all possible meeting times, each of which should contain the local time and date for all employees listed.
+Note that meetings should start "on the hour" in UTC - in other words, a meeting can't start at, 3:30, 12:10, or 17:45 UTC.
+Local times, of course may vary.
 
-Time zones are represented as UTC offsets.
+Local time zones are represented as _[UTC offsets][UTC offset]_.
 
-All possible meeting start times must be reported.
+All possible meeting start times should be reported.
+
+[UTC offset]: https://en.wikipedia.org/wiki/UTC_offset

--- a/exercises/practice/global-meeting/.docs/instructions.md
+++ b/exercises/practice/global-meeting/.docs/instructions.md
@@ -10,7 +10,7 @@ Given a collection of employee IDs with their time zones and working hours, retu
 Note that meetings should start "on the hour" in UTC - in other words, a meeting can't start at, 3:30, 12:10, or 17:45 UTC.
 Local times, of course may vary.
 
-Local time zones are represented as _[UTC offsets][UTC offset]_.
+Local time zones are represented as [UTC offsets][UTC offset].
 
 All possible meeting start times should be reported.
 

--- a/exercises/practice/global-meeting/.docs/instructions.md
+++ b/exercises/practice/global-meeting/.docs/instructions.md
@@ -1,0 +1,43 @@
+# Instructions
+
+Your task is to find out a time in which a set of your employees are working so that you can have an hour-long meeting.
+
+Company policy allows employees to choose their own 9 hours of working time, inclusive of an hour of break, and you don't mind if people are eating during the meeting.
+
+
+Take in a dictionary of employee IDs with their time zones and working hours, and return all possible meeting times in UTC.
+Note that the meeting should start and end corresponding with a UTC hour - that is, a meeting can't start at say, 3:30 UTC.
+
+Time zones are stored as a number which represents the difference from UTC.
+
+All possible meeting start times must be reported.
+```python
+>>> meeting_time({
+        110: [5.5, (9, 17)],
+        111: [-10, (12, 21)],
+        112: [3, (4, 13)],
+        113: [-4, (15, 0)]
+    })
+[3]
+```
+
+## Errors
+Admittedly, you're a little eccentric. 
+You might provide working hours that are more or less than 9 - in which case you want the program to call out your error:
+```
+>>> meeting_time({
+        201: [2, (5, 15)],
+        202: [5, (13, 22)],
+    })
+ValueError: some employees are working for more or less than 9 hours 
+```
+
+If there's no possible meeting period, then you have to reshuffle teams.
+Until then, your code should raise an error:
+```
+>>> meeting_time({
+        201: [5, (5, 14)],
+        202: [2, (13, 22)],
+    })
+ValueError: there's no possible meeting time for the provided employees
+```

--- a/exercises/practice/global-meeting/.docs/introduction.md
+++ b/exercises/practice/global-meeting/.docs/introduction.md
@@ -1,0 +1,14 @@
+# Introduction
+
+You've decided to make your video game manufacturing company fully remote: all employees work from home!
+This has multiple advantages: after all, transit is annoying, and you have much more time to play on your video console (working for the company, of course).
+Sun or rain, no matter to you anymore. 
+Furthermore, people all over the world have heard about your wonderful company, and you've got lots of new and diverse talent working away at the latest edition of _Mad Cat_. 
+
+You're thrilled! 
+There's only one hitch. 
+To ensure that everyone is working towards the same product and brainstorm your next bestseller, you need to have a weekly meeting. 
+Unfortunately, it's tough to arrange a meeting with people from different timezones, and your first attempt was a ghastly failure where many crucial people spent time rubbing their eyes.
+
+Your advisor tells you to calculate a timing suitable for everybody - but you barely passed high school math. 
+You panic as the date of release looms: but you've realized that you can write a program to do it for you! 

--- a/exercises/practice/global-meeting/.docs/introduction.md
+++ b/exercises/practice/global-meeting/.docs/introduction.md
@@ -9,6 +9,7 @@ You're thrilled!
 There's only one hitch. 
 To ensure that everyone is working towards the same product and brainstorm your next bestseller, you need to have a weekly meeting. 
 Unfortunately, it's tough to arrange a meeting with people from different timezones, and your first attempt was a ghastly failure where many crucial people spent time rubbing their eyes.
+Worse, employees often miscalculated the start time in their local timezone, so many missed the meeting. 
 
-Your advisor tells you to calculate a timing suitable for everybody - but you barely passed high school math. 
-You panic as the date of release looms: but you've realized that you can write a program to do it for you! 
+Your advisor tells you to calculate a timing suitable for everybody _and_ email employees with their local timings - but you barely passed high school math. 
+You panic as the date of release looms: but you've realized that you can write a program to do it for you!

--- a/exercises/practice/global-meeting/.docs/introduction.md
+++ b/exercises/practice/global-meeting/.docs/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
 You've decided to make your video game manufacturing company The Catness® fully remote: all employees work from home!
-This has multiple advantages: after all, transit is annoying and exhausting, and everyone has their commute time back for more important activities (_like plying on their gaming consoles_).
-Furthermore, people all over the world have heard about your wonderful company, and you've got lots of new and diverse talent working away at the latest edition of your flagship game _**Mad Cat**_. 
+This has multiple advantages: after all, transit is annoying and exhausting, and everyone has their commute time back for more important activities (_like playing on their gaming consoles_).
+Furthermore, people all over the world have heard about your wonderful company, and you've got lots of new and diverse talent working away at the latest edition of your flagship game _Mad Cat_. 
 
 You're thrilled! 
 There's only one hitch. 

--- a/exercises/practice/global-meeting/.docs/introduction.md
+++ b/exercises/practice/global-meeting/.docs/introduction.md
@@ -1,15 +1,15 @@
 # Introduction
 
-You've decided to make your video game manufacturing company fully remote: all employees work from home!
-This has multiple advantages: after all, transit is annoying, and you have much more time to play on your video console (working for the company, of course).
-Sun or rain, no matter to you anymore. 
-Furthermore, people all over the world have heard about your wonderful company, and you've got lots of new and diverse talent working away at the latest edition of _Mad Cat_. 
+You've decided to make your video game manufacturing company The Catness® fully remote: all employees work from home!
+This has multiple advantages: after all, transit is annoying and exhausting, and everyone has their commute time back for more important activities (_like plying on their gaming consoles_).
+Furthermore, people all over the world have heard about your wonderful company, and you've got lots of new and diverse talent working away at the latest edition of your flagship game _**Mad Cat**_. 
 
 You're thrilled! 
 There's only one hitch. 
-To ensure that everyone is working towards the same product and brainstorm your next bestseller, you need to have a weekly meeting. 
-Unfortunately, it's tough to arrange a meeting with people from different timezones, and your first attempt was a ghastly failure where many crucial people spent time rubbing their eyes.
-Worse, employees often miscalculated the start time in their local timezone, so many missed the meeting. 
+To ensure that everyone is working towards the same goals and keeping to the release schedule, you need to have a weekly meeting.
+It's tough to arrange a meeting across different timezones, and your first attempt was a ghastly failure.
+Many crucial people spent time rubbing their eyes and not paying attention.
+Worse, there were a lot of absences because employees miscalculated their local meeting start times. 
 
 Your advisor tells you to calculate a timing suitable for everybody _and_ email employees with their local timings - but you barely passed high school math. 
 You panic as the date of release looms: but you've realized that you can write a program to do it for you!

--- a/exercises/practice/global-meeting/.meta/config.json
+++ b/exercises/practice/global-meeting/.meta/config.json
@@ -1,0 +1,17 @@
+
+{
+  "authors": ["safwansamsudeen"],
+  "contributors": [],
+  "files": {
+    "solution": [
+      "global_meetup.py"
+    ],
+    "test": [
+      "global_meetup_test.py"
+    ],
+    "example": [
+      ".meta/example.py"
+    ]
+  },
+  "blurb": "Find a time when a global team can have a meeting",
+}

--- a/exercises/practice/global-meeting/.meta/config.json
+++ b/exercises/practice/global-meeting/.meta/config.json
@@ -13,5 +13,5 @@
       ".meta/example.py"
     ]
   },
-  "blurb": "Find a time when a global team can have a meeting",
+  "blurb": "Find a time when a global team can have a meeting"
 }

--- a/exercises/practice/global-meeting/.meta/config.json
+++ b/exercises/practice/global-meeting/.meta/config.json
@@ -13,5 +13,5 @@
       ".meta/example.py"
     ]
   },
-  "blurb": "Find a time when a global team can have a meeting"
+  "blurb": "Find a time when a global team can have their meeting"
 }

--- a/exercises/practice/global-meeting/.meta/example.py
+++ b/exercises/practice/global-meeting/.meta/example.py
@@ -1,0 +1,26 @@
+from math import ceil, floor
+
+def meeting_time(employee_info):
+    employee_times = []
+    for _, (time_zone, (start_time, end_time)) in employee_info.items():
+        if (end_time if end_time >= start_time else end_time + 24) - start_time != 9:
+            raise ValueError("some employees are working for more or less than 9 hours")
+        start_time_utc = (start_time - time_zone) % 24
+        end_time_utc = (end_time - time_zone) % 24
+
+        employee_times.append((start_time_utc, end_time_utc))
+
+
+    employee_times_set = []
+    for start_time, end_time in employee_times:
+        if end_time > start_time:
+            employee_times_set.append(set(range(ceil(start_time), floor(end_time))))
+        else:
+            employee_times_set.append({*range(ceil(start_time), 24), *range(0, floor(end_time))})
+
+
+    possible_times = list(set.intersection(*employee_times_set))
+
+    if not possible_times:
+        raise ValueError("there's no possible meeting time for the provided employees")
+    return possible_times

--- a/exercises/practice/global-meeting/.meta/example.py
+++ b/exercises/practice/global-meeting/.meta/example.py
@@ -1,26 +1,46 @@
-from math import ceil, floor
-
-def meeting_time(employee_info):
-    employee_times = []
-    for _, (time_zone, (start_time, end_time)) in employee_info.items():
-        if (end_time if end_time >= start_time else end_time + 24) - start_time != 9:
-            raise ValueError("some employees are working for more or less than 9 hours")
-        start_time_utc = (start_time - time_zone) % 24
-        end_time_utc = (end_time - time_zone) % 24
-
-        employee_times.append((start_time_utc, end_time_utc))
+from datetime import datetime, timedelta, timezone, time
 
 
-    employee_times_set = []
-    for start_time, end_time in employee_times:
-        if end_time > start_time:
-            employee_times_set.append(set(range(ceil(start_time), floor(end_time))))
-        else:
-            employee_times_set.append({*range(ceil(start_time), 24), *range(0, floor(end_time))})
+def meeting_time(date_str, employees):
+    meeting_times = {}
 
+    meeting_date = datetime.strptime(date_str, "%m/%d/%Y")
 
-    possible_times = list(set.intersection(*employee_times_set))
+    for hour in range(24):
+        meeting_start_time = meeting_date.replace(
+            hour=hour, minute=0, second=0, tzinfo=timezone.utc
+        )
+        meeting_end_time = meeting_start_time + timedelta(hours=1)
 
-    if not possible_times:
-        raise ValueError("there's no possible meeting time for the provided employees")
-    return possible_times
+        employees_possible = {}
+        for emp_id, (utc_offset, emp_start_str, emp_end_str) in employees.items():
+            emp_timezone = timezone(timedelta(hours=utc_offset))
+
+            start_datetime = datetime.combine(
+                meeting_date,
+                datetime.strptime(emp_start_str, "%I:%M %p").time(),
+                tzinfo=emp_timezone,
+            ).astimezone(timezone.utc)
+            end_datetime = datetime.combine(
+                meeting_date,
+                datetime.strptime(emp_end_str, "%I:%M %p").time(),
+                tzinfo=emp_timezone,
+            ).astimezone(timezone.utc)
+
+            if end_datetime < start_datetime:
+                end_datetime = end_datetime + timedelta(days=1)
+            for i in range(-1, 2):
+                modified_start = start_datetime + timedelta(days=i)
+                modified_end = end_datetime + timedelta(days=i)
+                if (
+                    modified_start <= meeting_start_time
+                    and modified_end >= meeting_end_time
+                ):
+                    employees_possible[emp_id] = meeting_start_time.astimezone(
+                        emp_timezone
+                    ).strftime("%m/%d/%Y %I:%M %p")
+
+        if len(employees_possible) == 4:
+            meeting_times[time(hour=hour).strftime("%I:%M %p")] = employees_possible
+
+    return meeting_times

--- a/exercises/practice/global-meeting/global_meeting.py
+++ b/exercises/practice/global-meeting/global_meeting.py
@@ -1,0 +1,2 @@
+def meeting_time(employee_info):
+    pass

--- a/exercises/practice/global-meeting/global_meeting.py
+++ b/exercises/practice/global-meeting/global_meeting.py
@@ -1,2 +1,2 @@
-def meeting_time(employee_info):
+def meeting_time(date_str, employee_info):
     pass

--- a/exercises/practice/global-meeting/global_meeting_test.py
+++ b/exercises/practice/global-meeting/global_meeting_test.py
@@ -32,5 +32,4 @@ class GlobalMeetingTest(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
     unittest.main()

--- a/exercises/practice/global-meeting/global_meeting_test.py
+++ b/exercises/practice/global-meeting/global_meeting_test.py
@@ -32,4 +32,4 @@ class GlobalMeetingTest(unittest.TestCase):
         )
 
 
-    unittest.main()
+unittest.main()

--- a/exercises/practice/global-meeting/global_meeting_test.py
+++ b/exercises/practice/global-meeting/global_meeting_test.py
@@ -1,0 +1,38 @@
+import unittest
+
+from global_meeting import meeting_time
+
+class GlobalMeetingTest(unittest.TestCase):
+    def test_same_working_times(self):
+        self.assertEqual(meeting_time({
+            111: [2, (8, 17)],
+            112: [8, (8, 17)],
+            113: [10, (8, 17)],
+        }), [6])
+
+    def test_different_working_times(self):
+        self.assertEqual(meeting_time({
+            201: [5.5, (8, 17)],
+            202: [-4, (15, 0)],
+            203: [-10, (12, 21)],
+            204: [3, (4, 13)],
+        }), [3])
+
+    def test_wrong_values(self):
+        with self.assertRaises(ValueError) as err:
+            meeting_time({
+                201: [2, (5, 15)],
+                202: [5, (13, 22)],
+            })
+        self.assertEqual("some employees are working for more or less than 9 hours", str(err.exception))
+
+    def test_impossible(self):
+        with self.assertRaises(ValueError) as err:
+            meeting_time({
+                201: [2, (13, 22)],
+                202: [5, (5, 14)],
+            })
+        self.assertEqual("there's no possible meeting time for the provided employees", str(err.exception))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exercises/practice/global-meeting/global_meeting_test.py
+++ b/exercises/practice/global-meeting/global_meeting_test.py
@@ -2,37 +2,35 @@ import unittest
 
 from global_meeting import meeting_time
 
+
 class GlobalMeetingTest(unittest.TestCase):
-    def test_same_working_times(self):
-        self.assertEqual(meeting_time({
-            111: [2, (8, 17)],
-            112: [8, (8, 17)],
-            113: [10, (8, 17)],
-        }), [6])
-
     def test_different_working_times(self):
-        self.assertEqual(meeting_time({
-            201: [5.5, (8, 17)],
-            202: [-4, (15, 0)],
-            203: [-10, (12, 21)],
-            204: [3, (4, 13)],
-        }), [3])
+        self.assertEqual(
+            meeting_time(
+                "06/21/2023",
+                {
+                    110: (5.5, "08:00 AM", "05:00 PM"),
+                    111: (-10, "12:00 PM", "09:00 PM"),
+                    112: (3, "04:00 AM", "01:00 PM"),
+                    113: (-4, "04:00 PM", "01:00 AM"),
+                },
+            ),
+            {
+                "03:00 AM": {
+                    110: "06/21/2023 08:30 AM",
+                    111: "06/20/2023 05:00 PM",
+                    112: "06/21/2023 06:00 AM",
+                    113: "06/20/2023 11:00 PM",
+                },
+                "04:00 AM": {
+                    110: "06/21/2023 09:30 AM",
+                    111: "06/20/2023 06:00 PM",
+                    112: "06/21/2023 07:00 AM",
+                    113: "06/21/2023 12:00 AM",
+                },
+            },
+        )
 
-    def test_wrong_values(self):
-        with self.assertRaises(ValueError) as err:
-            meeting_time({
-                201: [2, (5, 15)],
-                202: [5, (13, 22)],
-            })
-        self.assertEqual("some employees are working for more or less than 9 hours", str(err.exception))
-
-    def test_impossible(self):
-        with self.assertRaises(ValueError) as err:
-            meeting_time({
-                201: [2, (13, 22)],
-                202: [5, (5, 14)],
-            })
-        self.assertEqual("there's no possible meeting time for the provided employees", str(err.exception))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For background, check exercism/problem-specifications#1923 and linked forum posts.

This is a **very basic** draft. As it's my first exercise contribution, I thought I'd move slowly. 

First thing, the story is a little corny, but I thought it follows the "human" story policy. Feel free to change. Next, this exercise can currently be solved without `datetime`, as I've shown in the example answer. How can we change the exercise to force `datetime` usage, or should we not do that?

I also am not sure about the amount of tests to add: obviously, this isn't enough, but how many is?

I realize I should change the track `config.json`, so here's what should be there: only I'm unclear about the last three keys. I feel it'd make more sense to finalize them after the exercise is more or less complete.
```json
{
    "uuid": "2d9e74e6-d8ac-442f-9d08-165a896e179f",
    "slug": "global-meeting",
    "name": "global-meeting",
    // I'm unclear about the following lines
    "practices": ["if-statements", "numbers", "operator-precedence"],
    "prerequisites": ["if-statements", "numbers"],
    "difficulty": 1
}
```

I haven't yet set up the linter and formatter, so apologize for any errors in that end. Will be fixed over the coming days.

If you'd like to discuss about the improvement of the exercise from a non code perspective, please do so on [the forum](https://forum.exercism.org/t/discuss-global-meeting-exercise/6176).

Thanks!
