### PR TITLE
Clarify list copying

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
@@ -142,3 +142,16 @@ Define the `sorted_names()` function that takes 1 argument,  `queue`, (the `list
 ...
 ['Eltran', 'Natasha', 'Natasha', 'Rocket', 'Steve']
 ```
+
+## 8. Show how to not mutate the state
+
+Define the `functional_sort()` function that does what `sorted_names()` does, but doesn't modify the variable it's passed.
+
+```python
+>>> l = ["Natasha", "Steve", "Eltran", "Natasha", "Rocket"]
+>>> functional_sort(queue=l)
+...
+['Eltran', 'Natasha', 'Natasha', 'Rocket', 'Steve']
+>>> print(l)
+["Natasha", "Steve", "Eltran", "Natasha", "Rocket"]
+```

--- a/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
@@ -138,20 +138,10 @@ Define the `sorted_names()` function that takes 1 argument,  `queue`, (the `list
 
 
 ```python
->>> sorted_names(queue=["Natasha", "Steve", "Eltran", "Natasha", "Rocket"])
-...
+>>> queue = ["Natasha", "Steve", "Eltran", "Natasha", "Rocket"]
+>>> sorted = sorted_names(queue)
+>>> print(sorted)
 ['Eltran', 'Natasha', 'Natasha', 'Rocket', 'Steve']
-```
-
-## 8. Show how to not mutate the state
-
-Define the `functional_sort()` function that does what `sorted_names()` does, but doesn't modify the variable it's passed.
-
-```python
->>> l = ["Natasha", "Steve", "Eltran", "Natasha", "Rocket"]
->>> functional_sort(queue=l)
-...
-['Eltran', 'Natasha', 'Natasha', 'Rocket', 'Steve']
->>> print(l)
+>>> print(queue)
 ["Natasha", "Steve", "Eltran", "Natasha", "Rocket"]
 ```

--- a/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
@@ -15,6 +15,22 @@ Python also provides many useful [list-methods][list-methods] for working with l
 
 Note that when you manipulate a `list` with a `list-method`, **you alter the list** object that has been passed.
  If you do not wish to mutate the original `list`, you will need to at least make a `shallow copy` of it via slice or `<list>.copy()`.
+ Assigning it to a new variable, or passing it to a function, does not make a new list.
+
+```python
+>>> def double(internal):
+...     internal.extend(internal)
+...     return None
+...
+
+>>> external = [1, 2, 3]
+
+>>> double(external)
+
+>>> print(external)
+[1, 2, 3, 1, 2, 3]
+>>> # External was modified
+```
 
 
 ## Adding Items
@@ -233,94 +249,6 @@ ValueError: 10 is not in list
 3
 ```
 
-## Copying lists
-
-When coding, you may need to make multiple instances of a variable. Your first instinct may be to make a new variable and assign it to the value of the old one. This will work fine with integers:
-
-```python
->>> x = 3
-
->>> y = x
-
->>> y += 1
-
->>> print(x, y)
-3 4
-```
-
-However, trying to do the same with lists may surprise you:
-
-```python
->>> l = [1, 2, 3]
-
->>> l2 = l
-
->>> l2.append(4)
-
->>> print(l, l2)
-[1, 2, 3, 4] [1, 2, 3, 4]
-```
-
-When you reassign lists, you are *not* making a new list. This also holds true for function calls:
-
-```python
->>> def double(internal):
-...     internal.extend(internal)
-...     return None
-...
-
->>> external = [1, 2, 3]
-
->>> double(external)
-
->>> print(external)
-[1, 2, 3, 1, 2, 3]
-```
-
-You can see that calling `double()` modifies `external`. This isn't hard to deal with when doing beginner programming, but becomes a more tricky trap over time.
-
-This is happening because Python is sharing the object, rather than copying it. We can see this with the comparison operator `is`:
-
-```python
->>> x = 1
-
->>> y = x
-
->>> x is y
-True
-
->>> y += 1
-
->>> x is y
-False
-
->>> l = [1, 2, 3]
-
->>> l2 = l
-
->>> l2.append(4)
-
->>> l is l2
-True
-```
-
-To make a copy of a list, use the `.copy()` Method found on list objects.
-
-```python
->>> def double(internal):
-...     result = internal.extend(internal)
-...     return result
-...
-
->>> external = [1, 2, 3]
-
->>> returned = double(external)
-
->>> print(returned)
-[1, 2, 3, 1, 2, 3]
->>> print(returned)
-[1, 2, 3]
-```
 
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
 [dict]: https://docs.python.org/3/library/stdtypes.html#dict

--- a/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/introduction.md
@@ -233,6 +233,94 @@ ValueError: 10 is not in list
 3
 ```
 
+## Copying lists
+
+When coding, you may need to make multiple instances of a variable. Your first instinct may be to make a new variable and assign it to the value of the old one. This will work fine with integers:
+
+```python
+>>> x = 3
+
+>>> y = x
+
+>>> y += 1
+
+>>> print(x, y)
+3 4
+```
+
+However, trying to do the same with lists may surprise you:
+
+```python
+>>> l = [1, 2, 3]
+
+>>> l2 = l
+
+>>> l2.append(4)
+
+>>> print(l, l2)
+[1, 2, 3, 4] [1, 2, 3, 4]
+```
+
+When you reassign lists, you are *not* making a new list. This also holds true for function calls:
+
+```python
+>>> def double(internal):
+...     internal.extend(internal)
+...     return None
+...
+
+>>> external = [1, 2, 3]
+
+>>> double(external)
+
+>>> print(external)
+[1, 2, 3, 1, 2, 3]
+```
+
+You can see that calling `double()` modifies `external`. This isn't hard to deal with when doing beginner programming, but becomes a more tricky trap over time.
+
+This is happening because Python is sharing the object, rather than copying it. We can see this with the comparison operator `is`:
+
+```python
+>>> x = 1
+
+>>> y = x
+
+>>> x is y
+True
+
+>>> y += 1
+
+>>> x is y
+False
+
+>>> l = [1, 2, 3]
+
+>>> l2 = l
+
+>>> l2.append(4)
+
+>>> l is l2
+True
+```
+
+To make a copy of a list, use the `.copy()` Method found on list objects.
+
+```python
+>>> def double(internal):
+...     result = internal.extend(internal)
+...     return result
+...
+
+>>> external = [1, 2, 3]
+
+>>> returned = double(external)
+
+>>> print(returned)
+[1, 2, 3, 1, 2, 3]
+>>> print(returned)
+[1, 2, 3]
+```
 
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
 [dict]: https://docs.python.org/3/library/stdtypes.html#dict

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods.py
@@ -70,16 +70,8 @@ def remove_the_last_person(queue):
 
 
 def sorted_names(queue):
-    """Sort the names in the queue in alphabetical order and return the result.
-
-    :param queue: list - names in the queue.
-    :return: list - copy of the queue in alphabetical order.
-    """
-
-    pass
-
-def functional_sort(queue):
-    """Sort the queue without mutating the original.
+    """Make a copy of the queue, sort the names in the queue in alphabetical
+    order and return the result.
 
     :param queue: list - names in the queue.
     :return: list - copy of the queue in alphabetical order.

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods.py
@@ -77,3 +77,12 @@ def sorted_names(queue):
     """
 
     pass
+
+def functional_sort(queue):
+    """Sort the queue without mutating the original.
+
+    :param queue: list - names in the queue.
+    :return: list - copy of the queue in alphabetical order.
+    """
+
+    pass

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -114,8 +114,8 @@ class ListMethodsTest(unittest.TestCase):
 
         returned = sorted_names(in_data)
         error_message = 'The queue was not properly sorted.'
-        with self.subTest(f'sorting', input=in_data, output=returned):
+        with self.subTest('sorting', input=in_data, output=returned):
             self.assertListEqual(returned, out_data, msg=error_message)
         error_message = 'The original data was changed.'
-        with self.subTest(f'not mutating', input=in_data, output=returned):
+        with self.subTest('not mutating', input=in_data, output=returned):
             self.assertListEqual(in_data, backup_data, msg=error_message)

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -9,7 +9,6 @@ from list_methods import (
     how_many_namefellows,
     remove_the_last_person,
     sorted_names,
-    functional_sort
 )
 
 
@@ -109,28 +108,14 @@ class ListMethodsTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=7)
     def test_sorted_names(self):
-        data = [
-            (
-                ['Steve', 'Ultron', 'Natasha', 'Rocket'],
-                ['Natasha', 'Rocket', 'Steve', 'Ultron']
-            ),
-        ]
-
-        error_message = 'The queue was not properly sorted.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertListEqual(sorted_names(params), result, msg=error_message)
-
-    @pytest.mark.task(taskno=8)
-    def test_functional_sort(self):
         in_data = ['Steve', 'Ultron', 'Natasha', 'Rocket']
         backup_data = in_data
         out_data = ['Natasha', 'Rocket', 'Steve', 'Ultron']
 
-        returned = functional_sort(in_data)
+        returned = sorted_names(in_data)
         error_message = 'The queue was not properly sorted.'
         with self.subTest(f'sorting', input=in_data, output=returned):
             self.assertListEqual(returned, out_data, msg=error_message)
-        error_message = 'The original data was mutated.'
+        error_message = 'The original data was changed.'
         with self.subTest(f'not mutating', input=in_data, output=returned):
             self.assertListEqual(in_data, backup_data, msg=error_message)

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -9,6 +9,7 @@ from list_methods import (
     how_many_namefellows,
     remove_the_last_person,
     sorted_names,
+    functional_sort
 )
 
 
@@ -119,3 +120,17 @@ class ListMethodsTest(unittest.TestCase):
         for variant, (params, result) in enumerate(data, start=1):
             with self.subTest(f'variation #{variant}', input=params, output=result):
                 self.assertListEqual(sorted_names(params), result, msg=error_message)
+
+    @pytest.mark.task(taskno=8)
+    def test_functional_sort(self):
+        in_data = ['Steve', 'Ultron', 'Natasha', 'Rocket']
+        backup_data = in_data
+        out_data = ['Natasha', 'Rocket', 'Steve', 'Ultron']
+
+        returned = functional_sort(in_data)
+        error_message = 'The queue was not properly sorted.'
+        with self.subTest(f'sorting', input=in_data, output=returned):
+            self.assertListEqual(returned, out_data, msg=error_message)
+        error_message = 'The original data was mutated.'
+        with self.subTest(f'not mutating', input=in_data, output=returned):
+            self.assertListEqual(in_data, backup_data, msg=error_message)


### PR DESCRIPTION
This adds a new check to ensure that the coder didn't mutate the original list, and also clarifies list mutability a little bit more in the doc.

In the "first draft" I added a new task, without realizing that this exercise was already supposed to have covered it. The second draft was trimming that from the first and integrating it into the existing problem.