### PR TITLE
[RNA-Transcription]: Removed JinJa2 Footer Macro & Regenerated Test File

### DIFF
--- a/exercises/practice/rna-transcription/.meta/template.j2
+++ b/exercises/practice/rna-transcription/.meta/template.j2
@@ -9,5 +9,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
             '{{ case["expected"] }}'
         )
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/rna-transcription/rna_transcription_test.py
+++ b/exercises/practice/rna-transcription/rna_transcription_test.py
@@ -25,7 +25,3 @@ class RnaTranscriptionTest(unittest.TestCase):
 
     def test_rna_complement(self):
         self.assertEqual(to_rna("ACGTGGTCTTAA"), "UGCACCAGAAUU")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
@iHiD @ErikSchierboom -- I was going to list out a small PR for testing, but realized that all of the ones queued by Gelbelle included 10-12 files, which is probably too big a chunk.  This PR only touches the test template and file for one exercise.

This is not a change that should re-queue solutions, as it is only removing the 

```python
if __name__ == "__main__":
    unittest.main()
```

Footer from the test file.

