### PR TITLE
[Ledger]: Added JinJa2 Template, Re-Synced Tests & Regenerated Test Files 

### DIFF
--- a/exercises/practice/ledger/.meta/config.json
+++ b/exercises/practice/ledger/.meta/config.json
@@ -4,6 +4,7 @@
   ],
   "contributors": [
     "Dog",
+    "IsaaG",
     "tqa236"
   ],
   "files": {

--- a/exercises/practice/ledger/.meta/config.json
+++ b/exercises/practice/ledger/.meta/config.json
@@ -3,6 +3,7 @@
     "cmccandless"
   ],
   "contributors": [
+    "BethanyG",
     "Dog",
     "IsaaG",
     "tqa236"

--- a/exercises/practice/ledger/.meta/template.j2
+++ b/exercises/practice/ledger/.meta/template.j2
@@ -1,0 +1,22 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.header(imports=["format_entries", "create_entry"]) }}
+
+class {{ exercise | camel_case }}Test(unittest.TestCase):
+    maxDiff = 5000
+    {%- for case in cases %}
+
+    def test_{{ case["description"] | to_snake }}(self):
+        currency = '{{- case["input"]["currency"] }}'
+        locale = '{{- case["input"]["locale"] }}'
+        entries = [
+            {%- for entry in case["input"]["entries"] %}
+            create_entry('{{ entry["date"] }}', '{{ entry["description"] }}', {{ entry["amountInCents"] }}),
+            {%- endfor %}
+        ]
+        expected = '\n'.join([
+            {%- for line in case["expected"] %}
+            '{{- line -}}',
+            {%- endfor %}
+        ])
+        self.assertEqual(format_entries(currency, locale, entries), expected)
+    {%- endfor %}

--- a/exercises/practice/ledger/.meta/tests.toml
+++ b/exercises/practice/ledger/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d131ecae-a30e-436c-b8f3-858039a27234]
+description = "empty ledger"
+
+[ce4618d2-9379-4eca-b207-9df1c4ec8aaa]
+description = "one entry"
+
+[8d02e9cb-e6ee-4b77-9ce4-e5aec8eb5ccb]
+description = "credit and debit"
+
+[502c4106-0371-4e7c-a7d8-9ce33f16ccb1]
+description = "multiple entries on same date ordered by description"
+
+[29dd3659-6c2d-4380-94a8-6d96086e28e1]
+description = "final order tie breaker is change"
+
+[9b9712a6-f779-4f5c-a759-af65615fcbb9]
+description = "overlong description is truncated"
+
+[67318aad-af53-4f3d-aa19-1293b4d4c924]
+description = "euros"
+
+[bdc499b6-51f5-4117-95f2-43cb6737208e]
+description = "Dutch locale"
+
+[86591cd4-1379-4208-ae54-0ee2652b4670]
+description = "Dutch locale and euros"
+
+[876bcec8-d7d7-4ba4-82bd-b836ac87c5d2]
+description = "Dutch negative number with 3 digits before decimal point"
+
+[29670d1c-56be-492a-9c5e-427e4b766309]
+description = "American negative number with 3 digits before decimal point"

--- a/exercises/practice/ledger/ledger.py
+++ b/exercises/practice/ledger/ledger.py
@@ -296,3 +296,4 @@ def format_entries(currency, locale, entries):
                     change_str = ' ' + change_str
                 table += change_str
         return table
+

--- a/exercises/practice/ledger/ledger_test.py
+++ b/exercises/practice/ledger/ledger_test.py
@@ -1,147 +1,171 @@
-# -*- coding: utf-8 -*-
 import unittest
 
-from ledger import format_entries, create_entry
+from ledger import (
+    format_entries,
+    create_entry,
+)
+
+# Tests adapted from `problem-specifications//canonical-data.json`
 
 
 class LedgerTest(unittest.TestCase):
     maxDiff = 5000
 
     def test_empty_ledger(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = []
-        expected = 'Date       | Description               | Change       '
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_one_entry(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-01', 'Buy present', -1000),
+            create_entry("2015-01-01", "Buy present", -1000),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '01/01/2015 | Buy present               |      ($10.00)',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Buy present               |      ($10.00)",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_credit_and_debit(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-02', 'Get present', 1000),
-            create_entry('2015-01-01', 'Buy present', -1000),
+            create_entry("2015-01-02", "Get present", 1000),
+            create_entry("2015-01-01", "Buy present", -1000),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '01/01/2015 | Buy present               |      ($10.00)',
-            '01/02/2015 | Get present               |       $10.00 ',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Buy present               |      ($10.00)",
+                "01/02/2015 | Get present               |       $10.00 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_multiple_entries_on_same_date_ordered_by_description(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-02', 'Get present', 1000),
-            create_entry('2015-01-01', 'Buy present', -1000),
+            create_entry("2015-01-02", "Get present", 1000),
+            create_entry("2015-01-01", "Buy present", -1000),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '01/01/2015 | Buy present               |      ($10.00)',
-            '01/02/2015 | Get present               |       $10.00 ',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Buy present               |      ($10.00)",
+                "01/02/2015 | Get present               |       $10.00 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_final_order_tie_breaker_is_change(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-01', 'Something', 0),
-            create_entry('2015-01-01', 'Something', -1),
-            create_entry('2015-01-01', 'Something', 1),
+            create_entry("2015-01-01", "Something", 0),
+            create_entry("2015-01-01", "Something", -1),
+            create_entry("2015-01-01", "Something", 1),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '01/01/2015 | Something                 |       ($0.01)',
-            '01/01/2015 | Something                 |        $0.00 ',
-            '01/01/2015 | Something                 |        $0.01 ',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Something                 |       ($0.01)",
+                "01/01/2015 | Something                 |        $0.00 ",
+                "01/01/2015 | Something                 |        $0.01 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
-    def test_overlong_description(self):
-        currency = 'USD'
-        locale = 'en_US'
+    def test_overlong_description_is_truncated(self):
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-01', 'Freude schoner Gotterfunken', -123456),
+            create_entry("2015-01-01", "Freude schoner Gotterfunken", -123456),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_euros(self):
-        currency = 'EUR'
-        locale = 'en_US'
+        currency = "EUR"
+        locale = "en_US"
         entries = [
-            create_entry('2015-01-01', 'Buy present', -1000),
+            create_entry("2015-01-01", "Buy present", -1000),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            u'01/01/2015 | Buy present               |      (€10.00)',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "01/01/2015 | Buy present               |      (€10.00)",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_dutch_locale(self):
-        currency = 'USD'
-        locale = 'nl_NL'
+        currency = "USD"
+        locale = "nl_NL"
         entries = [
-            create_entry('2015-03-12', 'Buy present', 123456),
+            create_entry("2015-03-12", "Buy present", 123456),
         ]
-        expected = '\n'.join([
-            'Datum      | Omschrijving              | Verandering  ',
-            '12-03-2015 | Buy present               |   $ 1.234,56 ',
-        ])
+        expected = "\n".join(
+            [
+                "Datum      | Omschrijving              | Verandering  ",
+                "12-03-2015 | Buy present               |   $ 1.234,56 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_dutch_locale_and_euros(self):
-        currency = 'EUR'
-        locale = 'nl_NL'
+        currency = "EUR"
+        locale = "nl_NL"
         entries = [
-            create_entry('2015-03-12', 'Buy present', 123456),
+            create_entry("2015-03-12", "Buy present", 123456),
         ]
-        expected = '\n'.join([
-            'Datum      | Omschrijving              | Verandering  ',
-            u'12-03-2015 | Buy present               |   € 1.234,56 ',
-        ])
+        expected = "\n".join(
+            [
+                "Datum      | Omschrijving              | Verandering  ",
+                "12-03-2015 | Buy present               |   € 1.234,56 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_dutch_negative_number_with_3_digits_before_decimal_point(self):
-        currency = 'USD'
-        locale = 'nl_NL'
+        currency = "USD"
+        locale = "nl_NL"
         entries = [
-            create_entry('2015-03-12', 'Buy present', -12345),
+            create_entry("2015-03-12", "Buy present", -12345),
         ]
-        expected = '\n'.join([
-            'Datum      | Omschrijving              | Verandering  ',
-            '12-03-2015 | Buy present               |    $ -123,45 ',
-        ])
+        expected = "\n".join(
+            [
+                "Datum      | Omschrijving              | Verandering  ",
+                "12-03-2015 | Buy present               |    $ -123,45 ",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
 
     def test_american_negative_number_with_3_digits_before_decimal_point(self):
-        currency = 'USD'
-        locale = 'en_US'
+        currency = "USD"
+        locale = "en_US"
         entries = [
-            create_entry('2015-03-12', 'Buy present', -12345),
+            create_entry("2015-03-12", "Buy present", -12345),
         ]
-        expected = '\n'.join([
-            'Date       | Description               | Change       ',
-            '03/12/2015 | Buy present               |     ($123.45)',
-        ])
+        expected = "\n".join(
+            [
+                "Date       | Description               | Change       ",
+                "03/12/2015 | Buy present               |     ($123.45)",
+            ]
+        )
         self.assertEqual(format_entries(currency, locale, entries), expected)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Here is a test of the manual flag.
`Ledger` was recently added to `problem-specifications`, and a new JinJa2 template was made for it.
A new `tests.toml` file was also added, and all test cases were set to active.
However, great pains were taken to not have the canonical data invalidate the existing student solutions.

So the JinJa2 template and resulting new test file (_even though they've "changed"_) should not require re-queueing of student solutions.

