### PR TITLE
[Tooling]: Changed Generate Script to Skip Diffing Generated Comments & Timestamp

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -271,8 +271,12 @@ def check_template(slug: str, tests_path: Path, tmpfile: Path):
             check_ok = False
         if check_ok and not filecmp.cmp(tmpfile, tests_path):
             with tests_path.open() as f:
+                for line in range(5):
+                    next(f)
                 current_lines = f.readlines()
             with tmpfile.open() as f:
+                for line in range(4):
+                    next(f)
                 rendered_lines = f.readlines()
             diff = difflib.unified_diff(
                 current_lines,

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -16,6 +16,8 @@
 {%- endmacro %}
 
 {% macro header(imports=[], ignore=[]) -%}
+{{ canonical_ref() }}
+
 import unittest
 
 from {{ exercise | to_snake }} import ({% if imports -%}
@@ -29,8 +31,6 @@ from {{ exercise | to_snake }} import ({% if imports -%}
     {%- endif -%}
 {% endfor %}
 {%- endif %})
-
-{{ canonical_ref() }}
 {%- endmacro %}
 
 {% macro utility() -%}# Utility functions

--- a/exercises/practice/acronym/.meta/template.j2
+++ b/exercises/practice/acronym/.meta/template.j2
@@ -1,4 +1,5 @@
 {%- import "generator_macros.j2" as macros with context -%}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):

--- a/exercises/practice/acronym/acronym_test.py
+++ b/exercises/practice/acronym/acronym_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/acronym/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from acronym import (
     abbreviate,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/acronym/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AcronymTest(unittest.TestCase):

--- a/exercises/practice/affine-cipher/affine_cipher_test.py
+++ b/exercises/practice/affine-cipher/affine_cipher_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from affine_cipher import (
     decode,
     encode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AffineCipherTest(unittest.TestCase):

--- a/exercises/practice/all-your-base/all_your_base_test.py
+++ b/exercises/practice/all-your-base/all_your_base_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/all-your-base/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from all_your_base import (
     rebase,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/all-your-base/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AllYourBaseTest(unittest.TestCase):

--- a/exercises/practice/allergies/allergies_test.py
+++ b/exercises/practice/allergies/allergies_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/allergies/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from allergies import (
     Allergies,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/allergies/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AllergiesTest(unittest.TestCase):

--- a/exercises/practice/alphametics/alphametics_test.py
+++ b/exercises/practice/alphametics/alphametics_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from alphametics import (
     solve,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AlphameticsTest(unittest.TestCase):

--- a/exercises/practice/anagram/anagram_test.py
+++ b/exercises/practice/anagram/anagram_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from anagram import (
     find_anagrams,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AnagramTest(unittest.TestCase):

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/armstrong-numbers/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from armstrong_numbers import (
     is_armstrong_number,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/armstrong-numbers/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ArmstrongNumbersTest(unittest.TestCase):

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/atbash-cipher/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from atbash_cipher import (
     decode,
     encode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/atbash-cipher/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class AtbashCipherTest(unittest.TestCase):

--- a/exercises/practice/bank-account/bank_account_test.py
+++ b/exercises/practice/bank-account/bank_account_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bank-account/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from bank_account import (
     BankAccount,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/bank-account/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BankAccountTest(unittest.TestCase):

--- a/exercises/practice/beer-song/beer_song_test.py
+++ b/exercises/practice/beer-song/beer_song_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/beer-song/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from beer_song import (
     recite,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/beer-song/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BeerSongTest(unittest.TestCase):

--- a/exercises/practice/binary-search-tree/binary_search_tree_test.py
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search-tree/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from binary_search_tree import (
     BinarySearchTree,
     TreeNode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search-tree/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BinarySearchTreeTest(unittest.TestCase):

--- a/exercises/practice/binary-search/binary_search_test.py
+++ b/exercises/practice/binary-search/binary_search_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from binary_search import (
     find,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BinarySearchTest(unittest.TestCase):

--- a/exercises/practice/bob/bob_test.py
+++ b/exercises/practice/bob/bob_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from bob import (
     response,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BobTest(unittest.TestCase):

--- a/exercises/practice/book-store/book_store_test.py
+++ b/exercises/practice/book-store/book_store_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/book-store/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from book_store import (
     total,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/book-store/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BookStoreTest(unittest.TestCase):

--- a/exercises/practice/bottle-song/bottle_song_test.py
+++ b/exercises/practice/bottle-song/bottle_song_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from bottle_song import (
     recite,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BottleSongTest(unittest.TestCase):

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from bowling import (
     BowlingGame,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class BowlingTest(unittest.TestCase):

--- a/exercises/practice/change/change_test.py
+++ b/exercises/practice/change/change_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/change/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from change import (
     find_fewest_coins,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/change/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ChangeTest(unittest.TestCase):

--- a/exercises/practice/circular-buffer/circular_buffer_test.py
+++ b/exercises/practice/circular-buffer/circular_buffer_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/circular-buffer/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from circular_buffer import (
@@ -5,10 +9,6 @@ from circular_buffer import (
     BufferEmptyException,
     BufferFullException,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/circular-buffer/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class CircularBufferTest(unittest.TestCase):

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from clock import (
     Clock,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ClockTest(unittest.TestCase):

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from collatz_conjecture import (
     steps,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class CollatzConjectureTest(unittest.TestCase):

--- a/exercises/practice/complex-numbers/complex_numbers_test.py
+++ b/exercises/practice/complex-numbers/complex_numbers_test.py
@@ -1,14 +1,14 @@
 import math
 
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from complex_numbers import (
     ComplexNumber,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ComplexNumbersTest(unittest.TestCase):

--- a/exercises/practice/connect/connect_test.py
+++ b/exercises/practice/connect/connect_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from connect import (
     ConnectGame,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ConnectTest(unittest.TestCase):

--- a/exercises/practice/crypto-square/crypto_square_test.py
+++ b/exercises/practice/crypto-square/crypto_square_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/crypto-square/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from crypto_square import (
     cipher_text,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/crypto-square/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class CryptoSquareTest(unittest.TestCase):

--- a/exercises/practice/custom-set/custom_set_test.py
+++ b/exercises/practice/custom-set/custom_set_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from custom_set import (
     CustomSet,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class CustomSetTest(unittest.TestCase):

--- a/exercises/practice/darts/darts_test.py
+++ b/exercises/practice/darts/darts_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/darts/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from darts import (
     score,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/darts/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DartsTest(unittest.TestCase):

--- a/exercises/practice/diamond/diamond_test.py
+++ b/exercises/practice/diamond/diamond_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from diamond import (
     rows,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DiamondTest(unittest.TestCase):

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/difference-of-squares/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from difference_of_squares import (
@@ -5,10 +9,6 @@ from difference_of_squares import (
     square_of_sum,
     sum_of_squares,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/difference-of-squares/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DifferenceOfSquaresTest(unittest.TestCase):

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/diffie-hellman/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from diffie_hellman import (
@@ -5,10 +9,6 @@ from diffie_hellman import (
     public_key,
     secret,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/diffie-hellman/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DiffieHellmanTest(unittest.TestCase):

--- a/exercises/practice/dnd-character/dnd_character_test.py
+++ b/exercises/practice/dnd-character/dnd_character_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/dnd-character/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from dnd_character import (
     Character,
     modifier,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/dnd-character/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DndCharacterTest(unittest.TestCase):

--- a/exercises/practice/dominoes/dominoes_test.py
+++ b/exercises/practice/dominoes/dominoes_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/dominoes/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from dominoes import (
     can_chain,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/dominoes/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class DominoesTest(unittest.TestCase):

--- a/exercises/practice/etl/etl_test.py
+++ b/exercises/practice/etl/etl_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from etl import (
     transform,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class EtlTest(unittest.TestCase):

--- a/exercises/practice/flatten-array/flatten_array_test.py
+++ b/exercises/practice/flatten-array/flatten_array_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from flatten_array import (
     flatten,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class FlattenArrayTest(unittest.TestCase):

--- a/exercises/practice/food-chain/food_chain_test.py
+++ b/exercises/practice/food-chain/food_chain_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/food-chain/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from food_chain import (
     recite,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/food-chain/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class FoodChainTest(unittest.TestCase):

--- a/exercises/practice/forth/forth_test.py
+++ b/exercises/practice/forth/forth_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/forth/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from forth import (
     evaluate,
     StackUnderflowError,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/forth/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ForthTest(unittest.TestCase):

--- a/exercises/practice/gigasecond/gigasecond_test.py
+++ b/exercises/practice/gigasecond/gigasecond_test.py
@@ -1,13 +1,14 @@
 from datetime import datetime
+
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from gigasecond import (
     add,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class GigasecondTest(unittest.TestCase):

--- a/exercises/practice/go-counting/go_counting_test.py
+++ b/exercises/practice/go-counting/go_counting_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/go-counting/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from go_counting import (
@@ -6,10 +10,6 @@ from go_counting import (
     BLACK,
     NONE,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/go-counting/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class GoCountingTest(unittest.TestCase):

--- a/exercises/practice/grade-school/grade_school_test.py
+++ b/exercises/practice/grade-school/grade_school_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grade-school/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from grade_school import (
     School,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/grade-school/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class GradeSchoolTest(unittest.TestCase):

--- a/exercises/practice/grains/grains_test.py
+++ b/exercises/practice/grains/grains_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from grains import (
     square,
     total,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class GrainsTest(unittest.TestCase):

--- a/exercises/practice/grep/grep_test.py
+++ b/exercises/practice/grep/grep_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grep/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from grep import (
     grep,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/grep/canonical-data.json
-# File last updated on 2023-07-14
 import io
 from unittest import mock
 

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from hamming import (
     distance,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class HammingTest(unittest.TestCase):

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/high-scores/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from high_scores import (
     HighScores,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/high-scores/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class HighScoresTest(unittest.TestCase):

--- a/exercises/practice/house/house_test.py
+++ b/exercises/practice/house/house_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/house/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from house import (
     recite,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/house/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class HouseTest(unittest.TestCase):

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.py
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/isbn-verifier/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from isbn_verifier import (
     is_valid,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/isbn-verifier/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class IsbnVerifierTest(unittest.TestCase):

--- a/exercises/practice/isogram/isogram_test.py
+++ b/exercises/practice/isogram/isogram_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/isogram/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from isogram import (
     is_isogram,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/isogram/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class IsogramTest(unittest.TestCase):

--- a/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
+++ b/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/killer-sudoku-helper/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from killer_sudoku_helper import (
     combinations,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/killer-sudoku-helper/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class KillerSudokuHelperTest(unittest.TestCase):

--- a/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
+++ b/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/kindergarten-garden/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from kindergarten_garden import (
     Garden,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/kindergarten-garden/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class KindergartenGardenTest(unittest.TestCase):

--- a/exercises/practice/knapsack/knapsack_test.py
+++ b/exercises/practice/knapsack/knapsack_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/knapsack/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from knapsack import (
     maximum_value,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/knapsack/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class KnapsackTest(unittest.TestCase):

--- a/exercises/practice/largest-series-product/largest_series_product_test.py
+++ b/exercises/practice/largest-series-product/largest_series_product_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/largest-series-product/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from largest_series_product import (
     largest_product,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/largest-series-product/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class LargestSeriesProductTest(unittest.TestCase):

--- a/exercises/practice/leap/leap_test.py
+++ b/exercises/practice/leap/leap_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from leap import (
     leap_year,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class LeapTest(unittest.TestCase):

--- a/exercises/practice/ledger/ledger_test.py
+++ b/exercises/practice/ledger/ledger_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/ledger/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from ledger import (
     format_entries,
     create_entry,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/ledger/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class LedgerTest(unittest.TestCase):

--- a/exercises/practice/linked-list/linked_list_test.py
+++ b/exercises/practice/linked-list/linked_list_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/linked-list/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from linked_list import (
     LinkedList,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/linked-list/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class LinkedListTest(unittest.TestCase):

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from list_ops import (
@@ -10,10 +14,6 @@ from list_ops import (
     filter as list_ops_filter,
     map as list_ops_map,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ListOpsTest(unittest.TestCase):

--- a/exercises/practice/luhn/luhn_test.py
+++ b/exercises/practice/luhn/luhn_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from luhn import (
     Luhn,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class LuhnTest(unittest.TestCase):

--- a/exercises/practice/markdown/markdown_test.py
+++ b/exercises/practice/markdown/markdown_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/markdown/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from markdown import (
     parse,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/markdown/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class MarkdownTest(unittest.TestCase):

--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/matching-brackets/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from matching_brackets import (
     is_paired,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/matching-brackets/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class MatchingBracketsTest(unittest.TestCase):

--- a/exercises/practice/matrix/matrix_test.py
+++ b/exercises/practice/matrix/matrix_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/matrix/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from matrix import (
     Matrix,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/matrix/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class MatrixTest(unittest.TestCase):

--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -1,14 +1,15 @@
 from datetime import date
+
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/meetup/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from meetup import (
     meetup,
     MeetupDayException,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/meetup/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class MeetupTest(unittest.TestCase):

--- a/exercises/practice/minesweeper/minesweeper_test.py
+++ b/exercises/practice/minesweeper/minesweeper_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/minesweeper/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from minesweeper import (
     annotate,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/minesweeper/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class MinesweeperTest(unittest.TestCase):

--- a/exercises/practice/nth-prime/nth_prime_test.py
+++ b/exercises/practice/nth-prime/nth_prime_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/nth-prime/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from nth_prime import (
     prime,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/nth-prime/canonical-data.json
-# File last updated on 2023-07-14
 
 
 def prime_range(n):

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/ocr-numbers/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from ocr_numbers import (
     convert,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/ocr-numbers/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class OcrNumbersTest(unittest.TestCase):

--- a/exercises/practice/palindrome-products/palindrome_products_test.py
+++ b/exercises/practice/palindrome-products/palindrome_products_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/palindrome-products/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from palindrome_products import (
     largest,
     smallest,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/palindrome-products/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PalindromeProductsTest(unittest.TestCase):

--- a/exercises/practice/pangram/pangram_test.py
+++ b/exercises/practice/pangram/pangram_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pangram/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from pangram import (
     is_pangram,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/pangram/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PangramTest(unittest.TestCase):

--- a/exercises/practice/pascals-triangle/pascals_triangle_test.py
+++ b/exercises/practice/pascals-triangle/pascals_triangle_test.py
@@ -1,13 +1,14 @@
 import sys
+
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pascals-triangle/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from pascals_triangle import (
     rows,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/pascals-triangle/canonical-data.json
-# File last updated on 2023-07-14
 
 TRIANGLE = [
     [1],

--- a/exercises/practice/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/practice/perfect-numbers/perfect_numbers_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from perfect_numbers import (
     classify,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PerfectNumbersTest(unittest.TestCase):

--- a/exercises/practice/phone-number/phone_number_test.py
+++ b/exercises/practice/phone-number/phone_number_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/phone-number/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from phone_number import (
     PhoneNumber,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/phone-number/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PhoneNumberTest(unittest.TestCase):

--- a/exercises/practice/pig-latin/pig_latin_test.py
+++ b/exercises/practice/pig-latin/pig_latin_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pig-latin/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from pig_latin import (
     translate,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/pig-latin/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PigLatinTest(unittest.TestCase):

--- a/exercises/practice/poker/poker_test.py
+++ b/exercises/practice/poker/poker_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/poker/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from poker import (
     best_hands,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/poker/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PokerTest(unittest.TestCase):

--- a/exercises/practice/pov/pov_test.py
+++ b/exercises/practice/pov/pov_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pov/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from pov import (
     Tree,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/pov/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PovTest(unittest.TestCase):

--- a/exercises/practice/prime-factors/prime_factors_test.py
+++ b/exercises/practice/prime-factors/prime_factors_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/prime-factors/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from prime_factors import (
     factors,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/prime-factors/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PrimeFactorsTest(unittest.TestCase):

--- a/exercises/practice/protein-translation/protein_translation_test.py
+++ b/exercises/practice/protein-translation/protein_translation_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/protein-translation/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from protein_translation import (
     proteins,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/protein-translation/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ProteinTranslationTest(unittest.TestCase):

--- a/exercises/practice/proverb/proverb_test.py
+++ b/exercises/practice/proverb/proverb_test.py
@@ -1,12 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/proverb/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from proverb import (
     proverb,
 )
 
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/proverb/canonical-data.json
-# File last updated on 2023-07-14
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/pythagorean-triplet/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from pythagorean_triplet import (
     triplets_with_sum,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/pythagorean-triplet/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class PythagoreanTripletTest(unittest.TestCase):

--- a/exercises/practice/queen-attack/queen_attack_test.py
+++ b/exercises/practice/queen-attack/queen_attack_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/queen-attack/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from queen_attack import (
     Queen,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/queen-attack/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class QueenAttackTest(unittest.TestCase):

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rail-fence-cipher/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rail_fence_cipher import (
     decode,
     encode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rail-fence-cipher/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RailFenceCipherTest(unittest.TestCase):

--- a/exercises/practice/raindrops/raindrops_test.py
+++ b/exercises/practice/raindrops/raindrops_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/raindrops/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from raindrops import (
     convert,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/raindrops/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RaindropsTest(unittest.TestCase):

--- a/exercises/practice/rational-numbers/rational_numbers_test.py
+++ b/exercises/practice/rational-numbers/rational_numbers_test.py
@@ -1,13 +1,14 @@
 from __future__ import division
+
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rational-numbers/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rational_numbers import (
     Rational,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rational-numbers/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RationalNumbersTest(unittest.TestCase):

--- a/exercises/practice/react/react_test.py
+++ b/exercises/practice/react/react_test.py
@@ -1,15 +1,15 @@
 from functools import partial
 
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/react/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from react import (
     InputCell,
     ComputeCell,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/react/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ReactTest(unittest.TestCase):

--- a/exercises/practice/rectangles/rectangles_test.py
+++ b/exercises/practice/rectangles/rectangles_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rectangles import (
     rectangles,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RectanglesTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-duo/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from resistor_color_duo import (
     value,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-duo/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ResistorColorDuoTest(unittest.TestCase):

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from resistor_color_trio import (
     label,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ResistorColorTrioTest(unittest.TestCase):

--- a/exercises/practice/resistor-color/resistor_color_test.py
+++ b/exercises/practice/resistor-color/resistor_color_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from resistor_color import (
     color_code,
     colors,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ResistorColorTest(unittest.TestCase):

--- a/exercises/practice/rest-api/rest_api_test.py
+++ b/exercises/practice/rest-api/rest_api_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rest-api/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rest_api import (
     RestAPI,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rest-api/canonical-data.json
-# File last updated on 2023-07-14
 import json
 
 

--- a/exercises/practice/reverse-string/reverse_string_test.py
+++ b/exercises/practice/reverse-string/reverse_string_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from reverse_string import (
     reverse,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ReverseStringTest(unittest.TestCase):

--- a/exercises/practice/rna-transcription/rna_transcription_test.py
+++ b/exercises/practice/rna-transcription/rna_transcription_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rna-transcription/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rna_transcription import (
     to_rna,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rna-transcription/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RnaTranscriptionTest(unittest.TestCase):

--- a/exercises/practice/robot-simulator/robot_simulator_test.py
+++ b/exercises/practice/robot-simulator/robot_simulator_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/robot-simulator/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from robot_simulator import (
@@ -7,10 +11,6 @@ from robot_simulator import (
     SOUTH,
     WEST,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/robot-simulator/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RobotSimulatorTest(unittest.TestCase):

--- a/exercises/practice/roman-numerals/roman_numerals_test.py
+++ b/exercises/practice/roman-numerals/roman_numerals_test.py
@@ -1,12 +1,14 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/roman-numerals/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from roman_numerals import (
     roman,
 )
 
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/roman-numerals/canonical-data.json
-# File last updated on 2023-07-14
+
 class RomanNumeralsTest(unittest.TestCase):
     def test_1_is_i(self):
         self.assertEqual(roman(1), "I")

--- a/exercises/practice/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/practice/rotational-cipher/rotational_cipher_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rotational-cipher/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from rotational_cipher import (
     rotate,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/rotational-cipher/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RotationalCipherTest(unittest.TestCase):

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/run-length-encoding/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from run_length_encoding import (
     encode,
     decode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/run-length-encoding/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RunLengthEncodingTest(unittest.TestCase):

--- a/exercises/practice/saddle-points/saddle_points_test.py
+++ b/exercises/practice/saddle-points/saddle_points_test.py
@@ -5,15 +5,15 @@ The saddle_points function must validate the input matrix and raise a
 ValueError with a meaningful error message if the matrix turns out to be
 irregular.
 """
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/saddle-points/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from saddle_points import (
     saddle_points,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/saddle-points/canonical-data.json
-# File last updated on 2023-07-14
 
 
 def sorted_points(point_list):

--- a/exercises/practice/satellite/satellite_test.py
+++ b/exercises/practice/satellite/satellite_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/satellite/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from satellite import (
     tree_from_traversals,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/satellite/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SatelliteTest(unittest.TestCase):

--- a/exercises/practice/say/say_test.py
+++ b/exercises/practice/say/say_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/say/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from say import (
     say,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/say/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SayTest(unittest.TestCase):

--- a/exercises/practice/scale-generator/scale_generator_test.py
+++ b/exercises/practice/scale-generator/scale_generator_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/scale-generator/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from scale_generator import (
     Scale,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/scale-generator/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ScaleGeneratorTest(unittest.TestCase):

--- a/exercises/practice/scrabble-score/scrabble_score_test.py
+++ b/exercises/practice/scrabble-score/scrabble_score_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/scrabble-score/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from scrabble_score import (
     score,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/scrabble-score/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ScrabbleScoreTest(unittest.TestCase):

--- a/exercises/practice/secret-handshake/secret_handshake_test.py
+++ b/exercises/practice/secret-handshake/secret_handshake_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/secret-handshake/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from secret_handshake import (
     commands,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/secret-handshake/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SecretHandshakeTest(unittest.TestCase):

--- a/exercises/practice/series/series_test.py
+++ b/exercises/practice/series/series_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/series/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from series import (
     slices,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/series/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SeriesTest(unittest.TestCase):

--- a/exercises/practice/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/practice/sgf-parsing/sgf_parsing_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sgf-parsing/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from sgf_parsing import (
     parse,
     SgfTree,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/sgf-parsing/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SgfParsingTest(unittest.TestCase):

--- a/exercises/practice/sieve/sieve_test.py
+++ b/exercises/practice/sieve/sieve_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sieve/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from sieve import (
     primes,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/sieve/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SieveTest(unittest.TestCase):

--- a/exercises/practice/simple-cipher/simple_cipher_test.py
+++ b/exercises/practice/simple-cipher/simple_cipher_test.py
@@ -1,13 +1,14 @@
 import re
+
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/simple-cipher/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from simple_cipher import (
     Cipher,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/simple-cipher/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class RandomKeyCipherTest(unittest.TestCase):

--- a/exercises/practice/space-age/space_age_test.py
+++ b/exercises/practice/space-age/space_age_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from space_age import (
     SpaceAge,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SpaceAgeTest(unittest.TestCase):

--- a/exercises/practice/spiral-matrix/spiral_matrix_test.py
+++ b/exercises/practice/spiral-matrix/spiral_matrix_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/spiral-matrix/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from spiral_matrix import (
     spiral_matrix,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/spiral-matrix/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SpiralMatrixTest(unittest.TestCase):

--- a/exercises/practice/square-root/square_root_test.py
+++ b/exercises/practice/square-root/square_root_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/square-root/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from square_root import (
     square_root,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/square-root/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SquareRootTest(unittest.TestCase):

--- a/exercises/practice/sublist/sublist_test.py
+++ b/exercises/practice/sublist/sublist_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sublist/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from sublist import (
@@ -7,10 +11,6 @@ from sublist import (
     EQUAL,
     UNEQUAL,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/sublist/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SublistTest(unittest.TestCase):

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/sum-of-multiples/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from sum_of_multiples import (
     sum_of_multiples,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/sum-of-multiples/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class SumOfMultiplesTest(unittest.TestCase):

--- a/exercises/practice/tournament/tournament_test.py
+++ b/exercises/practice/tournament/tournament_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/tournament/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from tournament import (
     tally,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/tournament/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class TournamentTest(unittest.TestCase):

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from transpose import (
     transpose,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class TransposeTest(unittest.TestCase):

--- a/exercises/practice/triangle/triangle_test.py
+++ b/exercises/practice/triangle/triangle_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/triangle/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from triangle import (
@@ -5,10 +9,6 @@ from triangle import (
     isosceles,
     scalene,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/triangle/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class EquilateralTriangleTest(unittest.TestCase):

--- a/exercises/practice/twelve-days/twelve_days_test.py
+++ b/exercises/practice/twelve-days/twelve_days_test.py
@@ -1,12 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/twelve-days/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from twelve_days import (
     recite,
 )
 
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/twelve-days/canonical-data.json
-# File last updated on 2023-07-14
 # PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**
 # A new line in a result list below **does not** always equal a new list element.
 # Check comma placement carefully!

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from two_bucket import (
     measure,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class TwoBucketTest(unittest.TestCase):

--- a/exercises/practice/two-fer/two_fer_test.py
+++ b/exercises/practice/two-fer/two_fer_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from two_fer import (
     two_fer,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class TwoFerTest(unittest.TestCase):

--- a/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/variable-length-quantity/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from variable_length_quantity import (
     decode,
     encode,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/variable-length-quantity/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class VariableLengthQuantityTest(unittest.TestCase):

--- a/exercises/practice/word-count/word_count_test.py
+++ b/exercises/practice/word-count/word_count_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from word_count import (
     count_words,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class WordCountTest(unittest.TestCase):

--- a/exercises/practice/word-search/word_search_test.py
+++ b/exercises/practice/word-search/word_search_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/word-search/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from word_search import (
     WordSearch,
     Point,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/word-search/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class WordSearchTest(unittest.TestCase):

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from wordy import (
     answer,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class WordyTest(unittest.TestCase):

--- a/exercises/practice/yacht/yacht_test.py
+++ b/exercises/practice/yacht/yacht_test.py
@@ -4,7 +4,7 @@ import yacht
 
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/yacht/canonical-data.json
-# File last updated on 2023-07-14
+# File last updated on 2023-07-15
 
 
 class YachtTest(unittest.TestCase):

--- a/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
@@ -1,13 +1,13 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/zebra-puzzle/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from zebra_puzzle import (
     drinks_water,
     owns_zebra,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/zebra-puzzle/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ZebraPuzzleTest(unittest.TestCase):

--- a/exercises/practice/zipper/zipper_test.py
+++ b/exercises/practice/zipper/zipper_test.py
@@ -1,12 +1,12 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/zipper/canonical-data.json
+# File last updated on 2023-07-15
+
 import unittest
 
 from zipper import (
     Zipper,
 )
-
-# These tests are auto-generated with test data from:
-# https://github.com/exercism/problem-specifications/tree/main/exercises/zipper/canonical-data.json
-# File last updated on 2023-07-14
 
 
 class ZipperTest(unittest.TestCase):


### PR DESCRIPTION
The generated timestamp in practice exercise test files was causing CI to always fail.
 Because of the way the CI was checking for changes (_by regenerating the test file on the fly with a new timestamp_), there was always going to be a difference.  

These changes move the comment and timestamp to the top of test files and have the check skip those lines for the purposes of the on-the-fly diff, since the comment and timestamp are not significant in determining a code change in test files.