### PR TITLE
[Resistor Color Expert]: Corrected Small Typos

### DIFF
--- a/config/complexnumbers_template.j2
+++ b/config/complexnumbers_template.j2
@@ -1,6 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
 {{ macros.canonical_ref() }}
 
+import math
 {{ macros.header(imports=imports, ignore=ignore) }}
 
 {%- macro test_cases_recursive(cases) -%}
@@ -27,3 +28,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     # Additional tests for this track
     {{ additional_tests() }}
     {%- endif %}
+

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -16,7 +16,6 @@
 {%- endmacro %}
 
 {% macro header(imports=[], ignore=[]) -%}
-{{ canonical_ref() }}
 
 import unittest
 
@@ -36,14 +35,6 @@ from {{ exercise | to_snake }} import ({% if imports -%}
 {% macro utility() -%}# Utility functions
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
-{%- endmacro %}
-
-{% macro footer(_has_error_case) -%}
-{% if has_error_case or _has_error_case %}
-{{ utility() }}
-{% endif %}
-if __name__ == '__main__':
-    unittest.main()
 {%- endmacro %}
 
 {% macro empty_set(set, list, class_name) -%}

--- a/exercises/practice/acronym/.meta/template.j2
+++ b/exercises/practice/acronym/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
@@ -8,7 +11,7 @@
             "{{ case["expected"] }}"
         )
 {%- endmacro %}
-{{ macros.header()}}
+
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/acronym/acronym_test.py
+++ b/exercises/practice/acronym/acronym_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/acronym/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/affine-cipher/.meta/template.j2
+++ b/exercises/practice/affine-cipher/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {% macro test_supercase(supercase) %}
 {% for case in supercase["cases"] -%}
@@ -24,8 +27,6 @@ def test_{{ case["description"] | to_snake }}(self):
     self.assertEqual({{ function }}("{{ phrase }}", {{ a }}, {{ b }}), "{{ expected }}")
     {% endif -%}
 {%- endmacro %}
-
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases -%}

--- a/exercises/practice/affine-cipher/affine_cipher_test.py
+++ b/exercises/practice/affine-cipher/affine_cipher_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/all-your-base/.meta/template.j2
+++ b/exercises/practice/all-your-base/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {%- macro func_call(case) -%}
     {{ case["property"] }}(
@@ -21,8 +24,6 @@
         self.assertEqual({{ func_call(case) }}, {{ expected }})
     {%- endif %}
 {% endmacro %}
-
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/all-your-base/all_your_base_test.py
+++ b/exercises/practice/all-your-base/all_your_base_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/all-your-base/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/allergies/.meta/template.j2
+++ b/exercises/practice/allergies/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(imports=[ exercise | camel_case ]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/allergies/allergies_test.py
+++ b/exercises/practice/allergies/allergies_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/allergies/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/alphametics/.meta/template.j2
+++ b/exercises/practice/alphametics/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/alphametics/alphametics_test.py
+++ b/exercises/practice/alphametics/alphametics_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -1,4 +1,5 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
 {{ macros.header() }}
 

--- a/exercises/practice/anagram/anagram_test.py
+++ b/exercises/practice/anagram/anagram_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/armstrong-numbers/.meta/template.j2
+++ b/exercises/practice/armstrong-numbers/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/armstrong-numbers/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/atbash-cipher/.meta/template.j2
+++ b/exercises/practice/atbash-cipher/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/atbash-cipher/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/bank-account/.meta/template.j2
+++ b/exercises/practice/bank-account/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["BankAccount"]) }}
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         account = BankAccount()
@@ -36,7 +39,6 @@
             {%- endif  %}
 {% endmacro %}
 
-{{ macros.header(["BankAccount"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/bank-account/bank_account_test.py
+++ b/exercises/practice/bank-account/bank_account_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bank-account/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/beer-song/.meta/template.j2
+++ b/exercises/practice/beer-song/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/beer-song/beer_song_test.py
+++ b/exercises/practice/beer-song/beer_song_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/beer-song/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/binary-search-tree/.meta/template.j2
+++ b/exercises/practice/binary-search-tree/.meta/template.j2
@@ -1,6 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
-{%- macro build_tree(tree_obj) -%}
+{{ macros.header (imports=["BinarySearchTree", "TreeNode"]) }}
+
+{% macro build_tree(tree_obj) %}
 {%- if tree_obj is none -%}
 None
 {%- else -%}
@@ -24,8 +27,6 @@ TreeNode("{{ tree_obj["data"] }}",
     {%- endif %}
         self.{{ assertion }}(BinarySearchTree({{ tree_data }}).{{ prop | to_snake }}(),expected)
 {%- endmacro -%}
-
-{{ macros.header (imports=["BinarySearchTree", "TreeNode"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
 {%- for case in cases %}

--- a/exercises/practice/binary-search-tree/binary_search_tree_test.py
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search-tree/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -1,13 +1,15 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
 
 {%- macro test_call(case) %}
             {{ case["property"] }}(
                 {{ case["input"]["array"] }},
                 {{ case["input"]["value"] }}
             )
-{% endmacro -%}
+{% endmacro %}
 
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/binary-search/binary_search_test.py
+++ b/exercises/practice/binary-search/binary_search_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,5 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
+
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/bob/bob_test.py
+++ b/exercises/practice/bob/bob_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/book-store/.meta/template.j2
+++ b/exercises/practice/book-store/.meta/template.j2
@@ -1,11 +1,14 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
         basket = {{ input["basket"] }}
         self.assertEqual({{ case["property"] }}(basket), {{ case["expected"] }})
 {%- endmacro %}
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/book-store/book_store_test.py
+++ b/exercises/practice/book-store/book_store_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/book-store/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/bottle-song/.meta/template.j2
+++ b/exercises/practice/bottle-song/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/bottle-song/bottle_song_test.py
+++ b/exercises/practice/bottle-song/bottle_song_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/bowling/.meta/template.j2
+++ b/exercises/practice/bowling/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["BowlingGame"]) }}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -16,7 +20,6 @@
         self.assertEqual(game.score(), {{ case["expected"] }})
         {% endif %}
 {%- endmacro %}
-{{ macros.header(["BowlingGame"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     def roll_new_game(self, rolls):

--- a/exercises/practice/bowling/.meta/template.j2
+++ b/exercises/practice/bowling/.meta/template.j2
@@ -32,5 +32,4 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
     {{ test_case(case) }}
     {% endfor %}
 
-
-{{ macros.footer() }}
+{{ macros.utility() }}

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
-# File last updated on 2023-07-20
+# File last updated on 2023-07-21
 
 import unittest
 
@@ -211,7 +211,3 @@ class BowlingTest(unittest.TestCase):
     # Utility functions
     def assertRaisesWithMessage(self, exception):
         return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/bowling/bowling_test.py
+++ b/exercises/practice/bowling/bowling_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bowling/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/change/.meta/template.j2
+++ b/exercises/practice/change/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/change/change_test.py
+++ b/exercises/practice/change/change_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/change/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/circular-buffer/.meta/template.j2
+++ b/exercises/practice/circular-buffer/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["CircularBuffer","BufferEmptyException", "BufferFullException"]) }}
+
 {% macro call_op(op) -%}
 buf.{{ op["operation"] }}(
     {% if "item" in op -%}
@@ -6,7 +10,7 @@ buf.{{ op["operation"] }}(
     {%- endif -%}
 )
 {%- endmacro -%}
-{{ macros.header(["CircularBuffer","BufferEmptyException", "BufferFullException"]) }}
+
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/circular-buffer/circular_buffer_test.py
+++ b/exercises/practice/circular-buffer/circular_buffer_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/circular-buffer/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -1,8 +1,11 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["Clock"])}}
+
 {%- macro clock(obj) -%}
 Clock({{ obj["hour"] }}, {{ obj["minute"] }})
 {%- endmacro -%}
-{{ macros.header(["Clock"])}}
 
 {% set cases = additional_cases + cases %}
 

--- a/exercises/practice/clock/clock_test.py
+++ b/exercises/practice/clock/clock_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         {% set expected = case["expected"] -%}
@@ -15,7 +19,6 @@
         )
         {% endif %}
 {%- endmacro %}
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
 import unittest
 

--- a/exercises/practice/complex-numbers/.meta/template.j2
+++ b/exercises/practice/complex-numbers/.meta/template.j2
@@ -1,7 +1,6 @@
-import math
+{% extends "complexnumbers_template.j2" %}
 
-{% extends "master_template.j2" -%}
-{%- set imports = ["ComplexNumber"] -%}
+{% set imports = ["ComplexNumber"] %}
 
 {%- macro translate_math(item) -%}
 {{ item | replace("pi", "math.pi") | replace("e", "math.e") | replace("ln", "math.log") }}

--- a/exercises/practice/complex-numbers/complex_numbers_test.py
+++ b/exercises/practice/complex-numbers/complex_numbers_test.py
@@ -1,9 +1,8 @@
-import math
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+import math
 import unittest
 
 from complex_numbers import (
@@ -191,7 +190,3 @@ class ComplexNumbersTest(unittest.TestCase):
 
     def test_inequality_of_imaginary_part(self):
         self.assertNotEqual(ComplexNumber(1, 2), ComplexNumber(1, 1))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/connect/connect_test.py
+++ b/exercises/practice/connect/connect_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 
@@ -110,7 +110,3 @@ class ConnectTest(unittest.TestCase):
         )
         winner = game.get_winner()
         self.assertEqual(winner, "X")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/crypto-square/.meta/template.j2
+++ b/exercises/practice/crypto-square/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(['cipher_text']) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/crypto-square/crypto_square_test.py
+++ b/exercises/practice/crypto-square/crypto_square_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/crypto-square/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/custom-set/.meta/template.j2
+++ b/exercises/practice/custom-set/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {% set class_name = exercise | camel_case -%}
 {{ macros.header([class_name]) }}
 

--- a/exercises/practice/custom-set/custom_set_test.py
+++ b/exercises/practice/custom-set/custom_set_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/darts/.meta/template.j2
+++ b/exercises/practice/darts/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/darts/darts_test.py
+++ b/exercises/practice/darts/darts_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/darts/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/diamond/.meta/template.j2
+++ b/exercises/practice/diamond/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/diamond/diamond_test.py
+++ b/exercises/practice/diamond/diamond_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/difference-of-squares/.meta/template.j2
+++ b/exercises/practice/difference-of-squares/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.py
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/difference-of-squares/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/diffie-hellman/.meta/template.j2
+++ b/exercises/practice/diffie-hellman/.meta/template.j2
@@ -1,6 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{% set class = exercise | camel_case -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["private_key", "public_key", "secret"]) }}
+
+{% set class = exercise | camel_case -%}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.py
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/diffie-hellman/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/dnd-character/.meta/template.j2
+++ b/exercises/practice/dnd-character/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["Character", "modifier"]) }}
 
 {% macro test_case(supercase) -%}

--- a/exercises/practice/dnd-character/dnd_character_test.py
+++ b/exercises/practice/dnd-character/dnd_character_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/dnd-character/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/dominoes/.meta/template.j2
+++ b/exercises/practice/dominoes/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header()}}
 
 {% macro tuplify(dominoes_list) -%}

--- a/exercises/practice/dominoes/dominoes_test.py
+++ b/exercises/practice/dominoes/dominoes_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/dominoes/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/etl/.meta/template.j2
+++ b/exercises/practice/etl/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -9,7 +13,6 @@
             {{ case["property"] | to_snake }}(legacy_data), data
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/etl/etl_test.py
+++ b/exercises/practice/etl/etl_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/flatten-array/.meta/template.j2
+++ b/exercises/practice/flatten-array/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/flatten-array/flatten_array_test.py
+++ b/exercises/practice/flatten-array/flatten_array_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/food-chain/.meta/template.j2
+++ b/exercises/practice/food-chain/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/food-chain/food_chain_test.py
+++ b/exercises/practice/food-chain/food_chain_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/food-chain/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/forth/.meta/template.j2
+++ b/exercises/practice/forth/.meta/template.j2
@@ -1,6 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{% set imports = ["evaluate", "StackUnderflowError"] %}
-{{ macros.header(imports=imports, ignore=ignore) }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(imports = ["evaluate", "StackUnderflowError"])}}
 
 {% macro test_case(group, case) -%}
     def test_{{ group | to_snake }}_{{ case["description"] | to_snake }}(self):

--- a/exercises/practice/forth/forth_test.py
+++ b/exercises/practice/forth/forth_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/forth/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/gigasecond/.meta/template.j2
+++ b/exercises/practice/gigasecond/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 from datetime import datetime
 {{ macros.header() }}
 

--- a/exercises/practice/gigasecond/gigasecond_test.py
+++ b/exercises/practice/gigasecond/gigasecond_test.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+from datetime import datetime
 import unittest
 
 from gigasecond import (

--- a/exercises/practice/go-counting/go_counting_test.py
+++ b/exercises/practice/go-counting/go_counting_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/go-counting/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 
@@ -85,11 +85,3 @@ class GoCountingTest(unittest.TestCase):
         self.assertSetEqual(territories[BLACK], {(0, 0), (2, 0)})
         self.assertSetEqual(territories[WHITE], set())
         self.assertSetEqual(territories[NONE], set())
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/grade-school/.meta/template.j2
+++ b/exercises/practice/grade-school/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["School"]) }}
+
 {%- macro test_case( case) -%}
     {%- set input = case["input"] -%}
     {%- set property = case["property"] -%}
@@ -15,8 +19,7 @@
         {% else %}
         self.assertEqual(school.{{ case["property"] | to_snake }}(), expected)
         {%- endif %}
-{% endmacro -%}
-{{ macros.header(["School"]) }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/grade-school/grade_school_test.py
+++ b/exercises/practice/grade-school/grade_school_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grade-school/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {% macro test_case(case) %}
     {%- set input = case["input"] %}
@@ -15,8 +18,6 @@
             {{ input["square"] }}), {{ case["expected"] }})
     {% endif %}
 {%- endmacro %}
-
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/grains/grains_test.py
+++ b/exercises/practice/grains/grains_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/grep/.meta/template.j2
+++ b/exercises/practice/grep/.meta/template.j2
@@ -1,6 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
 import io
+{{ macros.header()}}
 from unittest import mock
 
 {% set filenames = comments | join("\n") | regex_find("[a-z-]*\.txt") -%}

--- a/exercises/practice/grep/grep_test.py
+++ b/exercises/practice/grep/grep_test.py
@@ -1,13 +1,13 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grep/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+import io
 import unittest
 
 from grep import (
     grep,
 )
-import io
 from unittest import mock
 
 FILE_TEXT = {

--- a/exercises/practice/hamming/.meta/template.j2
+++ b/exercises/practice/hamming/.meta/template.j2
@@ -1,12 +1,15 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) %}
             {{ case["property"] }}(
                 {% for arg in case["input"].values() -%}
                 "{{ arg }}"{{ "," if not loop.last }}
                 {% endfor %}
             )
-{% endmacro -%}
-{{ macros.header() }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/hamming/hamming_test.py
+++ b/exercises/practice/hamming/hamming_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,4 +1,5 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
 import unittest
 

--- a/exercises/practice/hello-world/hello_world_test.py
+++ b/exercises/practice/hello-world/hello_world_test.py
@@ -1,3 +1,7 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/hello-world/canonical-data.json
+# File last updated on 2023-07-19
+
 import unittest
 
 try:

--- a/exercises/practice/high-scores/.meta/template.j2
+++ b/exercises/practice/high-scores/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["HighScores"]) }}
+
 {%- macro get_property(property) %}
     {%- if property == "scores" %}
     scores
@@ -19,10 +23,7 @@
         highscores.personal_{{ function }}()
         self.assertEqual(highscores.{{ get_property(property) }}, expected)
         {% endif -%}
-{% endmacro -%}
-
-{{ macros.header(["HighScores"]) }}
-
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- for case in cases -%}

--- a/exercises/practice/high-scores/high_scores_test.py
+++ b/exercises/practice/high-scores/high_scores_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/high-scores/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/house/.meta/template.j2
+++ b/exercises/practice/house/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/house/house_test.py
+++ b/exercises/practice/house/house_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/house/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/isbn-verifier/.meta/template.j2
+++ b/exercises/practice/isbn-verifier/.meta/template.j2
@@ -1,6 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
-{{ macros.header() }}
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.py
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/isbn-verifier/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/isogram/.meta/template.j2
+++ b/exercises/practice/isogram/.meta/template.j2
@@ -1,12 +1,15 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) %}
             {{ case["property"] | to_snake }}(
                 {% for arg in case["input"].values() -%}
                 "{{ arg }}"{{ "," if not loop.last }}
                 {% endfor %}
             )
-{% endmacro -%}
-{{ macros.header() }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {# All test cases in this exercise are nested, so use two for loops -#}

--- a/exercises/practice/isogram/isogram_test.py
+++ b/exercises/practice/isogram/isogram_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/isogram/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/killer-sudoku-helper/.meta/template.j2
+++ b/exercises/practice/killer-sudoku-helper/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -8,7 +12,6 @@
             {{ case["input"]["cage"]["exclude"] }}), 
             {{ case["expected"] }})
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases[0]["cases"] -%}

--- a/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
+++ b/exercises/practice/killer-sudoku-helper/killer_sudoku_helper_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/killer-sudoku-helper/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/kindergarten-garden/.meta/template.j2
+++ b/exercises/practice/kindergarten-garden/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["Garden"]) }}
+
 {%- macro test_case(group_name, case) -%}
     {%- set input = case["input"] -%}
     def test_{{ group_name | to_snake }}_
@@ -16,8 +20,7 @@
             "{{ val | camel_case }}"{{- "," if not loop.last }}
             {% endfor %}]
         )
-{% endmacro -%}
-{{ macros.header(["Garden"]) }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases %}

--- a/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
+++ b/exercises/practice/kindergarten-garden/kindergarten_garden_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/kindergarten-garden/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/knapsack/.meta/template.j2
+++ b/exercises/practice/knapsack/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/knapsack/knapsack_test.py
+++ b/exercises/practice/knapsack/knapsack_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/knapsack/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/largest-series-product/.meta/template.j2
+++ b/exercises/practice/largest-series-product/.meta/template.j2
@@ -1,9 +1,11 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) -%}
   {{ case["property"] | to_snake }}("{{ case["input"]["digits"] }}", {{ case["input"]["span"] }})
-{%- endmacro -%}
-
-{{ macros.header() }}
+{%- endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/largest-series-product/largest_series_product_test.py
+++ b/exercises/practice/largest-series-product/largest_series_product_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/largest-series-product/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/leap/.meta/template.j2
+++ b/exercises/practice/leap/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/leap/leap_test.py
+++ b/exercises/practice/leap/leap_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/ledger/.meta/template.j2
+++ b/exercises/practice/ledger/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(imports=["format_entries", "create_entry"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/ledger/ledger_test.py
+++ b/exercises/practice/ledger/ledger_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/ledger/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/linked-list/.meta/template.j2
+++ b/exercises/practice/linked-list/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["LinkedList"]) }}
+
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         lst = LinkedList()
@@ -45,7 +49,6 @@
     {%- endif  %}
 {%- endmacro %}
 
-{{ macros.header(["LinkedList"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/linked-list/linked_list_test.py
+++ b/exercises/practice/linked-list/linked_list_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/linked-list/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/list-ops/.meta/template.j2
+++ b/exercises/practice/list-ops/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(imports=["append", "concat", "foldl", "foldr", "length", "reverse", "filter as list_ops_filter", "map as list_ops_map"]) }}
+
 {% macro lambdify(function) -%}
     {% set function = function.replace("(", "", 1).replace(")", "", 1).replace(" ->", ":") %}
     {% set function = function.replace("modulo", "%") %}
@@ -36,7 +40,6 @@
             {{ stringify(case["expected"]) }}
         )
 {%- endmacro %}
-{{ macros.header(imports=["append", "concat", "foldl", "foldr", "length", "reverse", "filter as list_ops_filter", "map as list_ops_map"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases -%}

--- a/exercises/practice/list-ops/list_ops_test.py
+++ b/exercises/practice/list-ops/list_ops_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/luhn/.meta/template.j2
+++ b/exercises/practice/luhn/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["Luhn"]) }}
+
 {%- macro test_case(group_name, case) -%}
     {%- set input = case["input"] -%}
     def test_{{ group_name | to_snake }}_
@@ -16,8 +20,7 @@
             "{{ val | camel_case }}",
             {% endfor %}]
         )
-{% endmacro -%}
-{{ macros.header(["Luhn"]) }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/luhn/luhn_test.py
+++ b/exercises/practice/luhn/luhn_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/markdown/.meta/template.j2
+++ b/exercises/practice/markdown/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/markdown/markdown_test.py
+++ b/exercises/practice/markdown/markdown_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/markdown/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/matching-brackets/.meta/template.j2
+++ b/exercises/practice/matching-brackets/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/matching-brackets/matching_brackets_test.py
+++ b/exercises/practice/matching-brackets/matching_brackets_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/matching-brackets/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/matrix/.meta/template.j2
+++ b/exercises/practice/matrix/.meta/template.j2
@@ -1,16 +1,15 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["Matrix"])}}
+
 {%- macro testcase(case) %}
     def test_{{ case["description"] | to_snake }}(self):
         matrix = Matrix("{{ case["input"]["string"] | replace('\n', '\\n') }}")
         self.assertEqual(matrix.{{ case["property"] | to_snake }}({{ case["input"]["index"]}} ), {{ case["expected"] }})
-{% endmacro -%}
-{{ macros.header(["Matrix"])}}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {%- for case in cases -%}
     {{- testcase(case) -}}
     {% endfor %}
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/exercises/practice/matrix/matrix_test.py
+++ b/exercises/practice/matrix/matrix_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/matrix/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 
@@ -41,7 +41,3 @@ class MatrixTest(unittest.TestCase):
     def test_extract_column_where_numbers_have_different_widths(self):
         matrix = Matrix("89 1903 3\n18 3 1\n9 4 800")
         self.assertEqual(matrix.column(2), [1903, 3, 4])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/meetup/.meta/template.j2
+++ b/exercises/practice/meetup/.meta/template.j2
@@ -1,4 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+from datetime import date
+{{ macros.header(imports=["meetup", "MeetupDayException"]) }}
+
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         {%- set input = namespace() %}
@@ -17,9 +22,6 @@
             {{ input.year }}, {{ input.month }}, "{{ input.week }}", "{{ input.dayofweek }}"), date({{ year }}, {{ month }}, {{ day }}))
         {% endif %}
 {%- endmacro %}
-
-from datetime import date
-{{ macros.header(imports=["meetup", "MeetupDayException"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/meetup/meetup_test.py
+++ b/exercises/practice/meetup/meetup_test.py
@@ -1,9 +1,8 @@
-from datetime import date
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/meetup/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+from datetime import date
 import unittest
 
 from meetup import (

--- a/exercises/practice/minesweeper/.meta/template.j2
+++ b/exercises/practice/minesweeper/.meta/template.j2
@@ -1,8 +1,11 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) -%}
     {{ case["property"] | to_snake }}({{ case["input"]["minefield"] }})
-{%- endmacro -%}
-{{ macros.header() }}
+{%- endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/minesweeper/minesweeper_test.py
+++ b/exercises/practice/minesweeper/minesweeper_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/minesweeper/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/nth-prime/.meta/template.j2
+++ b/exercises/practice/nth-prime/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -14,7 +18,6 @@
             )
         {%- endif %}
 {%- endmacro %}
-{{ macros.header()}}
 
 def prime_range(n):
     """Returns a list of the first n primes"""

--- a/exercises/practice/nth-prime/nth_prime_test.py
+++ b/exercises/practice/nth-prime/nth_prime_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/nth-prime/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/ocr-numbers/.meta/template.j2
+++ b/exercises/practice/ocr-numbers/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.py
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/ocr-numbers/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/palindrome-products/.meta/template.j2
+++ b/exercises/practice/palindrome-products/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {%- macro value_factor_unpacking(case) -%}
     {%- set input = case["input"] -%}
@@ -23,8 +26,6 @@
         self.assertFactorsEqual(factors, {{ expected["factors"] }})
     {%- endif %}
 {% endmacro %}
-
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/palindrome-products/palindrome_products_test.py
+++ b/exercises/practice/palindrome-products/palindrome_products_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/palindrome-products/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/pangram/.meta/template.j2
+++ b/exercises/practice/pangram/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {# All test cases in this exercise are nested, so use two for loops -#}

--- a/exercises/practice/pangram/pangram_test.py
+++ b/exercises/practice/pangram/pangram_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pangram/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/pascals-triangle/.meta/template.j2
+++ b/exercises/practice/pascals-triangle/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 import sys
 {{ macros.header() }}
 

--- a/exercises/practice/pascals-triangle/pascals_triangle_test.py
+++ b/exercises/practice/pascals-triangle/pascals_triangle_test.py
@@ -1,9 +1,8 @@
-import sys
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pascals-triangle/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+import sys
 import unittest
 
 from pascals_triangle import (

--- a/exercises/practice/perfect-numbers/.meta/template.j2
+++ b/exercises/practice/perfect-numbers/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -14,7 +18,6 @@
         )
     {% endif %}
 {%- endmacro %}
-{{ macros.header()}}
 
 {% for case in cases -%}
 class {{ case["description"] | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/perfect-numbers/perfect_numbers_test.py
+++ b/exercises/practice/perfect-numbers/perfect_numbers_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/phone-number/.meta/template.j2
+++ b/exercises/practice/phone-number/.meta/template.j2
@@ -1,6 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {% set class = exercise | camel_case -%}
 {{ macros.header([class]) }}
+
 
 class {{ class }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/phone-number/phone_number_test.py
+++ b/exercises/practice/phone-number/phone_number_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/phone-number/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/pig-latin/.meta/template.j2
+++ b/exercises/practice/pig-latin/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}

--- a/exercises/practice/pig-latin/pig_latin_test.py
+++ b/exercises/practice/pig-latin/pig_latin_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pig-latin/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/poker/.meta/template.j2
+++ b/exercises/practice/poker/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/poker/poker_test.py
+++ b/exercises/practice/poker/poker_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/poker/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/pov/.meta/template.j2
+++ b/exercises/practice/pov/.meta/template.j2
@@ -1,6 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
-{%- macro test_case(case) %}
+{{ macros.header(["Tree"]) }}
+
+{% macro test_case(case) %}
     def test_{{ case["description"] | to_snake }}(self):
         tree = {{ write_tree(case["input"]["tree"]) }}
         {% if case["property"] == "fromPov" -%}
@@ -8,7 +11,7 @@
         {%- elif case["property"] == "pathTo" -%}
         {{ test_path_to(case) }}
         {%- endif -%}
-{% endmacro -%}
+{% endmacro %}
 
 {%- macro test_from_pov(case) -%}
         {% if case["expected"] -%}
@@ -20,7 +23,7 @@
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "Tree could not be reoriented")
         {% endif -%}
-{% endmacro -%}
+{% endmacro %}
 
 {%- macro test_path_to(case) -%}
         {% if case["expected"] -%}
@@ -46,8 +49,6 @@
         {%- endfor %}
         ]{% endif %})
 {%- endmacro -%}
-
-{{ macros.header(["Tree"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases -%}

--- a/exercises/practice/pov/pov_test.py
+++ b/exercises/practice/pov/pov_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pov/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/prime-factors/.meta/template.j2
+++ b/exercises/practice/prime-factors/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/prime-factors/prime_factors_test.py
+++ b/exercises/practice/prime-factors/prime_factors_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/prime-factors/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/protein-translation/.meta/template.j2
+++ b/exercises/practice/protein-translation/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/protein-translation/protein_translation_test.py
+++ b/exercises/practice/protein-translation/protein_translation_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/protein-translation/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/proverb/.meta/template.j2
+++ b/exercises/practice/proverb/.meta/template.j2
@@ -1,5 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(imports=["proverb"]) }}
+
 {{ "# PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**" }}
 {{ "# A new line in a result list below **does not** always equal a new list element." }}
 {{ "# Check comma placement carefully!" }}

--- a/exercises/practice/proverb/proverb_test.py
+++ b/exercises/practice/proverb/proverb_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/proverb/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/pythagorean-triplet/.meta/template.j2
+++ b/exercises/practice/pythagorean-triplet/.meta/template.j2
@@ -1,6 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
-{{ macros.header() }}
+{{ macros.header()}}
 
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/pythagorean-triplet/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/queen-attack/.meta/template.j2
+++ b/exercises/practice/queen-attack/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(imports=['Queen']) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/queen-attack/queen_attack_test.py
+++ b/exercises/practice/queen-attack/queen_attack_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/queen-attack/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/rail-fence-cipher/.meta/template.j2
+++ b/exercises/practice/rail-fence-cipher/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rail-fence-cipher/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/raindrops/.meta/template.j2
+++ b/exercises/practice/raindrops/.meta/template.j2
@@ -1,12 +1,15 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) %}
             {{ case["property"] | to_snake }}(
                 {% for arg in case["input"].values() -%}
                 {{ arg }}{{- "," if not loop.last }}
                 {% endfor %}
             )
-{% endmacro -%}
-{{ macros.header() }}
+{% endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/raindrops/raindrops_test.py
+++ b/exercises/practice/raindrops/raindrops_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/raindrops/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/rational-numbers/.meta/template.j2
+++ b/exercises/practice/rational-numbers/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(imports=["Rational"]) }}
 
 {%- set operators = {
     "add": "+",
@@ -81,9 +84,6 @@
     {% endfor %}
 
 {%- endmacro %}
-
-from __future__ import division
-{{ macros.header(imports=["Rational"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for mathtypescases in cases %}

--- a/exercises/practice/rational-numbers/rational_numbers_test.py
+++ b/exercises/practice/rational-numbers/rational_numbers_test.py
@@ -1,8 +1,6 @@
-from __future__ import division
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rational-numbers/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/react/.meta/template.j2
+++ b/exercises/practice/react/.meta/template.j2
@@ -1,5 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 from functools import partial
+{{ macros.header(["InputCell", "ComputeCell"])}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     {%- set callback = [] -%}
@@ -48,7 +52,6 @@ from functools import partial
             {%- endif %}
         {% endfor -%}
 {%- endmacro %}
-{{ macros.header(["InputCell", "ComputeCell"])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/react/react_test.py
+++ b/exercises/practice/react/react_test.py
@@ -1,9 +1,8 @@
-from functools import partial
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/react/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+from functools import partial
 import unittest
 
 from react import (

--- a/exercises/practice/rectangles/.meta/template.j2
+++ b/exercises/practice/rectangles/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/rectangles/rectangles_test.py
+++ b/exercises/practice/rectangles/rectangles_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/resistor-color-duo/.meta/template.j2
+++ b/exercises/practice/resistor-color-duo/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-duo/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/resistor-color-expert/.docs/instructions.md
+++ b/exercises/practice/resistor-color-expert/.docs/instructions.md
@@ -41,7 +41,8 @@ The four-band resistor is built up like this:
 Meaning
 
 - orange-orange-brown-green would be 330 ohms with a ±0.5% tolerance.
-- orange-orange-red would-grey would be 3300 ohms with ±0.005% tolerance.
+- orange-orange-red-grey would be 3300 ohms with ±0.05% tolerance.
+
 The difference between a four and five-band resistor is that the five-band resistor has an extra band to indicate a more precise value.
 
 | Band_1  | Band_2  | Band_3  | Band_4     | band_5    |
@@ -50,9 +51,11 @@ The difference between a four and five-band resistor is that the five-band resis
 
 Meaning
 
-- orange-orange-orange-black-green would be 330 ohms with a ±0.5% tolerance.
+- orange-orange-orange-black-green would be 333 ohms with a ±0.5% tolerance.
+- orange-red-orange-blue-violet would be 323M ohms with a ±0.10 tolerance.
+
 There are also one band resistors.
-This type of resistor only has the color black and has a value of 0.
+One band resistors only have the color black with a value of 0.
 
 This exercise is about translating the resistor band colors into a label:
 

--- a/exercises/practice/resistor-color-trio/.meta/template.j2
+++ b/exercises/practice/resistor-color-trio/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             "{{ case['expected']['value']}} {{ case['expected']['unit']}}"
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
+++ b/exercises/practice/resistor-color-trio/resistor_color_trio_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/resistor-color/.meta/template.j2
+++ b/exercises/practice/resistor-color/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/resistor-color/resistor_color_test.py
+++ b/exercises/practice/resistor-color/resistor_color_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/rest-api/.meta/template.j2
+++ b/exercises/practice/rest-api/.meta/template.j2
@@ -1,6 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header(imports=["RestAPI"]) }}
+{{ macros.canonical_ref() }}
+
 import json
+{{ macros.header(imports=["RestAPI"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for casegroup in cases -%}{%- for case in casegroup["cases"] -%}

--- a/exercises/practice/rest-api/rest_api_test.py
+++ b/exercises/practice/rest-api/rest_api_test.py
@@ -1,13 +1,13 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rest-api/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
+import json
 import unittest
 
 from rest_api import (
     RestAPI,
 )
-import json
 
 
 class RestApiTest(unittest.TestCase):

--- a/exercises/practice/reverse-string/.meta/template.j2
+++ b/exercises/practice/reverse-string/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/reverse-string/reverse_string_test.py
+++ b/exercises/practice/reverse-string/reverse_string_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/rna-transcription/.meta/template.j2
+++ b/exercises/practice/rna-transcription/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/rna-transcription/rna_transcription_test.py
+++ b/exercises/practice/rna-transcription/rna_transcription_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rna-transcription/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/robot-simulator/.meta/template.j2
+++ b/exercises/practice/robot-simulator/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(imports=["Robot", "NORTH", "EAST", "SOUTH", "WEST"]) }}
 
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
@@ -15,7 +18,6 @@
         self.assertEqual(robot.direction, {{case["expected"]["direction"] | upper }})
 {%- endmacro %}
 
-{{ macros.header(imports=["Robot", "NORTH", "EAST", "SOUTH", "WEST"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}

--- a/exercises/practice/robot-simulator/robot_simulator_test.py
+++ b/exercises/practice/robot-simulator/robot_simulator_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/robot-simulator/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/roman-numerals/.meta/template.j2
+++ b/exercises/practice/roman-numerals/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["roman"]) }}
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/roman-numerals/roman_numerals_test.py
+++ b/exercises/practice/roman-numerals/roman_numerals_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/roman-numerals/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/rotational-cipher/.meta/template.j2
+++ b/exercises/practice/rotational-cipher/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/rotational-cipher/rotational_cipher_test.py
+++ b/exercises/practice/rotational-cipher/rotational_cipher_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/rotational-cipher/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/run-length-encoding/.meta/template.j2
+++ b/exercises/practice/run-length-encoding/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(['encode','decode'])}}
 
 {% macro test_case(case, tmod) -%}
     {%- set input = case["input"] -%}
@@ -13,7 +16,6 @@
         )
 {%- endmacro %}
 
-{{ macros.header(['encode','decode'])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases -%}

--- a/exercises/practice/run-length-encoding/run_length_encoding_test.py
+++ b/exercises/practice/run-length-encoding/run_length_encoding_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/run-length-encoding/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/saddle-points/.meta/template.j2
+++ b/exercises/practice/saddle-points/.meta/template.j2
@@ -1,11 +1,7 @@
-"""Tests for the saddle-points exercise
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
 
-Implementation note:
-The saddle_points function must validate the input matrix and raise a
-ValueError with a meaningful error message if the matrix turns out to be
-irregular.
-"""
-{% import "generator_macros.j2" as macros with context -%}
+{{ macros.header()}}
 
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
@@ -29,7 +25,6 @@ irregular.
         {% endif -%}
 {% endmacro -%}
 
-{{ macros.header()}}
 
 def sorted_points(point_list):
     return sorted(point_list, key=lambda p: (p["row"], p["column"]))

--- a/exercises/practice/saddle-points/saddle_points_test.py
+++ b/exercises/practice/saddle-points/saddle_points_test.py
@@ -1,13 +1,6 @@
-"""Tests for the saddle-points exercise
-
-Implementation note:
-The saddle_points function must validate the input matrix and raise a
-ValueError with a meaningful error message if the matrix turns out to be
-irregular.
-"""
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/saddle-points/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/satellite/.meta/template.j2
+++ b/exercises/practice/satellite/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/satellite/satellite_test.py
+++ b/exercises/practice/satellite/satellite_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/satellite/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/say/.meta/template.j2
+++ b/exercises/practice/say/.meta/template.j2
@@ -1,12 +1,14 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {%- macro test_call(case) %}
             {{ case["property"] }}(
                 {{ case["input"]["number"] }}
             )
-{% endmacro -%}
+{% endmacro %}
 
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/say/say_test.py
+++ b/exercises/practice/say/say_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/say/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/scale-generator/.meta/template.j2
+++ b/exercises/practice/scale-generator/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["Scale"])}}
 
 {% macro test_case(case) -%}
     {%- set tonic = case["input"]["tonic"] -%}
@@ -19,7 +22,6 @@
     {% endfor %}
 {%- endmacro %}
 
-{{ macros.header(["Scale"])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for supercase in cases %}

--- a/exercises/practice/scale-generator/scale_generator_test.py
+++ b/exercises/practice/scale-generator/scale_generator_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/scale-generator/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/scrabble-score/.meta/template.j2
+++ b/exercises/practice/scrabble-score/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/scrabble-score/scrabble_score_test.py
+++ b/exercises/practice/scrabble-score/scrabble_score_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/scrabble-score/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/secret-handshake/.meta/template.j2
+++ b/exercises/practice/secret-handshake/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/secret-handshake/secret_handshake_test.py
+++ b/exercises/practice/secret-handshake/secret_handshake_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/secret-handshake/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/series/.meta/template.j2
+++ b/exercises/practice/series/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/series/series_test.py
+++ b/exercises/practice/series/series_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/series/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/sgf-parsing/.meta/template.j2
+++ b/exercises/practice/sgf-parsing/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(["parse","SgfTree"])}}
 
 {% macro escape_sequences(string) -%}
     {{ string | replace("\\", "\\\\") | replace("\n", "\\n") | replace("\t", "\\t") }}
@@ -43,7 +46,6 @@
     {% endfor -%} }
 {%- endmacro -%}
 
-{{ macros.header(["parse","SgfTree"])}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/sgf-parsing/sgf_parsing_test.py
+++ b/exercises/practice/sgf-parsing/sgf_parsing_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sgf-parsing/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/sieve/.meta/template.j2
+++ b/exercises/practice/sieve/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/sieve/sieve_test.py
+++ b/exercises/practice/sieve/sieve_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sieve/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/simple-cipher/.meta/template.j2
+++ b/exercises/practice/simple-cipher/.meta/template.j2
@@ -1,6 +1,9 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 import re
 {{ macros.header(imports=['Cipher']) }}
+
 {%- macro convert_js(s) -%}
 {{ s |
     regex_replace("\\.substring\\((\\d+), ([^)]+)\\)", "[\\1:\\2]") |

--- a/exercises/practice/simple-cipher/simple_cipher_test.py
+++ b/exercises/practice/simple-cipher/simple_cipher_test.py
@@ -1,9 +1,8 @@
-import re
-
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/simple-cipher/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-20
 
+import re
 import unittest
 
 from simple_cipher import (

--- a/exercises/practice/space-age/.meta/template.j2
+++ b/exercises/practice/space-age/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["SpaceAge"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/space-age/space_age_test.py
+++ b/exercises/practice/space-age/space_age_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/spiral-matrix/.meta/template.j2
+++ b/exercises/practice/spiral-matrix/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/spiral-matrix/spiral_matrix_test.py
+++ b/exercises/practice/spiral-matrix/spiral_matrix_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/spiral-matrix/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/square-root/.meta/template.j2
+++ b/exercises/practice/square-root/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/square-root/square_root_test.py
+++ b/exercises/practice/square-root/square_root_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/square-root/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/sublist/.meta/template.j2
+++ b/exercises/practice/sublist/.meta/template.j2
@@ -1,10 +1,13 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header(imports=["sublist", "SUBLIST", "SUPERLIST", "EQUAL", "UNEQUAL"]) }}
+
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         self.assertEqual({{ case["property"] }}({{ case["input"]["listOne"] }}, {{ case["input"]["listTwo"] }}),
                          {{ case["expected"] | upper }})
 {%- endmacro %}
-{{ macros.header(imports=["sublist", "SUBLIST", "SUPERLIST", "EQUAL", "UNEQUAL"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/sublist/sublist_test.py
+++ b/exercises/practice/sublist/sublist_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sublist/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/sum-of-multiples/.meta/template.j2
+++ b/exercises/practice/sum-of-multiples/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["sum_of_multiples"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/sum-of-multiples/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/tournament/.meta/template.j2
+++ b/exercises/practice/tournament/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases %}

--- a/exercises/practice/tournament/tournament_test.py
+++ b/exercises/practice/tournament/tournament_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/tournament/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/transpose/.meta/template.j2
+++ b/exercises/practice/transpose/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/triangle/.meta/template.j2
+++ b/exercises/practice/triangle/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(["equilateral", "isosceles", "scalene"]) }}
 
 {% for case in cases -%}

--- a/exercises/practice/triangle/triangle_test.py
+++ b/exercises/practice/triangle/triangle_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/triangle/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/twelve-days/.meta/template.j2
+++ b/exercises/practice/twelve-days/.meta/template.j2
@@ -1,5 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {{ "# PLEASE TAKE NOTE: Expected result lists for these test cases use **implicit line joining.**" }}
 {{ "# A new line in a result list below **does not** always equal a new list element." }}
 {{ "# Check comma placement carefully!" }}

--- a/exercises/practice/twelve-days/twelve_days_test.py
+++ b/exercises/practice/twelve-days/twelve_days_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/twelve-days/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -26,3 +26,5 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- endif %}
 
     {% endfor %}
+
+{{ macros.utility() }}

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,11 +1,14 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {%- macro test_call(case) -%}
 {{ case["property"] }}({{ case["input"]["bucketOne"] }},
                       {{ case["input"]["bucketTwo"] }},
                       {{ case["input"]["goal"] }},
                       "{{ case["input"]["startBucket"] }}")
-{%- endmacro -%}
-{{ macros.header() }}
+{%- endmacro %}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
@@ -23,5 +26,3 @@ class {{ exercise | camel_case }}Test(unittest.TestCase):
         {%- endif %}
 
     {% endfor %}
-
-{{ macros.footer() }}

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
-# File last updated on 2023-07-19
+# File last updated on 2023-07-21
 
 import unittest
 
@@ -50,3 +50,7 @@ class TwoBucketTest(unittest.TestCase):
     def test_goal_larger_than_both_buckets_is_impossible(self):
         with self.assertRaisesWithMessage(ValueError):
             measure(5, 7, 8, "one")
+
+    # Utility functions
+    def assertRaisesWithMessage(self, exception):
+        return self.assertRaisesRegex(exception, r".+")

--- a/exercises/practice/two-bucket/two_bucket_test.py
+++ b/exercises/practice/two-bucket/two_bucket_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 
@@ -50,11 +50,3 @@ class TwoBucketTest(unittest.TestCase):
     def test_goal_larger_than_both_buckets_is_impossible(self):
         with self.assertRaisesWithMessage(ValueError):
             measure(5, 7, 8, "one")
-
-    # Utility functions
-    def assertRaisesWithMessage(self, exception):
-        return self.assertRaisesRegex(exception, r".+")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/exercises/practice/two-fer/.meta/template.j2
+++ b/exercises/practice/two-fer/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/two-fer/two_fer_test.py
+++ b/exercises/practice/two-fer/two_fer_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-fer/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/variable-length-quantity/.meta/template.j2
+++ b/exercises/practice/variable-length-quantity/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 {%- macro list_int_to_hex(integers) %}
             [
@@ -6,9 +9,8 @@
                 {{ "0x{:x}".format(integer) }}{{- "," if not loop.last }}
                 {% endfor %}
             ]
-{% endmacro -%}
+{% endmacro %}
 
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
+++ b/exercises/practice/variable-length-quantity/variable_length_quantity_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/variable-length-quantity/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/word-count/.meta/template.j2
+++ b/exercises/practice/word-count/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     {%- set input = case["input"] -%}
     def test_{{ case["description"] | to_snake }}(self):
@@ -7,7 +11,6 @@
             {{ case["expected"] }}
         )
 {%- endmacro %}
-{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/word-count/word_count_test.py
+++ b/exercises/practice/word-count/word_count_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/word-count/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/word-search/.meta/template.j2
+++ b/exercises/practice/word-search/.meta/template.j2
@@ -1,4 +1,6 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
 {{ macros.header(imports=["WordSearch", "Point"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/word-search/word_search_test.py
+++ b/exercises/practice/word-search/word_search_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/word-search/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/wordy/.meta/template.j2
+++ b/exercises/practice/wordy/.meta/template.j2
@@ -1,4 +1,8 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
 {% macro test_case(case) -%}
     def test_{{ case["description"] | to_snake }}(self):
         {%- set question = case["input"]["question"] %}
@@ -11,7 +15,6 @@
         self.assertEqual({{ case["property"] }}("{{ question }}"), {{ case["expected"] }})
         {%- endif %}
 {%- endmacro %}
-{{ macros.header() }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/yacht/.meta/template.j2
+++ b/exercises/practice/yacht/.meta/template.j2
@@ -1,6 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-import unittest
+{{ macros.canonical_ref() }}
 
+import unittest
 import {{ exercise }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):

--- a/exercises/practice/yacht/yacht_test.py
+++ b/exercises/practice/yacht/yacht_test.py
@@ -1,5 +1,8 @@
-import unittest
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/yacht/canonical-data.json
+# File last updated on 2023-07-19
 
+import unittest
 import yacht
 
 

--- a/exercises/practice/zebra-puzzle/.meta/template.j2
+++ b/exercises/practice/zebra-puzzle/.meta/template.j2
@@ -1,5 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
-{{ macros.header() }}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}

--- a/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/zebra-puzzle/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 

--- a/exercises/practice/zipper/.meta/template.j2
+++ b/exercises/practice/zipper/.meta/template.j2
@@ -1,4 +1,7 @@
 {%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header (imports=["Zipper"]) }}
 
 {%- macro test_case(case) %}
     {%- set input = case["input"] -%}
@@ -9,7 +12,7 @@
         {%- else %}
         {{ expected_value(input, expected) }}
         {%- endif %}
-{%- endmacro -%}
+{% endmacro %}
 
 {%- macro expected_value(input, expected) -%}
         initial = {{ input["initialTree"] }}
@@ -44,9 +47,8 @@
     {%- for op in operations -%}
         .{{ op["operation"] }}({{ op["item"] }})
     {%- endfor %}
-{%- endmacro -%}
+{%- endmacro %}
 
-{{ macros.header (imports=["Zipper"]) }}
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
 {%- for case in cases %}

--- a/exercises/practice/zipper/zipper_test.py
+++ b/exercises/practice/zipper/zipper_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/zipper/canonical-data.json
-# File last updated on 2023-07-16
+# File last updated on 2023-07-19
 
 import unittest
 


### PR DESCRIPTION
While the original purpose of this PR was to fix small typos in `Resistor Color Expert`, it has ballooned into a 237-file change to fix the CI.  All practice exercise JinJa2 templates needed to be altered, and all related test files needed to be regenerated.

Hopefully, this is the last time this will be necessary.
Please see the commit message for more details.