### PR TITLE
[Say]:  Instruction Append Typo in writing 999 billion .... 999 thousand 999

### DIFF
--- a/exercises/practice/say/.docs/instructions.append.md
+++ b/exercises/practice/say/.docs/instructions.append.md
@@ -12,6 +12,6 @@ To raise a `ValueError` with a message, write the message as an argument to the 
 # if the number is negative
 raise ValueError("input out of range")
 
-# if the number is larger than 999,999,999,99
+# if the number is larger than 999,999,999,999
 raise ValueError("input out of range")
 ```


### PR DESCRIPTION
Missing a 9 in the unit's digit. Does not match the desciption given at instructions.md of "It's fine to stop at "trillion".