### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/generators/about.md
+++ b/concepts/generators/about.md
@@ -94,9 +94,9 @@ When `yield` is evaluated, it pauses the execution of the enclosing function and
 
 The function then _stays in scope_, and when `__next__()` is called, execution resumes until `yield` is encountered again.
 
-```exercism/note
+~~~~exercism/note
 Using `yield` expressions is prohibited outside of functions.
-```
+~~~~
 
 ```python
 >>> def infinite_sequence():

--- a/exercises/concept/plane-tickets/.docs/introduction.md
+++ b/exercises/concept/plane-tickets/.docs/introduction.md
@@ -94,9 +94,9 @@ When `yield` is evaluated, it pauses the execution of the enclosing function and
 
 The function then _stays in scope_, and when `__next__()` is called, execution resumes until `yield` is encountered again.
 
-```exercism/note
+~~~~exercism/note
 Using `yield` expressions is prohibited outside of functions.
-```
+~~~~
 
 ```python
 >>> def infinite_sequence():

--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -5,9 +5,9 @@ Your task is to implement a binary search algorithm.
 A binary search algorithm finds an item in a list by repeatedly splitting it in half, only keeping the half which contains the item we're looking for.
 It allows us to quickly narrow down the possible locations of our item until we find it, or until we've eliminated all possible locations.
 
-```exercism/caution
+~~~~exercism/caution
 Binary search only works when a list has been sorted.
-```
+~~~~
 
 The algorithm looks like this:
 

--- a/exercises/practice/bob/.approaches/answer-list/content.md
+++ b/exercises/practice/bob/.approaches/answer-list/content.md
@@ -22,12 +22,12 @@ Python doesn't _enforce_ having real constant values,
 but the `ANSWERS` list is defined with all uppercase letters, which is the naming convention for a Python [constant][const].
 It indicates that the value is not intended to be changed.
 
-```exercism/note
+~~~~exercism/note
 `ANSWERS` could prevent item reassignment by being defined as a [tuple](https://realpython.com/python-lists-tuples/#python-tuples) instead of a list.
 The items in a tuple cannot be changed, and the performance between a tuple and a list here is equivalent.
 The entire `ANSWERS` tuple could still be reassigned to another tuple,
 so uppercase letters would still be used to indicate that the `ANSWERS` tuple should not be changed.
-```
+~~~~
 
 The [`rstrip`][rstrip] method is applied to the input to eliminate any whitespace at the end of the input.
 If the input has no characters left, it uses the [falsiness][falsiness] of an empty string with the [`not`][not] operator to return the response for saying nothing.
@@ -37,11 +37,11 @@ A [ternary operator][ternary] is used for determining the score for a shout and 
 
 The [`isupper`][isupper] method is used to test that there is at least one cased character and that all cased characters are uppercase.
 
-```exercism/note
+~~~~exercism/note
 A cased character is one which differs between lowercase and uppercase.
 For example, `?` and `3` are not cased characters, as they do not change between lowercase and uppercase.
 `a` and `z` are cased characters, since their lowercase form changes to `A` and ` Z` when uppercase.
-```
+~~~~
 
 If `isupper` is `True`, then `is_shout` is given the value of `2`; otherwise, it is given the value of `0`.
 

--- a/exercises/practice/bob/.approaches/if-statements-nested/content.md
+++ b/exercises/practice/bob/.approaches/if-statements-nested/content.md
@@ -20,11 +20,11 @@ def response(hey_bob):
 In this approach you have a series of `if` statements using the calculated variables to evaluate the conditions, some of which are nested.
 As soon as a `True` condition is found, the correct response is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that there are no `elif` or `else` statements.
 If an `if` statement can return, then an `elif` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-```
+~~~~
 
 The [`rstrip`][rstrip] method is applied to the input to eliminate any whitespace at the end of the input.
 If the input has no characters left, it uses the [falsiness][falsiness] of an empty string with the [`not`][not] operator to return the response for saying nothing.
@@ -32,11 +32,11 @@ Since it doesn't matter if there is leading whitespace, the `rstrip` function is
 
 The [`isupper`][isupper] method is used to test that there is at least one cased character and that all cased characters are uppercase.
 
-```exercism/note
+~~~~exercism/note
 A cased character is one which differs between lowercase and uppercase.
 For example, `?` and `3` are not cased characters, as they do not change between lowercase and uppercase.
 `a` and `z` are cased characters, since their lowercase form changes to `A` and ` Z` when uppercase.
-```
+~~~~
 
 The [`endswith`][endswith] method is used to determine if the input ends with a question mark.
 

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -20,11 +20,11 @@ def response(hey_bob):
 In this approach you have a series of `if` statements using the calculated variables to evaluate the conditions.
 As soon as a `True` condition is found, the correct response is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that there are no `elif` or `else` statements.
 If an `if` statement can return, then an `elif` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-```
+~~~~
 
 The [`rstrip`][rstrip] method is applied to the input to eliminate any whitespace at the end of the input.
 If the input has no characters left, it uses the [falsiness][falsiness] of an empty string with the [`not`][not] operator to return the response for saying nothing.
@@ -32,11 +32,11 @@ Since it doesn't matter if there is leading whitespace, the `rstrip` function is
 
 The [`isupper`][isupper] method is used to test that there is at least one cased character and that all cased characters are uppercase.
 
-```exercism/note
+~~~~exercism/note
 A cased character is one which differs between lowercase and uppercase.
 For example, `?` and `3` are not cased characters, as they do not change between lowercase and uppercase.
 `a` and `z` are cased characters, since their lowercase form changes to `A` and ` Z` when uppercase.
-```
+~~~~
 
 The [`endswith`][endswith] method is used to determine if the input ends with a question mark.
 

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -22,6 +22,6 @@ This needs to be changed to store each individual letter with its score in a one
 
 As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
 
-```exercism/note
+~~~~exercism/note
 If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/grains/grains_test.py
+++ b/exercises/practice/grains/grains_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2023-07-19
+# File last updated on 2023-09-27
 
 import unittest
 
@@ -32,19 +32,19 @@ class GrainsTest(unittest.TestCase):
     def test_grains_on_square_64(self):
         self.assertEqual(square(64), 9223372036854775808)
 
-    def test_square_0_raises_an_exception(self):
+    def test_square_0_is_invalid(self):
         with self.assertRaises(ValueError) as err:
             square(0)
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "square must be between 1 and 64")
 
-    def test_negative_square_raises_an_exception(self):
+    def test_negative_square_is_invalid(self):
         with self.assertRaises(ValueError) as err:
             square(-1)
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "square must be between 1 and 64")
 
-    def test_square_greater_than_64_raises_an_exception(self):
+    def test_square_greater_than_64_is_invalid(self):
         with self.assertRaises(ValueError) as err:
             square(65)
         self.assertEqual(type(err.exception), ValueError)

--- a/exercises/practice/isogram/.approaches/scrub-regex/content.md
+++ b/exercises/practice/isogram/.approaches/scrub-regex/content.md
@@ -12,9 +12,9 @@ def is_isogram(phrase):
 
 For this approach, [regular expression][regex], also known as a [regex][regex-how-to], is used to scrub the input phrase [str][str]ing.
 - In the pattern of `[^a-zA-Z]` the brackets are used to define a character set that looks for characters which are _not_ `a` through `z` and `A` through `Z`.
-```exercism/note
+~~~~exercism/note
 If the first character of a character set is `^`, all the characters that are _not_ in the rest of the character set will be matched.
-```
+~~~~
 This essentially matches any characters which are not in the English alphabet.
  The pattern is passed to the [`compile()`][compile] method to construct a [regular expression object][regex-object].
 - The [`sub()`][sub] method is then called on the regex object.

--- a/exercises/practice/leap/.approaches/datetime-addition/content.md
+++ b/exercises/practice/leap/.approaches/datetime-addition/content.md
@@ -10,9 +10,9 @@ def leap_year(year):
 
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach may be considered a "cheat" for this exercise.
-```
+~~~~
 
 By adding a day to February 28th for the year, you can see if the new day is the 29th or the 1st.
 If it is the 29th, then the function returns `True` for the year being a leap year.

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/luhn/.approaches/recursion/content.md
+++ b/exercises/practice/luhn/.approaches/recursion/content.md
@@ -44,13 +44,13 @@ The `luhny_bin()` method takes that list, along with two `0` values that represe
 The `luhny_bin()` can call itself, which is a behavior called [recursion][recursion].
 Since `luhny_bin()` can call itself, the first thing it does is to check that it is done calling itself.
 
-```exercism/note
+~~~~exercism/note
 This check is called the terminating condition.
 It's critical to have a terminating condition, since every call of a recursive function to itself places another
 [frame on the stack](https://realpython.com/lessons/stack-frames-and-stack-traces/#:~:text=A%20stack%20frame%20represents%20a,is%20removed%20from%20the%20stack.).
 If there is no terminating condition, then the recursive function will keep calling itself until the stack runs out of space
 and a stack overflow error will occur.
-```
+~~~~
 
 The `luhny_bin()` method should terminate when there are no more characters to process.
 By using the [falsiness][falsiness] of an empty list, the [`not` operator][not-operator] can be used instead of comparing the `len()` of the list to `0`.

--- a/exercises/practice/pangram/.approaches/all/content.md
+++ b/exercises/practice/pangram/.approaches/all/content.md
@@ -15,13 +15,13 @@ def is_pangram(sentence):
 using the [`all()`][all] function.
 - If all of the letters in the alphabet are contained in the `sentence`, then the function will return `True`.
 
-```exercism/note
+~~~~exercism/note
 Instead of `lower()`, the [`casefold`](https://docs.python.org/3/library/stdtypes.html#str.casefold)
 method could be used to lowercase the letters.
 `casefold()` differs from `lower()` in lowercasing certain Unicode characters.
 At the time of writing, those differences are not of concern to this exercise.
 Also, `casefold()` benched slower than `lower()`.
-```
+~~~~
 
 [ascii-lowercase]: https://docs.python.org/3/library/string.html#string.ascii_lowercase
 [lower]: https://docs.python.org/3/library/stdtypes.html?#str.lower

--- a/exercises/practice/pangram/.approaches/bitfield/content.md
+++ b/exercises/practice/pangram/.approaches/bitfield/content.md
@@ -20,11 +20,11 @@ def is_pangram(sentence):
 This solution uses the [ASCII][ascii] value of the letter to set the corresponding bit position.
 First, some [constant][const] values are set.
 
-```exercism/note
+~~~~exercism/note
 Python doesn't _enforce_ having real constant values,
 but using all uppercase letters is the naming convention for a Python constant.
 It indicates that the value is not intended to be changed.
-```
+~~~~
 
 These values will be used for readability in the body of the `is_pangram` function.
 The ASCII value for `a` is `97`.

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/pig-latin/.approaches/sets-and-slices/content.md
+++ b/exercises/practice/pig-latin/.approaches/sets-and-slices/content.md
@@ -42,11 +42,11 @@ If the beginning of the word matches either condition, the loop [continue][conti
 If the beginning of the word did not match either condition,
 that leaves [ranging][ranging] its characters from position 1 until the [`len()`][len] of the word.
 
-```exercism/note
+~~~~exercism/note
 When a [range](https://docs.python.org/3/library/stdtypes.html?#range) is provided two arguments,
 it generates values from the `start` argument up to _but not including_ the `stop` argument.
 This behavior can be referred to as start inclusive, stop exclusive.
-```
+~~~~
 
 The inner loop iterating characters is nested within the outer loop that iterates the words.
 Each character is iterated until finding a vowel (at this point, the letter `y` is now considered a vowel.)

--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -2,11 +2,11 @@
 
 A rational number is defined as the quotient of two integers `a` and `b`, called the numerator and denominator, respectively, where `b != 0`.
 
-```exercism/note
+~~~~exercism/note
 Note that mathematically, the denominator can't be zero.
 However in many implementations of rational numbers, you will find that the denominator is allowed to be zero with behaviour similar to positive or negative infinity in floating point numbers.
 In those cases, the denominator and numerator generally still can't both be zero at once.
-```
+~~~~
 
 The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
 

--- a/exercises/practice/rna-transcription/.approaches/translate-maketrans/content.md
+++ b/exercises/practice/rna-transcription/.approaches/translate-maketrans/content.md
@@ -23,9 +23,9 @@ and is passed the translation table.
 The output of `translate()` is a string where all of the input DNA characters have been replaced by their RNA complement in the translation table.
 
 
-```exercism/note
+~~~~exercism/note
 As of this writing, no invalid DNA characters are in the argument to `to_rna()`, so there is no error handling required for invalid input.
-```
+~~~~
 
 [dictionaries]: https://docs.python.org/3/tutorial/datastructures.html?#dictionaries
 [maketrans]: https://docs.python.org/3/library/stdtypes.html?#str.maketrans

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -15,6 +15,6 @@ Given a DNA strand, its transcribed RNA strand is formed by replacing each nucle
 - `T` -> `A`
 - `A` -> `U`
 
-```exercism/note
+~~~~exercism/note
 If you want to look at how the inputs and outputs are structured, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/rna-transcription/.docs/introduction.md
+++ b/exercises/practice/rna-transcription/.docs/introduction.md
@@ -4,7 +4,7 @@ You work for a bioengineering company that specializes in developing therapeutic
 
 Your team has just been given a new project to develop a targeted therapy for a rare type of cancer.
 
-```exercism/note
+~~~~exercism/note
 It's all very complicated, but the basic idea is that sometimes people's bodies produce too much of a given protein.
 That can cause all sorts of havoc.
 
@@ -13,4 +13,4 @@ But if you can create a very specific molecule (called a micro-RNA), it can prev
 This technique is called [RNA Interference][rnai].
 
 [rnai]: https://admin.acceleratingscience.com/ask-a-scientist/what-is-rnai/
-```
+~~~~

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -41,8 +41,8 @@ The secret handshake for 26 is therefore:
 jump, double blink
 ```
 
-```exercism/note
+~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
 
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
-```
+~~~~

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -18,11 +18,11 @@ Then you repeat the following steps:
 You keep repeating these steps until you've gone through every number in your list.
 At the end, all the unmarked numbers are prime.
 
-```exercism/note
+~~~~exercism/note
 [Wikipedia's Sieve of Eratosthenes article][eratosthenes] has a useful graphic that explains the algorithm.
 
 The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
 A good first test is to check that you do not use division or remainder operations.
 
 [eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
-```
+~~~~

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -7,7 +7,7 @@ Given a range of numbers (the song IDs), create a singly linked list.
 
 Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 
 The simplest kind of linked list is a **singly** linked list.
@@ -16,4 +16,4 @@ That means that each element (or "node") contains data, along with something tha
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/wordy/.approaches/dunder-getattribute/content.md
+++ b/exercises/practice/wordy/.approaches/dunder-getattribute/content.md
@@ -35,17 +35,17 @@ def answer(question):
 
 This approach begins by defining a [dictionary][dictionaries] of the word keys with their related [dunder][dunder] methods.
 
-```exercism/note
+~~~~exercism/note
 They are called "dunder" methods because they have **d**ouble **under**scores at the beginning and end of the method name.
 They are also called magic methods.
-```
+~~~~
 
 Since only whole numbers are involved, the dunder methods are those for [`int`][int].
 The supported methods for `int` can be found by using `print(dir(int))`.
 
-```exercism/note
+~~~~exercism/note
 The built-in [`dir`](https://docs.python.org/3/library/functions.html?#dir) function returns a list of valid attributes for an object.
-```
+~~~~
 
 Python doesn't _enforce_ having real constant values,
 but the `OPS` dictionary is defined with all uppercase letters, which is the naming convention for a Python [constant][const].
@@ -74,10 +74,10 @@ passing it `y` converted to an `int`.
 
 It sets the list to the result of the dunder method plus the remaining elements in `*tail`.
 
-```exercism/note
+~~~~exercism/note
 The `*` prefix in `*tail` [unpacks](https://treyhunner.com/2018/10/asterisks-in-python-what-they-are-and-how-to-use-them/) the `tail` list back into its elements.
 This concept is also a part of [unpacking-and-multiple-assignment](https://exercism.org/tracks/python/concepts/unpacking-and-multiple-assignment) concept in the syllabus.
-```
+~~~~
 
 When the loop exhausts, the first element of the list is selected as the function return value.
 

--- a/exercises/practice/wordy/.approaches/introduction.md
+++ b/exercises/practice/wordy/.approaches/introduction.md
@@ -4,10 +4,10 @@ There are various ways to solve Wordy.
 Using [`eval`][eval] is a [convenient but potentially dangerous][eval-danger] approach.
 Another approach could replace the operation words with [dunder][dunder] methods.
 
-```exercism/note
+~~~~exercism/note
 They are called "dunder" methods because they have **d**ouble **under**scores at the beginning and end of the method name.
 They are also called magic methods.
-```
+~~~~
 
 The dunder methods can be called by using the [`__getattribute__`][getattribute] method for [`int`][int].
 


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705