### PR TITLE
Fix grammar in currency-exchange exercise

### DIFF
--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -36,7 +36,7 @@ This function should return the amount of money that *is left* from the budget.
 Create the `get_value_of_bills()` function, taking 2 parameters:
 
 1. `denomination` : The value of a single bill.
-2. `number_of_bills` : Amount of bills you received.
+2. `number_of_bills` : Number of bills you received.
 
 This exchanging booth only deals in cash of certain increments.
 The total you receive must be divisible by the value of one "bill" or unit, which can leave behind a fraction or remainder.

--- a/exercises/concept/currency-exchange/.docs/introduction.md
+++ b/exercises/concept/currency-exchange/.docs/introduction.md
@@ -8,7 +8,7 @@ There are three different kinds of built-in numbers in Python : `ints`, `floats`
 
 `ints` are whole numbers. e.g. `1234`, `-10`, `20201278`.
 
-Integers in Python have [arbitrary precision][arbitrary-precision] -- the amount of digits is limited only by the available memory of the host system.
+Integers in Python have [arbitrary precision][arbitrary-precision] -- the number of digits is limited only by the available memory of the host system.
 
 ### floats
 

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -24,7 +24,7 @@ def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int - amount of bills you received.
+    :param number_of_bills: int - number of bills you received.
     :return: int - total value of bills you now have.
     """
 

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -24,7 +24,7 @@ def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int - amount of bills you received.
+    :param number_of_bills: int - number of bills you received.
     :return: int - total value of bills you now have.
     """
 


### PR DESCRIPTION
The word _amount_ is generally used for things that come in piles (like money) or
that can otherwise be measured but not counted (like water).

The word _number_ is typically used if you can count the things.

Technically money can be counted, but it's an exception (see 'piles' above).

Here we count bills and digits, so 'number' is the more common choice of word.
