### PR TITLE
Clarify bills in currency exchange exercise

### DIFF
--- a/exercises/concept/currency-exchange/.docs/hints.md
+++ b/exercises/concept/currency-exchange/.docs/hints.md
@@ -19,7 +19,7 @@
 ## 4. Calculate number of bills
 
 - You need to divide `amount` into `denomination`.
-- You need to use type casting to _int_ to get the exact number of bills.
+- You need to use type casting to `int` to get the exact number of bills.
 - To remove decimal places from a `float`, you can convert it to `int`.
 
   **Note:** The `//` operator also does floor division. But, if the operand has `float`, the result is still `float`.
@@ -32,12 +32,12 @@
 ## 6. Calculate value after exchange
 
 - You need to calculate `spread` percent of `exchange_rate` using multiplication operator and add it to `exchange_rate` to get the exchanged currency.
-- The actual rate needs to be computed. Remember to add exchange rate and exchange fee.
-- You can get exchanged money affected by commission by using divide operation and type casting _int_.
+- The actual rate needs to be computed. Remember to add exchange _rate_ and exchange _fee_.
+- You can get exchanged money affected by commission by using divide operation and type casting to `int`.
 
 
+[division-operator]: https://docs.python.org/3/tutorial/introduction.html#numbers
+[multiplication-operator]: https://docs.python.org/3/tutorial/introduction.html#numbers
 [python-numbers-tutorial]: https://docs.python.org/3/tutorial/introduction.html#numbers
 [python-numeric-types]: https://docs.python.org/3.9/library/stdtypes.html#numeric-types-int-float-complex
-[division-operator]: https://docs.python.org/3/tutorial/introduction.html#numbers
 [subtraction-operator]: https://docs.python.org/3/tutorial/introduction.html#numbers
-[multiplication-operator]: https://docs.python.org/3/tutorial/introduction.html#numbers

--- a/exercises/concept/currency-exchange/.docs/hints.md
+++ b/exercises/concept/currency-exchange/.docs/hints.md
@@ -18,7 +18,7 @@
 
 ## 4. Calculate number of bills
 
-- You need to divide `budget` into `denomination`.
+- You need to divide `amount` into `denomination`.
 - You need to use type casting to _int_ to get the exact number of bills.
 - To remove decimal places from a `float`, you can convert it to `int`.
 
@@ -26,7 +26,7 @@
 
 ## 5. Calculate leftover after exchanging into bills
 
-- You need to find the remainder of `budget` that does not equal a whole `denomination`.
+- You need to find the remainder of `amount` that does not equal a whole `denomination`.
 - The Modulo operator `%` can help find the remainder.
 
 ## 6. Calculate value after exchange

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -12,6 +12,7 @@ Create the `exchange_money()` function, taking 2 parameters:
 This function should return the value of the exchanged currency.
 
 **Note:** If your currency is USD and you want to exchange USD for EUR with an exchange rate of `1.20`, then `1.20 USD == 1 EUR`.
+
 ```python
 >>> exchange_money(127.5, 1.2)
 106.25

--- a/exercises/concept/currency-exchange/.docs/instructions.md
+++ b/exercises/concept/currency-exchange/.docs/instructions.md
@@ -36,7 +36,7 @@ This function should return the amount of money that *is left* from the budget.
 Create the `get_value_of_bills()` function, taking 2 parameters:
 
 1. `denomination` : The value of a single bill.
-2. `number_of_bills` : Number of bills you received.
+2. `number_of_bills` : The total number of bills.
 
 This exchanging booth only deals in cash of certain increments.
 The total you receive must be divisible by the value of one "bill" or unit, which can leave behind a fraction or remainder.
@@ -50,10 +50,10 @@ Unfortunately, the booth gets to keep the remainder/change as an added bonus.
 
 ## 4. Calculate number of bills
 
-Create the `get_number_of_bills()` function, taking `budget` and `denomination`.
+Create the `get_number_of_bills()` function, taking `amount` and `denomination`.
 
-This function should return the _number of currency bills_ that you can receive within the given _budget_.
-In other words:  How many _whole bills_ of currency fit into the amount of currency you have in your budget?
+This function should return the _number of currency bills_ that you can receive within the given _amount_.
+In other words:  How many _whole bills_ of currency fit into the starting amount?
 Remember -- you can only receive _whole bills_, not fractions of bills, so remember to divide accordingly.
 Effectively, you are rounding _down_ to the nearest whole bill/denomination.
 
@@ -64,9 +64,9 @@ Effectively, you are rounding _down_ to the nearest whole bill/denomination.
 
 ## 5. Calculate leftover after exchanging into bills
 
-Create the `get_leftover_of_bills()` function, taking `budget` and `denomination`.
+Create the `get_leftover_of_bills()` function, taking `amount` and `denomination`.
 
-This function should return the _leftover amount_ that cannot be exchanged from your _budget_ given the denomination of bills.
+This function should return the _leftover amount_ that cannot be returned from your starting _amount_ given the denomination of bills.
 It is very important to know exactly how much the booth gets to keep.
 
 ```python

--- a/exercises/concept/currency-exchange/.docs/introduction.md
+++ b/exercises/concept/currency-exchange/.docs/introduction.md
@@ -70,9 +70,9 @@ To convert a float to an integer, you can use `int()`. Also, to convert an integ
 3.0
 ```
 
-[arbitrary-precision]: https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic#:~:text=In%20computer%20science%2C%20arbitrary%2Dprecision,memory%20of%20the%20host%20system.
-[numeric-type-docs]: https://docs.python.org/3/library/stdtypes.html#typesnumeric
-[`int()` built in]: https://docs.python.org/3/library/functions.html#int
-[`float()` built in]: https://docs.python.org/3/library/functions.html#float
 [0.30000000000000004.com]: https://0.30000000000000004.com/
+[`float()` built in]: https://docs.python.org/3/library/functions.html#float
+[`int()` built in]: https://docs.python.org/3/library/functions.html#int
+[arbitrary-precision]: https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic#:~:text=In%20computer%20science%2C%20arbitrary%2Dprecision,memory%20of%20the%20host%20system.
 [floating point math]: https://docs.python.org/3.9/tutorial/floatingpoint.html
+[numeric-type-docs]: https://docs.python.org/3/library/stdtypes.html#typesnumeric

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -39,7 +39,7 @@ def get_number_of_bills(amount, denomination):
     :return: int - number of bills that can be obtained from the amount.
     """
 
-    return int(budget) // denomination
+    return int(amount) // denomination
 
 
 def get_leftover_of_bills(amount, denomination):
@@ -50,7 +50,7 @@ def get_leftover_of_bills(amount, denomination):
     :return: float - the amount that is "leftover", given the current denomination.
     """
 
-    return budget % denomination
+    return amount % denomination
 
 
 def exchangeable_value(budget, exchange_rate, spread, denomination):

--- a/exercises/concept/currency-exchange/.meta/exemplar.py
+++ b/exercises/concept/currency-exchange/.meta/exemplar.py
@@ -24,30 +24,30 @@ def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int - number of bills you received.
-    :return: int - total value of bills you now have.
+    :param number_of_bills: int - total number of bills.
+    :return: int - calculated value of the bills.
     """
 
     return denomination * number_of_bills
 
 
-def get_number_of_bills(budget, denomination):
+def get_number_of_bills(amount, denomination):
     """
 
-    :param budget: float - the amount of money you are planning to exchange.
+    :param amount: float - the total starting value.
     :param denomination: int - the value of a single bill.
-    :return: int - number of bills after exchanging all your money.
+    :return: int - number of bills that can be obtained from the amount.
     """
 
     return int(budget) // denomination
 
 
-def get_leftover_of_bills(budget, denomination):
+def get_leftover_of_bills(amount, denomination):
     """
 
-    :param budget: float - the amount of money you are planning to exchange.
+    :param amount: float - the total starting value.
     :param denomination: int - the value of a single bill.
-    :return: float - the leftover amount that cannot be exchanged given the current denomination.
+    :return: float - the amount that is "leftover", given the current denomination.
     """
 
     return budget % denomination

--- a/exercises/concept/currency-exchange/exchange.py
+++ b/exercises/concept/currency-exchange/exchange.py
@@ -24,30 +24,30 @@ def get_value_of_bills(denomination, number_of_bills):
     """
 
     :param denomination: int - the value of a bill.
-    :param number_of_bills: int - number of bills you received.
-    :return: int - total value of bills you now have.
+    :param number_of_bills: int - total number of bills.
+    :return: int - calculated value of the bills.
     """
 
     pass
 
 
-def get_number_of_bills(budget, denomination):
+def get_number_of_bills(amount, denomination):
     """
 
-    :param budget: float - the amount of money you are planning to exchange.
+    :param amount: float - the total starting value.
     :param denomination: int - the value of a single bill.
-    :return: int - number of bills after exchanging all your money.
+    :return: int - number of bills that can be obtained from the amount.
     """
 
     pass
 
 
-def get_leftover_of_bills(budget, denomination):
+def get_leftover_of_bills(amount, denomination):
     """
 
-    :param budget: float - the amount of money you are planning to exchange.
+    :param amount: float - the total starting value.
     :param denomination: int - the value of a single bill.
-    :return: float - the leftover amount that cannot be exchanged given the current denomination.
+    :return: float - the amount that is "leftover", given the current denomination.
     """
 
     pass


### PR DESCRIPTION
The exchange booth in this exercise only deals in
cash of specific increments. That is to say, you can bring any combination of bills and coins to exchange, but you get a collection of bills of a single denomination in the target currency in return.

The explanation was quite clear on this, but the parameter names and docstrings in the methods dealing with this part of the task used the term 'budget', which could lead readers to assume that the bills had to do with the original currency.

This reworks the methods related to bills to be more generic, not referring to the exchange process at all, hopefully avoiding this misinterpretation.

See forum thread here for details of the discussion leading to this change:

https://forum.exercism.org/t/currency-exchange-exercise-suggested-naming-tweaks/7790