### PR TITLE
Change Thai in string methods concept and exercise

### DIFF
--- a/concepts/string-methods/about.md
+++ b/concepts/string-methods/about.md
@@ -41,13 +41,13 @@ There may also be [locale][locale] rules in place for a language or character se
 
 
 ```python
->>> man_in_hat_th = 'ู้ชายในหมวก'
+>>> man_in_hat_th = 'ผู้ชายใส่หมวก'
 >>> man_in_hat_ru = 'mужчина в шляпе'
 >>> man_in_hat_ko = '모자를 쓴 남자'
 >>> man_in_hat_en = 'the man in the hat.'
 
 >>> man_in_hat_th.title()
-'ผู้ชายในหมวก'
+'ผู้ชายใส่หมวก'
 
 >>> man_in_hat_ru.title()
 'Мужчина В Шляпе'

--- a/exercises/concept/little-sisters-essay/.docs/introduction.md
+++ b/exercises/concept/little-sisters-essay/.docs/introduction.md
@@ -21,13 +21,13 @@ There may also be [locale][locale] rules in place for a language or character se
 
 
 ```python
-man_in_hat_th = 'ู้ชายในหมวก'
+man_in_hat_th = 'ผู้ชายใส่หมวก'
 man_in_hat_ru = 'mужчина в шляпе'
 man_in_hat_ko = '모자를 쓴 남자'
 man_in_hat_en = 'the man in the hat.'
 
 >>> man_in_hat_th.title()
-'ผู้ชายในหมวก'
+'ผู้ชายใส่หมวก'
 
 >>> man_in_hat_ru.title()
 'Мужчина В Шляпе'


### PR DESCRIPTION
The Little Sister's Essay concept and associated concept gives some example sentences using the phrase 'the man in the hat'. In English this is an idiomatic phrase that means the man who is wearing the hat, but could technically also translate to the man who is inside the hat.

The Thai phrase ผู้ชายในหมวก translates the second meaning. I've replaced this with a phrase that better matches the intended meaning.

This change was discussed in the following forum thread: https://forum.exercism.org/t/the-man-inside-the-hat-little-sisters-essay/7828/2