### PR TITLE
[Black Jack]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/concepts/comparisons/about.md
+++ b/concepts/comparisons/about.md
@@ -29,7 +29,7 @@ Numeric types are (mostly) an exception to this type matching rule.
 An `integer` **can** be considered equal to a `float` (_or an [`octal`][octal] equal to a [`hexadecimal`][hex]_), as long as the types can be implicitly converted for comparison.
 
 For the other numeric types ([complex][complex numbers], [decimal][decimal numbers], [fractions][rational numbers]), comparison operators are defined where they "make sense" (_where implicit conversion does not change the outcome_), but throw a `TypeError` if the underlying objects cannot be accurately converted for comparison.
-For more information on the rules that python uses for numeric conversion, see [arithmetic conversions][arithmetic conversions] in the Python documentation.
+For more information on the rules that Python uses for numeric conversion, see [arithmetic conversions][arithmetic conversions] in the Python documentation.
 
 ```python
 >>> import fractions
@@ -47,7 +47,8 @@ True
 >>> 6/3 == 0b10
 True
 
-# An int can be converted to a complex number with a 0 imaginary part.
+# An int can be converted to a complex 
+# number with a 0 imaginary part.
 >>> 17 == complex(17)
 True
 
@@ -60,8 +61,8 @@ True
 ```
 
 Any ordered comparison of a number to a `NaN` (_not a number_) type is `False`.
-A confusing side-effect of Python's `NaN` definition is that `NaN` never compares equal to `NaN`.
-If you are curious as to why `Nan` was defined this way in Python, this [Stack Overflow Post on NaN][so nan post] around the setting of the international standard is an interesting read.
+A confusing side effect of Python's `NaN` definition is that `NaN` never compares equal to `NaN`.
+If you are curious as to why `NaN` was defined this way in Python, this [Stack Overflow Post on NaN][so nan post] around the setting of the international standard is an interesting read.
 
 ```python
 >>> x = float('NaN')
@@ -188,7 +189,7 @@ See the Python reference docs on [value comparisons][value comparisons none] and
 >>> my_fav_numbers is your_fav_numbers
 True
 
-# The returned id will differ by system and python version.
+# The returned id will differ by system and Python version.
 >>> id(my_fav_numbers)
 4517478208
 

--- a/concepts/comparisons/links.json
+++ b/concepts/comparisons/links.json
@@ -1,27 +1,19 @@
 [
   {
-    "url": "https://docs.python.org/3/reference/expressions.html#comparisons",
-    "description": "Comparisons in Python (Python language reference)"
-  },
-  {
     "url": "https://www.tutorialspoint.com/python/python_basic_operators.htm",
     "description": "Python basic operators on Tutorials Point"
   },
   {
-    "url": "https://data-flair.training/blogs/python-comparison-operators/",
-    "description": "Python comparison operators on Data Flair"
-  },
-  {
-    "url": "https://www.python.org/dev/peps/pep-0207/",
-    "description": "PEP 207 to allow Operator Overloading for Comparison"
+    "url": "https://docs.python.org/3/reference/expressions.html#comparisons",
+    "description": "Comparisons in Python (Python language reference)"
   },
   {
     "url": "https://docs.python.org/3/reference/expressions.html#is-not",
     "description": "Identity comparisons in Python (Python language reference)"
   },
   {
-    "url": "https://docs.python.org/3/library/operator.html",
-    "description": "Operators (Python Docs)"
+    "url": "https://docs.python.org/3/reference/expressions.html#value-comparisons",
+    "description": "Value comparisons in Python (Python language reference)"
   },
   {
     "url": "https://docs.python.org/3/library/stdtypes.html#typesnumeric",
@@ -44,11 +36,11 @@
     "description": "Python Object Model (Python docs)"
   },
   {
-    "url": "https://docs.python.org/3/reference/datamodel.html#customization",
-    "description": "Basic Customization (Python language reference)"
+    "url": "https://www.python.org/dev/peps/pep-0207/",
+    "description": "PEP 207 to allow Operator Overloading for Comparison"
   },
   {
-    "url": "https://docs.python.org/3/reference/expressions.html#value-comparisons",
-    "description": "Value comparisons in Python (Python language reference)"
+    "url": "https://docs.python.org/3/reference/datamodel.html#customization",
+    "description": "Basic Customization (Python language reference)"
   }
 ]

--- a/exercises/concept/black-jack/.docs/introduction.md
+++ b/exercises/concept/black-jack/.docs/introduction.md
@@ -59,7 +59,7 @@ True
 ```
 
 Any ordered comparison of a number to a `NaN` (_not a number_) type is `False`.
-A confusing side-effect of Python's `NaN` definition is that `NaN` never compares equal to `NaN`.
+A confusing side effect of Python's `NaN` definition is that `NaN` never compares equal to `NaN`.
 
 ```python
 >>> x = float('NaN')
@@ -186,7 +186,6 @@ The operators `in` and `not in` test for _membership_.
 For string and bytes types, `<name> in <fullname>` is `True` _**if and only if**_ `<name>` is a substring of `<fullname>`.
 
 ```python
->>> 
 # A set of lucky numbers.
 >>> lucky_numbers = {11, 22, 33}
 >>> 22 in lucky_numbers
@@ -196,7 +195,9 @@ True
 False
 
 # A dictionary of employee information.
->>> employee = {'name': 'John Doe', 'id': 67826, 'age': 33, 'title': 'ceo'}
+>>> employee = {'name': 'John Doe', 
+                'id': 67826, 'age': 33, 
+                'title': 'ceo'}
 
 # Checking for the membership of certain keys.
 >>> 'age' in employee

--- a/exercises/concept/black-jack/black_jack_test.py
+++ b/exercises/concept/black-jack/black_jack_test.py
@@ -15,84 +15,100 @@ class BlackJackTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_value_of_card(self):
-        data = [
-                ('2', 2), ('5', 5), ('8', 8),
-                ('A', 1), ('10', 10), ('J', 10),
-                ('Q', 10), ('K', 10)]
+        test_data = [('2', 2), ('5', 5), ('8', 8),
+                     ('A', 1), ('10', 10), ('J', 10),
+                     ('Q', 10), ('K', 10)]
 
-        for variant, (card, value) in enumerate(data, 1):
-            with self.subTest(f'variation #{variant}', input=card, output=value):
-                error_msg = f'Expected {value} as the value of {card}.'
+        for variant, (card, expected) in enumerate(test_data, 1):
+            with self.subTest(f'variation #{variant}', card=card, expected=expected):
+                actual_result = value_of_card(card)
+                error_msg = (f'Called value_of_card({card}). '
+                             f'The function returned {actual_result} as the value of the {card} card, '
+                             f'but the test expected {expected} as the {card} card value.')
 
-                self.assertEqual(value_of_card(card), value, msg=error_msg)
+                self.assertEqual(actual_result, expected, msg=error_msg)
+
 
     @pytest.mark.task(taskno=2)
     def test_higher_card(self):
-        data = [
-                ('A', 'A', ('A', 'A')),
-                ('10', 'J', ('10', 'J')),
-                ('3', 'A', '3'),
-                ('3', '6', '6'),
-                ('Q', '10', ('Q', '10')),
-                ('4', '4', ('4', '4')),
-                ('9',  '10', '10'),
-                ('6', '9', '9'),
-                ('4', '8', '8')]
+        test_data = [('A', 'A', ('A', 'A')),
+                     ('10', 'J', ('10', 'J')),
+                     ('3', 'A', '3'),
+                     ('3', '6', '6'),
+                     ('Q', '10', ('Q', '10')),
+                     ('4', '4', ('4', '4')),
+                     ('9',  '10', '10'),
+                     ('6', '9', '9'),
+                     ('4', '8', '8')]
 
-        for variant, (card_one, card_two, result) in enumerate(data, 1):
-            with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, output=result):
-                error_msg = f'Expected {result} as the higher value of the cards {card_one, card_two}.'
+        for variant, (card_one, card_two, expected) in enumerate(test_data, 1):
+            with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, expected=expected):
+                actual_result = higher_card(card_one, card_two)
+                error_msg = (f'Called higher_card({card_one}, {card_two}). '
+                             f'The function returned {actual_result}, '
+                             f'but the test expected {expected} as the result for the cards {card_one, card_two}.')
 
-                self.assertEqual(higher_card(card_one, card_two), result, msg=error_msg)
+                self.assertEqual(actual_result, expected, msg=error_msg)
 
     @pytest.mark.task(taskno=3)
     def test_value_of_ace(self):
-        data = [
-                ('2', '3', 11), ('3', '6', 11), ('5', '2', 11),
-                ('8', '2', 11), ('5', '5', 11), ('Q', 'A', 1),
-                ('10', '2', 1), ('7', '8', 1), ('J', '9', 1),
-                ('K', 'K', 1), ('2', 'A', 1), ('A', '2', 1)]
+        test_data = [('2', '3', 11), ('3', '6', 11), ('5', '2', 11),
+                     ('8', '2', 11), ('5', '5', 11), ('Q', 'A', 1),
+                     ('10', '2', 1), ('7', '8', 1), ('J', '9', 1),
+                     ('K', 'K', 1), ('2', 'A', 1), ('A', '2', 1)]
 
-        for variant, (card_one, card_two, ace_value) in enumerate(data, 1):
+        for variant, (card_one, card_two, ace_value) in enumerate(test_data, 1):
             with self.subTest(f'variation #{variant}', card_one=card_one, card_two=card_two, ace_value=ace_value):
-                error_msg = f'Expected {ace_value} as the value of an ace card when the hand has {card_one, card_two}.'
+                actual_result = value_of_ace(card_one, card_two)
+                error_msg = (f'Called value_of_ace({card_one}, {card_two}). '
+                             f'The function returned {actual_result}, '
+                             f'but the test expected {ace_value} as the value of an ace card '
+                             f'when the hand includes {card_one, card_two}.')
 
                 self.assertEqual(value_of_ace(card_one, card_two), ace_value, msg=error_msg)
 
     @pytest.mark.task(taskno=4)
     def test_is_blackjack(self):
-        data = [
-                (('A', 'K'), True), (('10', 'A'), True),
-                (('10', '9'), False), (('A', 'A'), False),
-                (('4', '7'), False), (('9', '2'), False),
-                (('Q', 'K'), False)]
+        test_data = [(('A', 'K'), True), (('10', 'A'), True),
+                     (('10', '9'), False), (('A', 'A'), False),
+                     (('4', '7'), False), (('9', '2'), False),
+                     (('Q', 'K'), False)]
 
-        for variant, (hand, blackjack) in enumerate(data, 1):
-            with self.subTest(f'variation #{variant}', input=hand, output=blackjack):
-                error_msg = f'Hand {hand} {"is" if blackjack else "is not"} a blackjack.'
+        for variant, (hand, expected) in enumerate(test_data, 1):
+            with self.subTest(f'variation #{variant}', hand=hand, expected=expected):
+                actual_result = is_blackjack(*hand)
+                error_msg = (f'Called is_blackjack({hand[0]}, {hand[1]}). '
+                             f'The function returned {actual_result}, '             
+                             f'but hand {hand} {"is" if expected else "is not"} a blackjack.')
 
-                self.assertEqual(is_blackjack(*hand), blackjack, msg=error_msg)
+                self.assertEqual(actual_result, expected, msg=error_msg)
 
     @pytest.mark.task(taskno=5)
     def test_can_split_pairs(self):
-        data = [
-                (('Q', 'K'), True), (('6', '6'), True), (('A', 'A'), True),
-                (('10', 'A'), False), (('10', '9'), False)]
+        test_data = [(('Q', 'K'), True), (('6', '6'), True),
+                     (('A', 'A'), True),(('10', 'A'), False),
+                     (('10', '9'), False)]
 
-        for variant, (hand, split_pairs) in enumerate(data, 1):
-            with self.subTest(f'variation #{variant}', input=hand, output=split_pairs):
-                error_msg = f'Hand {hand} {"can" if split_pairs else "cannot"} be split into pairs.'
+        for variant, (hand, expected) in enumerate(test_data, 1):
+            with self.subTest(f'variation #{variant}', input=hand, expected=expected):
+                actual_result = can_split_pairs(*hand)
+                error_msg = (f'Called can_split_pairs({hand[0]}, {hand[1]}). '
+                             f'The function returned {actual_result}, '
+                             f'but hand {hand} {"can" if expected else "cannot"} be split into pairs.')
 
-                self.assertEqual(can_split_pairs(*hand), split_pairs, msg=error_msg)
+                self.assertEqual(actual_result, expected, msg=error_msg)
 
     @pytest.mark.task(taskno=6)
     def test_can_double_down(self):
-        data = [
-                (('A', '9'), True), (('K', 'A'), True), (('4', '5'), True),
-                (('A', 'A'), False), (('10', '2'), False), (('10', '9'), False)]
+        test_data = [(('A', '9'), True), (('K', 'A'), True),
+                     (('4', '5'), True),(('A', 'A'), False),
+                     (('10', '2'), False), (('10', '9'), False)]
 
-        for variant, (hand, double_down) in enumerate(data, 1):
-            with self.subTest(f'variation #{variant}', input=hand, output=double_down):
-                error_msg = f'Hand {hand} {"can" if double_down else "cannot"} be doubled down.'
+        for variant, (hand, expected) in enumerate(test_data, 1):
+            with self.subTest(f'variation #{variant}', hand=hand, expected=expected):
+                actual_result = can_double_down(*hand)
+                error_msg = (f'Called can_double_down({hand[0]}, {hand[1]}). '
+                             f'The function returned {actual_result}, '
+                             f'but hand {hand} {"can" if expected else "cannot"} be doubled down.')
 
-                self.assertEqual(can_double_down(*hand), double_down, msg=error_msg)
+                self.assertEqual(actual_result, expected, msg=error_msg)


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes. 