### PR TITLE
Change 'amount' to 'number' for countables

### DIFF
--- a/concepts/function-arguments/about.md
+++ b/concepts/function-arguments/about.md
@@ -182,7 +182,7 @@ For instance, `*` is used for multiplication, it is used for unpacking, and it i
 Since a tuple can be iterated, `args` can be passed to any other function which takes an iterable.
 Although `*args` is commonly juxtaposed with `**kwargs`, it doesn't have to be.
 
-Following is an example of an arbitrary amount of values being passed to a function:
+Following is an example of an arbitrary number of values being passed to a function:
 
 ```python
 
@@ -196,7 +196,7 @@ Following is an example of an arbitrary amount of values being passed to a funct
 
 If `*args` follows one or more positional arguments, then `*args` will be what is left over after the positional arguments.
 
-Following is an example of an arbitrary amount of values being passed to a function after a positional argument:
+Following is an example of an arbitrary number of values being passed to a function after a positional argument:
 
 ```python
 
@@ -210,7 +210,7 @@ Following is an example of an arbitrary amount of values being passed to a funct
 
 If one or more default arguments are defined after `*args` they are separate from the `*args` values.
 
-To put it all together is an example of an arbitrary amount of values being passed to a function that also has a positional argument and a default argument:
+To put it all together is an example of an arbitrary number of values being passed to a function that also has a positional argument and a default argument:
 
 ```python
 
@@ -228,7 +228,7 @@ To put it all together is an example of an arbitrary amount of values being pass
 
 ```
 
-Note that when an argument is already in an iterable, such as a tuple or list, it needs to be unpacked before being passed to a function that takes an arbitrary amount of separate arguments.
+Note that when an argument is already in an iterable, such as a tuple or list, it needs to be unpacked before being passed to a function that takes an arbitrary number of separate arguments.
 This is accomplished by using `*`, which is the [unpacking operator][unpacking operator].
 
 `*` in this context _unpacks_ the container into its separate elements which are then transformed by `*args` into a tuple.
@@ -257,7 +257,7 @@ The `**` transforms the group of named arguments into a [`dictionary`][dictionar
 Since a dictionary can be iterated, `kwargs` can be passed to any other function which takes an iterable.
 Although `**kwargs` is commonly juxtaposed with `*args`, it doesn't have to be.
 
-Following is an example of an arbitrary amount of key-value pairs being passed to a function:
+Following is an example of an arbitrary number of key-value pairs being passed to a function:
 
 ```python
 >>> def add(**kwargs):
@@ -271,7 +271,7 @@ Note that the `dict.values()` method is called to iterate through the `kwargs` d
 
 When iterating a dictionary the default is to iterate the keys.
 
-Following is an example of an arbitrary amount of key-value pairs being passed to a function that then iterates over `kwargs.keys()`:
+Following is an example of an arbitrary number of key-value pairs being passed to a function that then iterates over `kwargs.keys()`:
 
 ```python
 >>> def concat(**kwargs):

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -177,7 +177,7 @@ This means calculations within `()` have the highest priority, followed by `**`,
 
 ## Precision & Representation
 
-Integers in Python have [arbitrary precision][arbitrary-precision] -- the amount of digits is limited only by the available memory of the host system.
+Integers in Python have [arbitrary precision][arbitrary-precision] -- the number of digits is limited only by the available memory of the host system.
 
 Floating point numbers are usually implemented using a `double` in C (_15 decimal places of precision_), but will vary in representation based on the host system.
 Complex numbers have a `real` and an `imaginary` part, both of which are represented by floating point numbers.

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -6,7 +6,7 @@ Recursion can be viewed as another way to loop/iterate.
 And like looping, a Boolean expression or `True/False` test is used to know when to stop the recursive execution.
 _Unlike_ looping, recursion without termination in Python cannot not run infinitely.
 Values used in each function call are placed in their own frame on the Python interpreter stack.
-If the total amount of function calls takes up more space than the stack has room for, it will result in an error.
+If the total number of function calls takes up more space than the stack has room for, it will result in an error.
 
 ## Looping vs Recursive Implementation
 

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -5,7 +5,7 @@ It can be viewed as another way to loop/iterate.
 Like looping, a Boolean expression or `True/False` test is used to know when to stop the recursive execution.
 _Unlike_ looping, recursion without termination in Python cannot not run infinitely.
 Values used in each function call are placed in their own frame on the Python interpreter stack.
-If the total amount of function calls takes up more space than the stack has room for, it will result in an error.
+If the total number of function calls takes up more space than the stack has room for, it will result in an error.
 
 ```python
 def print_increment(step, max_value):

--- a/exercises/concept/electric-bill/.docs/introduction.md
+++ b/exercises/concept/electric-bill/.docs/introduction.md
@@ -150,7 +150,7 @@ This means calculations within `()` have the highest priority, followed by `**`,
 
 ## Precision & Representation
 
-Integers in Python have [arbitrary precision][arbitrary-precision] -- the amount of digits is limited only by the available memory of the host system.
+Integers in Python have [arbitrary precision][arbitrary-precision] -- the number of digits is limited only by the available memory of the host system.
 
 Floating point numbers are usually implemented using a `double` in C (_15 decimal places of precision_), but will vary in representation based on the host system.
 Complex numbers have a `real` and an `imaginary` part, both of which are represented by floating point numbers.

--- a/exercises/concept/electric-bill/.meta/exemplar.py
+++ b/exercises/concept/electric-bill/.meta/exemplar.py
@@ -2,10 +2,10 @@
 
 
 def get_extra_hours(hours):
-    """Return the amount of hours.
+    """Return the number of hours.
 
-    :param: hours: int - amount of hours.
-    :return: int - amount of "extra" hours.
+    :param: hours: int - number of hours.
+    :return: int - number of "extra" hours.
     """
 
     return (hours + 3) % 24

--- a/exercises/concept/electric-bill/electric_bill.py
+++ b/exercises/concept/electric-bill/electric_bill.py
@@ -2,10 +2,10 @@
 
 
 def get_extra_hours(hours):
-    """Return the amount of hours.
+    """Return the number of hours.
 
-    :param: hours: int - amount of hours.
-    :return: int - amount of "extra" hours.
+    :param: hours: int - number of hours.
+    :return: int - number of "extra" hours.
     """
     pass
 

--- a/exercises/concept/ellens-alien-game/.meta/exemplar.py
+++ b/exercises/concept/ellens-alien-game/.meta/exemplar.py
@@ -9,7 +9,7 @@ class Alien:
     (class)total_aliens_created: int
     x_coordinate: int - Position on the x-axis.
     y_coordinate: int - Position on the y-axis.
-    health: int - Amount of health points.
+    health: int - Number of health points.
 
     Methods
     -------

--- a/exercises/concept/ellens-alien-game/classes.py
+++ b/exercises/concept/ellens-alien-game/classes.py
@@ -9,7 +9,7 @@ class Alien:
     (class)total_aliens_created: int
     x_coordinate: int - Position on the x-axis.
     y_coordinate: int - Position on the y-axis.
-    health: int - Amount of health points.
+    health: int - Number of health points.
 
     Methods
     -------

--- a/exercises/concept/locomotive-engineer/.docs/hints.md
+++ b/exercises/concept/locomotive-engineer/.docs/hints.md
@@ -16,7 +16,7 @@
 
 ## 3. Add missing stops
 
-- Using `**kwargs` as a function parameter will allow an arbitrary amount of keyword arguments to be passed.
+- Using `**kwargs` as a function parameter will allow an arbitrary number of keyword arguments to be passed.
 - Using `**<dict>` as an argument will unpack a dictionary into keyword arguments.
 - You can put keyword arguments in a `{}` or `dict()`.
 - To get the values out of a dictionary, you can use the `<dict>.values()` method.

--- a/exercises/concept/locomotive-engineer/.docs/instructions.md
+++ b/exercises/concept/locomotive-engineer/.docs/instructions.md
@@ -48,7 +48,7 @@ The function should then `return` a `list` with the modifications.
 
 Now that all the wagon data is correct, Linus would like you to update the system's routing information.
 Along a transport route, a train might make stops at a few different stations to pick up and/or drop off cargo.
-Each journey could have a different amount of these intermediary delivery points.
+Each journey could have a different number of these intermediary delivery points.
 Your friend would like you to update the systems routing `dict` with any missing/additional delivery information.
 
 Implement a function `add_missing_stops()` that accepts a routing `dict` followed by a variable number of keyword arguments.

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -36,7 +36,7 @@ For `total` we want all of the 64 bits set to `1` to get the sum of grains on al
 The easy way to do this is to set the 65th bit to `1` and then subtract `1`.
 To go back to our two-square example, if we can grow to three squares, then we can shift `1` two positions to the left for binary `100`,
 which is decimal `4`.
-By subtracting `1` we get `3`, which is the total amount of grains on the two squares.
+By subtracting `1` we get `3`, which is the total number of grains on the two squares.
 
 | Square  | Binary Value | Decimal Value |
 | ------- | ------------ | ------------- |

--- a/exercises/practice/grains/.approaches/introduction.md
+++ b/exercises/practice/grains/.approaches/introduction.md
@@ -7,8 +7,8 @@ Another approach is to use [`pow`][pow].
 
 ## General guidance
 
-The key to solving Grains is to focus on each square having double the amount of grains as the square before it.
-This means that the amount of grains grows exponentially.
+The key to solving Grains is to focus on each square having double the number of grains as the square before it.
+This means that the number of grains grows exponentially.
 The first square has one grain, which is `2` to the power of `0`.
 The second square has two grains, which is `2` to the power of `1`.
 The third square has four grains, which is `2` to the power of `2`.

--- a/exercises/practice/robot-name/.approaches/mass-name-generation/content.md
+++ b/exercises/practice/robot-name/.approaches/mass-name-generation/content.md
@@ -42,7 +42,7 @@ However, this has a huge startup memory and time cost, as 676,000 strings have t
 For an approximate calculation, 676,000 strings * 5 characters / string * 1 byte / character gives 3380000 bytes or 3.38 MB of RAM - and that's just the memory aspect of it.
 Sounds small, but it's relatively very expensive at the beginning.
 
-Thus, this approach is inefficient in cases where only a small amount of names are needed _and_ the time to set/reset the robot isn't crucial.
+Thus, this approach is inefficient in cases where only a small number of names are needed _and_ the time to set/reset the robot isn't crucial.
 
 [random-seed]: https://docs.python.org/3/library/random.html#random.seed
 [iter-and-next]: https://www.programiz.com/python-programming/methods/built-in/iter


### PR DESCRIPTION
This is a follow-up to https://github.com/exercism/python/pull/3517

I've been meaning to do this for a while, and finally found the time to sit down and meticulously check all the occurrences of "[Aa]mount of" in the repository.

I've fixed the following occurrences:
- number of values
- number of digits
- number of function calls
- number of hours
- number of health points
- number of (intermediate) delivery points
- number of keyword arguments
- number of grains
- number of names

I have also verified that the following are correct:
- amount of reputation
- amount of work
- amount of functionality
- amount of memory
- amount of money
- amount of domestic currency
- amount of tree climbing
- amount of energy

There are also two things that we need to figure out:

**Currency Exchange concept exercise**
https://github.com/exercism/python/blob/358e406e5a7a3c6b37fabda9bd2a867d0200dd4a/exercises/concept/currency-exchange/.docs/hints.md?plain=1#L13

This says `get the amount of changes` -- do we mean "number of changes" or "amount of change"? I _think_ it should be amount of change, but I'd like a second opinion. If so, it might belong in a separate PR since it's a completely different problem.

**Plane Tickets concept exercise**
This is a WIP exercise, so it might not matter yet, but the exercise talks about _amount of seats_, and it should be _number of seats_.