### PR TITLE
Fix grammar in currency-exchange hint

### DIFF
--- a/exercises/concept/currency-exchange/.docs/hints.md
+++ b/exercises/concept/currency-exchange/.docs/hints.md
@@ -10,7 +10,7 @@
 
 ## 2. Calculate currency left after an exchange
 
-- You can use the [subtraction operator][subtraction-operator] to get the amount of changes.
+- You can use the [subtraction operator][subtraction-operator] to get the amount of change.
 
 ## 3. Calculate value of bills
 


### PR DESCRIPTION
This is a tiny thing, and it probably wouldn't confuse people who are
actually doing the exercise.

I came across it because I was doing a full audit of instances where
we say 'amount of ...' since there were several instances where it
should have been 'number of ...'.

At first I thought this was supposed to be 'number of changes', but
then in the context of the exercise it turns out that it was a
different problem entirely :)
