### PR TITLE
[Plane Tickets]: Update `generators_test.py` to Correct L47 Test Error Message

### DIFF
--- a/exercises/concept/plane-tickets/generators_test.py
+++ b/exercises/concept/plane-tickets/generators_test.py
@@ -44,7 +44,7 @@ class PlaneTicketsTest(unittest.TestCase):
         """Test if generate_seats() returns a generator type."""
 
         number = 7
-        error_message = (f'Called generate_seat_letters({number}). '
+        error_message = (f'Called generate_seats({number}). '
                          f'The function returned a {type(generate_seats(number))} type, '
                          f"but the tests expected the function to return a <class 'generator'> type.")
 


### PR DESCRIPTION
Bad typo.  [forum post](https://forum.exercism.org/t/wrong-error-message-in-plane-tickets-python-track-exercise/7984)