### PR TITLE
[Chaitanas Colossal Coaster]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/.docs/hints.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/hints.md
@@ -1,11 +1,13 @@
 # General
 
-Make sure you have a good understanding of how to create and update lists.
+- Make sure you have a good understanding of how to create and update lists.
+- The Python [documentation on `lists`][python lists] can be really helpful.
+- The Python [tutorial section on `lists`][more on lists] is also a good resource.
 
 ## 1. Add Me to the queue
 
-- You need to find the ticket type with an `if-else` statement.
-- You can `append()` the person to the queue based on the ticket type.
+- An `if-else` statement can help you find which ticket type you are dealing with.
+- You can then `append()` the person to the queue based on the ticket type.
 
 ## 2. Where are my friends
 
@@ -29,7 +31,9 @@ Make sure you have a good understanding of how to create and update lists.
 
 ## 7. Sort the Queue List
 
-- Don't forget that You need to make a `copy()` of the queue to avoid mutating it and losing the original order.
+- Don't forget that You need to avoid mutating the queue and losing its original order.
 - Once you have a `copy()`, `sort()`-ing should be straightforward.
-- Order is alphabetical or _ascending_ sort.
+- We're looking for an _ascending_ sort, or _alphabetical from a-z_.
 
+[python lists]: https://docs.python.org/3.11/library/stdtypes.html#list
+[more on lists]: https://docs.python.org/3.11/tutorial/datastructures.html#more-on-lists

--- a/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
+++ b/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
@@ -4,6 +4,7 @@
     "BethanyG"
   ],
   "contributors": [
+    "BethanyG",
     "valentin-p",
     "pranasziaukas"
   ],

--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -1,5 +1,6 @@
 import unittest
 import pytest
+from copy import deepcopy
 
 from list_methods import (
     add_me_to_the_queue,
@@ -15,107 +16,146 @@ from list_methods import (
 class ListMethodsTest(unittest.TestCase):
     @pytest.mark.task(taskno=1)
     def test_add_me_to_the_queue(self):
-        data = [
-            ((['Tony', 'Bruce'], ['RobotGuy', 'WW'], 0, 'HawkEye'), ['RobotGuy', 'WW', 'HawkEye']),
-            ((['Tony', 'Bruce'], ['RobotGuy', 'WW'], 1, 'RichieRich'), ['Tony', 'Bruce', 'RichieRich']),
-        ]
+        test_data = [(['Tony', 'Bruce'], ['RobotGuy', 'WW'], 0, 'HawkEye'),
+                     (['Tony', 'Bruce'], ['RobotGuy', 'WW'], 1, 'RichieRich')]
+        result_data = [['RobotGuy', 'WW', 'HawkEye'],
+                       ['Tony', 'Bruce', 'RichieRich']]
 
-        error_message = 'The person was not added to the queue correctly.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertListEqual(add_me_to_the_queue(*params), result, msg=error_message)
+        for variant, (params, expected) in enumerate(zip(test_data, result_data), start=1):
+
+            # Deepcopy() is needed here because the task expects the input lists to be mutated.
+            # That mutation wrecks havoc with the verification and error messaging.
+            express_queue, normal_queue, ticket_type, person_name = deepcopy(params)
+
+            with self.subTest(f'variation #{variant}',
+                              express_queue=express_queue,
+                              normal_queue=normal_queue,
+                              ticket_type=ticket_type,
+                              person_name=person_name,
+                              expected=expected):
+
+                actual_result = add_me_to_the_queue(*params)
+                error_message = (f'Called add_me_to_the_queue{express_queue, normal_queue, ticket_type, person_name}. '
+                                 f'The function returned {actual_result}, but '
+                                 f'The tests expected {expected} when adding '
+                                 f'{person_name} to the queue.')
+
+                self.assertListEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_find_my_friend(self):
-        data = [
-            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Natasha'), 0),
-            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Steve'), 1),
-            ((['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Rocket'), 4),
-        ]
+        test_data = [(['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Natasha'),
+                     (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Steve'),
+                     (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 'Rocket')]
+        result_data = (0,1,4)
 
-        error_message = 'The index of the friend to find is incorrect.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertIs(find_my_friend(*params), result, msg=error_message)
+        for variant, (params, expected) in enumerate(zip(test_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', params=params, expected=expected):
+                actual_result = find_my_friend(*params)
+                error_message = (f'Called find_my_friend{params}. '
+                                 f'The function returned {actual_result}, but '
+                                 f'The tests expected {expected} when looking for '
+                                 f'{params[-1]} in the queue.')
+
+                self.assertIs(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_add_me_with_my_friends(self):
-        data = [
-            (
-                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 0, 'Bucky'),
-                ['Bucky', 'Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket']
-            ),
-            (
+        test_data = [(['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 0, 'Bucky'),
                 (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 1, 'Bucky'),
-                ['Natasha', 'Bucky', 'Steve', 'Tchalla', 'Wanda', 'Rocket']
-            ),
-            (
-                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 5, 'Bucky'),
-                ['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket', 'Bucky']
-            ),
-        ]
+                (['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'], 5, 'Bucky')]
 
-        error_message = 'The person was added to the wrong location in the queue or was not added at all.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertListEqual(add_me_with_my_friends(*params), result, error_message)
+        result_data = [['Bucky', 'Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket'],
+                       ['Natasha', 'Bucky', 'Steve', 'Tchalla', 'Wanda', 'Rocket'],
+                       ['Natasha', 'Steve', 'Tchalla', 'Wanda', 'Rocket', 'Bucky']]
+
+        for variant, (params, expected) in enumerate(zip(test_data, result_data), start=1):
+
+            # Deepcopy() is needed here because the task expects the input lists to be mutated.
+            # That mutation wrecks havoc with the verification and error messaging.
+            queue, index, person_name = deepcopy(params)
+
+            with self.subTest(f'variation #{variant}',
+                              queue=queue,
+                              index=index,
+                              person_name=person_name,
+                              expected=expected):
+
+                actual_result = add_me_with_my_friends(*params)
+                error_message = (f'Called add_me_with_my_friends{queue, index, person_name}. '
+                                 f'The function returned {actual_result}, but '
+                                 f'The tests expected {expected} when adding '
+                                 f'{person_name} to position {index} in the queue.')
+
+                self.assertListEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_remove_the_mean_person(self):
-        data = [
-            (
-                (['Natasha', 'Steve', 'Ultron', 'Wanda', 'Rocket'], 'Ultron'),
-                ['Natasha', 'Steve', 'Wanda', 'Rocket']
-            ),
-            (
-                (['Natasha', 'Steve', 'Wanda', 'Rocket', 'Ultron'], 'Ultron'),
-                ['Natasha', 'Steve', 'Wanda', 'Rocket']
-            ),
-            (
-                (['Ultron', 'Natasha', 'Steve', 'Wanda', 'Rocket'], 'Ultron'),
-                ['Natasha', 'Steve', 'Wanda', 'Rocket']
-            ),
-        ]
+        test_data = [(['Natasha', 'Steve', 'Ultron', 'Wanda', 'Rocket'], 'Ultron'),
+                     (['Natasha', 'Steve', 'Wanda', 'Rocket', 'Ultron'], 'Ultron'),
+                     (['Ultron', 'Natasha', 'Steve', 'Wanda', 'Rocket'], 'Ultron'),
 
-        error_message = 'The mean person was not removed properly.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertListEqual(remove_the_mean_person(*params), result, msg=error_message)
+        ]
+        result_data = [['Natasha', 'Steve', 'Wanda', 'Rocket'],
+                       ['Natasha', 'Steve', 'Wanda', 'Rocket'],
+                       ['Natasha', 'Steve', 'Wanda', 'Rocket']]
+
+        for variant, (params, expected) in enumerate(zip(test_data, result_data), start=1):
+
+            # Deepcopy() is needed here because the task expects the input lists to be mutated.
+            # That mutation wrecks havoc with the verification and error messaging.
+            queue, person_name = deepcopy(params)
+
+            with self.subTest(f'variation #{variant}',
+                              queue=queue,
+                              person_name=person_name,
+                              expected=expected):
+
+                actual_result = remove_the_mean_person(*params)
+                error_message = (f'Called remove_the_mean_person{queue, person_name}. '
+                                 f'The function returned {actual_result}, but '
+                                 f'The tests expected {expected} when removing '
+                                 f'{person_name} from the queue.')
+
+                self.assertListEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=5)
     def test_how_many_namefellows(self):
-        data = [
-            ((['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Bucky'), 0),
-            ((['Natasha', 'Steve', 'Ultron', 'Rocket'], 'Natasha'), 1),
-            ((['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Natasha'), 2),
-        ]
+        test_data = [(['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Bucky'),
+                     (['Natasha', 'Steve', 'Ultron', 'Rocket'], 'Natasha'),
+                     (['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Natasha')]
 
-        error_message = 'The namefellow count is incorrect.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertIs(how_many_namefellows(*params), result, msg=error_message)
+        result_data = (0,1,2)
+
+        for variant, (params, expected) in enumerate(zip(test_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', params=params, expected=expected):
+                actual_result = how_many_namefellows(*params)
+
+                error_message = (f'Called how_many_namefellows{params}. '
+                                 f'The function returned {actual_result}, but '
+                                 f'The tests expected {expected} when counting '
+                                 f'namefellows in the queue for {params[-1]}.')
+
+                self.assertIs(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=6)
     def test_remove_the_last_person(self):
-        data = [
-            (['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket'], 'Rocket'),
-        ]
+        test_data = ['Natasha', 'Steve', 'Ultron', 'Natasha', 'Rocket']
+        actual_result = remove_the_last_person(test_data)
+        expected = 'Rocket'
+        error_message = (f'Called remove_the_last_person({test_data}).'
+                         f'The function returned {actual_result}, but the tests '
+                         f'expected {expected} as the person who was removed.')
 
-        error_message = 'The last person was not removed properly.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertIs(remove_the_last_person(params), result, msg=error_message)
+        self.assertIs(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=7)
     def test_sorted_names(self):
-        data = [
-            (
-                ['Steve', 'Ultron', 'Natasha', 'Rocket'],
-                ['Natasha', 'Rocket', 'Steve', 'Ultron']
-            ),
-        ]
+        test_data = ['Steve', 'Ultron', 'Natasha', 'Rocket']
+        expected =  ['Natasha', 'Rocket', 'Steve', 'Ultron']
+        actual_result = sorted_names(test_data)
+        error_message = (f'Called sorted_names({test_data}).'
+                         f'The function returned {actual_result}, but the tests '
+                         f'expected {expected}.')
 
-        error_message = 'The queue was not properly sorted.'
-        for variant, (params, result) in enumerate(data, start=1):
-            with self.subTest(f'variation #{variant}', input=params, output=result):
-                self.assertListEqual(sorted_names(params), result, msg=error_message)
+        self.assertListEqual(actual_result, expected, msg=error_message)


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes.