### PR TITLE
[Little Sister's Essay]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/concepts/string-methods/.meta/config.json
+++ b/concepts/string-methods/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "The 'str' class provides many useful 'string-methods'. They can be used for cleaning, splitting, translating, or otherwise working with any 'str' object. Because strings are immutable, any functions or methods that operate on a 'str' will return a new instance or copy of the 'str' rather than modifying the original 'str' object.",
   "authors": ["kimolivia"],
-  "contributors": ["valentin-p", "bethanyg"]
+  "contributors": ["valentin-p", "BethanyG"]
 }

--- a/concepts/string-methods/about.md
+++ b/concepts/string-methods/about.md
@@ -18,6 +18,7 @@ Some of the more commonly used `str` methods include:
 
 Being _immutable_, a `str` object's value in memory cannot change; methods that appear to modify a string return a new copy or instance of that `str` object.
 
+
 [`<str>.endswith(<suffix>)`][str-endswith] returns `True` if the string ends with `<suffix>`, `False` otherwise.
 
 ```python

--- a/concepts/string-methods/links.json
+++ b/concepts/string-methods/links.json
@@ -1,18 +1,18 @@
 [
   {
     "url": "https://docs.python.org/3/library/stdtypes.html#string-methods",
-    "description": "string methods"
+    "description": "Python Documentation: string methods"
   },
   {
     "url": "https://docs.python.org/3/library/stdtypes.html#common-sequence-operations",
-    "description": "common sequence operations"
+    "description": "Python Documentation: common sequence operations"
   },
   {
     "url": "https://realpython.com/python-strings/",
-    "description": "strings and character data in Python"
+    "description": "Real Python: strings and character data in Python"
   },
   {
     "url": "https://www.programiz.com/python-programming/string",
-    "description": "more string operations and functions"
+    "description": "Programiz: more string operations and functions"
   }
 ]

--- a/exercises/concept/little-sisters-essay/.docs/hints.md
+++ b/exercises/concept/little-sisters-essay/.docs/hints.md
@@ -2,7 +2,8 @@
 
 ## General
 
-- [Introduction to string methods in Python][string-method-docs]
+- [Python Documentation: String Methods][string-method-docs]
+- [Python Documentation Tutorial: Text][tutorial-strings]
 
 ## 1. Capitalize the title of the paper
 
@@ -20,8 +21,9 @@
 
 - You can use [string methods][replace-method-docs] to replace words.
 
-[string-method-docs]: https://docs.python.org/3/library/stdtypes.html#string-methods
-[title-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.title
 [endswith-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.endswith
-[strip-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.strip
 [replace-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.replace
+[string-method-docs]: https://docs.python.org/3/library/stdtypes.html#string-methods
+[strip-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.strip
+[title-method-docs]: https://docs.python.org/3/library/stdtypes.html#str.title
+[tutorial-strings]: https://docs.python.org/3/tutorial/introduction.html#text

--- a/exercises/concept/little-sisters-essay/.meta/config.json
+++ b/exercises/concept/little-sisters-essay/.meta/config.json
@@ -4,7 +4,7 @@
   ],
   "contributors": [
     "valentin-p",
-    "bethanyg"
+    "BethanyG"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/little-sisters-essay/string_methods_test.py
+++ b/exercises/concept/little-sisters-essay/string_methods_test.py
@@ -10,37 +10,89 @@ class LittleSistersEssayTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_capitalize_word(self):
-        self.assertEqual(capitalize_title("canopy"), "Canopy")
+
+        actual_result = capitalize_title("canopy")
+        expected = "Canopy"
+        error_message = (f'Called capitalize_title("canopy"). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the title.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=1)
     def test_capitalize_title(self):
-        self.assertEqual(capitalize_title("fish are cold blooded"),
-                         "Fish Are Cold Blooded")
+
+        actual_result = capitalize_title("fish are cold blooded")
+        expected = "Fish Are Cold Blooded"
+        error_message = (f'Called capitalize_title("fish are cold blooded"). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the title.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_sentence_ending(self):
-        self.assertEqual(check_sentence_ending("Snails can sleep for 3 years."), True)
+
+        actual_result = check_sentence_ending("Snails can sleep for 3 years.")
+        expected = True
+        error_message = (f'Called check_sentence_ending("Snails can sleep for 3 years."). '
+                         f'The function returned {actual_result}, '
+                         f'but the tests expected {expected} for a period ending.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_sentence_ending_without_period(self):
-        self.assertEqual(check_sentence_ending("Fittonia are nice"), False)
+
+        actual_result = check_sentence_ending("Fittonia are nice")
+        expected = False
+        error_message = (f'Called check_sentence_ending("Fittonia are nice"). '
+                         f'The function returned {actual_result}, '
+                         f'but the tests expected {expected} for a period ending.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_remove_extra_spaces_only_start(self):
-        self.assertEqual(clean_up_spacing("  A rolling stone gathers no moss"),
-                         "A rolling stone gathers no moss")
+
+        actual_result = clean_up_spacing("  A rolling stone gathers no moss")
+        expected = "A rolling stone gathers no moss"
+        error_message = (f'Called clean_up_spacing("  A rolling stone gathers no moss"). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" as a cleaned string.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_remove_extra_spaces(self):
-        self.assertEqual(clean_up_spacing("  Elephants can't jump.  "),
-                         "Elephants can't jump.")
+
+        actual_result = clean_up_spacing("  Elephants can't jump.  ")
+        expected = "Elephants can't jump."
+        error_message = ("Called clean_up_spacing(\"  Elephants can't jump.  \")"
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" as a cleaned string.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_replace_word_choice(self):
-        self.assertEqual(replace_word_choice("Animals are cool.", "cool", "awesome"),
-                         "Animals are awesome.")
+
+        actual_result = replace_word_choice("Animals are cool.", "cool", "awesome")
+        expected = "Animals are awesome."
+        error_message = ('Called replace_word_choice("Animals are cool.", "cool", "awesome"). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" after the word replacement.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_replace_word_not_exist(self):
-        self.assertEqual(replace_word_choice("Animals are cool.", "small", "tiny"),
-                         "Animals are cool.")
+
+        actual_result = replace_word_choice("Animals are cool.", "small", "tiny")
+        expected = "Animals are cool."
+        error_message = ('Called replace_word_choice("Animals are cool.", "small", "tiny"). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}", because the word '
+                         'to be replaced is not in the sentence.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes.