### PR TITLE
[Little Sisters Vocab]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/exercises/concept/little-sisters-vocab/.docs/hints.md
+++ b/exercises/concept/little-sisters-vocab/.docs/hints.md
@@ -2,9 +2,9 @@
 
 ## General
 
-- The [Python Docs Tutorial for strings][python-str-doc] has an overview of the Python `str` type.
-- String methods [<str>.join()][str-join] and [<str>.split()][str-split] ar very helpful when processing strings.
-- The [Python Docs on Sequence Types][common sequence operations] has a rundown of operations common to all sequences, including `strings`, `lists`, `tuples`, and `ranges`.
+- The Python Docs [Tutorial for strings][python-str-doc] has an overview of the Python `str` type.
+- String methods [`str.join()`][str-join] and [`str.split()`][str-split] ar very helpful when processing strings.
+- The Python Docs on [Sequence Types][common sequence operations] has a rundown of operations common to all sequences, including `strings`, `lists`, `tuples`, and `ranges`.
 
 There's four activities in the assignment, each with a set of text or words to work with.
 
@@ -14,24 +14,24 @@ There's four activities in the assignment, each with a set of text or words to w
 
 ## 2. Add prefixes to word groups
 
-- Believe it or not, `<str>.join()` is all you need.
-- Like `<str>.split()`, `<str>.join()` can take an arbitrary-length string, made up of any unicode code points.
+- Believe it or not, [`str.join()`][str-join] is all you need here.
+- Like [`str.split()`][str-split]`, `str.join()` can take an arbitrary-length string, made up of any unicode code points.
 
 ## 3. Remove a suffix from a word
 
-- Strings can be both indexed and sliced from either the left (starting at 0) or the right (starting at -1).
+- Strings can be indexed or sliced from either the left (starting at 0) or the right (starting at -1).
 - If you want the last code point of an arbitrary-length string, you can use [-1].
 - The last three letters in a string can be "sliced off" using a negative index. e.g. 'beautiful'[:-3] == 'beauti'
 
 ## 4. Extract and transform a word
 
-- Using `<str>.split()` returns a list of strings broken on white space.
+- Using [`str.split()`][str-split] returns a `list` of strings broken on white space.
 - `lists` are sequences, and can be indexed.
-- `<str>.split()` can be direcly indexed. e.g. `'Exercism rocks!'.split()[0] == 'Exercism'`
+- [`str.split()`][str-split] can be directly indexed: `'Exercism rocks!'.split()[0] == 'Exercism'`
 - Be careful of punctuation! Periods can be removed via slice: `'dark.'[:-1] == 'dark'`
 
-[python-str-doc]: https://docs.python.org/3/tutorial/introduction.html#strings
 
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str
+[python-str-doc]: https://docs.python.org/3/tutorial/introduction.html#strings
 [str-join]: https://docs.python.org/3/library/stdtypes.html#str.join
 [str-split]: https://docs.python.org/3/library/stdtypes.html#str.split

--- a/exercises/concept/little-sisters-vocab/.docs/instructions.md
+++ b/exercises/concept/little-sisters-vocab/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-You are helping your younger sister with her English vocabulary homework, which she's finding very tedious.
+You are helping your younger sister with her English vocabulary homework, which she is finding very tedious.
  Her class is learning to create new words by adding _prefixes_ and _suffixes_.
  Given a set of words, the teacher is looking for correctly transformed words with correct spelling by adding the prefix to the beginning or the suffix to the ending.
 
@@ -12,7 +12,7 @@ There's four activities in the assignment, each with a set of text or words to w
 One of the most common prefixes in English is `un`, meaning "not".
  In this activity, your sister needs to make negative, or "not" words by adding `un` to them.
 
-Implement the `add_prefix_un()` function that takes `word` as a parameter and returns a new `un` prefixed word:
+Implement the `add_prefix_un(<word>)` function that takes `word` as a parameter and returns a new `un` prefixed word:
 
 
 ```python
@@ -63,7 +63,7 @@ Implement the `make_word_groups(<vocab_words>)` function that takes a `vocab_wor
   But of course there are pesky spelling rules: If the root word originally ended in a consonant followed by a 'y', then the 'y' was changed to 'i'.
  Removing 'ness' needs to restore the 'y' in those root words. e.g. `happiness` --> `happi` --> `happy`.
 
-Implement the `remove_suffix_ness(<word>)` function that takes in a word `str`, and returns the root word without the `ness` suffix.
+Implement the `remove_suffix_ness(<word>)` function that takes in a `word`, and returns the root word without the `ness` suffix.
 
 
 ```python
@@ -76,7 +76,7 @@ Implement the `remove_suffix_ness(<word>)` function that takes in a word `str`, 
 
 ## 4. Extract and transform a word
 
-Suffixes are often used to change the part of speech a word has.
+Suffixes are often used to change the part of speech a word is assigned to.
  A common practice in English is "verbing" or "verbifying" -- where an adjective _becomes_ a verb by adding an `en` suffix.
 
 In this task, your sister is going to practice "verbing" words by extracting an adjective from a sentence and turning it into a verb.

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -228,4 +228,3 @@ Strings support all [common sequence operations][common sequence operations].
 [str-split]: https://docs.python.org/3/library/stdtypes.html#str.split
 [text sequence]: https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str
 [unicode code points]: https://stackoverflow.com/questions/27331819/whats-the-difference-between-a-character-a-code-point-a-glyph-and-a-grapheme
-

--- a/exercises/concept/little-sisters-vocab/.meta/config.json
+++ b/exercises/concept/little-sisters-vocab/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "authors": [
     "aldraco",
-    "bethanyg"
+    "BethanyG"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/little-sisters-vocab/strings_test.py
+++ b/exercises/concept/little-sisters-vocab/strings_test.py
@@ -12,65 +12,93 @@ class LittleSistersVocabTest(unittest.TestCase):
     def test_add_prefix_un(self):
         input_data = ['happy', 'manageable', 'fold', 'eaten', 'avoidable', 'usual']
         result_data = [f'un{item}' for item in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, word, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', word=word, result=result):
-                self.assertEqual(add_prefix_un(word), result,
-                                 msg=f'Expected: {result} but got a different word instead.')
+        for variant, (word, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', word=word, expected=expected):
+
+                actual_result = add_prefix_un(word)
+                error_message = (f'Called add_prefix_un("{word}"). '
+                                f'The function returned "{actual_result}", but the '
+                                f'tests expected "{expected}" after adding "un" as a prefix.')
+
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_make_word_groups_en(self):
         input_data = ['en', 'circle', 'fold', 'close', 'joy', 'lighten', 'tangle', 'able', 'code', 'culture']
-        result_data = ('en :: encircle :: enfold :: enclose :: enjoy :: enlighten ::'
+        expected = ('en :: encircle :: enfold :: enclose :: enjoy :: enlighten ::'
                        ' entangle :: enable :: encode :: enculture')
 
-        self.assertEqual(make_word_groups(input_data), result_data,
-                         msg=f'Expected {result_data} but got something else instead.')
+        actual_result = make_word_groups(input_data)
+        error_message = (f'Called make_word_groups({input_data}). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the '
+                         'word groups.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_make_word_groups_pre(self):
         input_data = ['pre', 'serve', 'dispose', 'position', 'requisite', 'digest',
                       'natal', 'addressed', 'adolescent', 'assumption', 'mature', 'compute']
-        result_data = ('pre :: preserve :: predispose :: preposition :: prerequisite :: '
-                       'predigest :: prenatal :: preaddressed :: preadolescent :: preassumption :: '
-                       'premature :: precompute')
+        expected = ('pre :: preserve :: predispose :: preposition :: prerequisite :: '
+                    'predigest :: prenatal :: preaddressed :: preadolescent :: preassumption :: '
+                    'premature :: precompute')
 
-        self.assertEqual(make_word_groups(input_data), result_data,
-                         msg=f'Expected {result_data} but got something else instead.')
+        actual_result = make_word_groups(input_data)
+        error_message = (f'Called make_word_groups({input_data}). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the '
+                         'word groups.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_make_word_groups_auto(self):
         input_data = ['auto', 'didactic', 'graph', 'mate', 'chrome', 'centric', 'complete',
                       'echolalia', 'encoder', 'biography']
-        result_data = ('auto :: autodidactic :: autograph :: automate :: autochrome :: '
-                       'autocentric :: autocomplete :: autoecholalia :: autoencoder :: '
-                       'autobiography')
+        expected = ('auto :: autodidactic :: autograph :: automate :: autochrome :: '
+                    'autocentric :: autocomplete :: autoecholalia :: autoencoder :: '
+                    'autobiography')
 
-        self.assertEqual(make_word_groups(input_data), result_data,
-                         msg=f'Expected {result_data} but got something else instead.')
+        actual_result = make_word_groups(input_data)
+        error_message = (f'Called make_word_groups({input_data}). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the '
+                         'word groups.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_make_words_groups_inter(self):
         input_data = ['inter', 'twine', 'connected', 'dependent', 'galactic', 'action',
                       'stellar', 'cellular', 'continental', 'axial', 'operative', 'disciplinary']
-        result_data = ('inter :: intertwine :: interconnected :: interdependent :: '
-                       'intergalactic :: interaction :: interstellar :: intercellular :: '
-                       'intercontinental :: interaxial :: interoperative :: interdisciplinary')
+        expected = ('inter :: intertwine :: interconnected :: interdependent :: '
+                    'intergalactic :: interaction :: interstellar :: intercellular :: '
+                    'intercontinental :: interaxial :: interoperative :: interdisciplinary')
 
-        self.assertEqual(make_word_groups(input_data), result_data,
-                         msg=f'Expected {result_data} but got something else instead.')
+        actual_result = make_word_groups(input_data)
+        error_message = (f'Called make_word_groups({input_data}). '
+                         f'The function returned "{actual_result}", '
+                         f'but the tests expected "{expected}" for the '
+                         'word groups.')
+
+        self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_remove_suffix_ness(self):
         input_data = ['heaviness', 'sadness', 'softness', 'crabbiness', 'lightness', 'artiness', 'edginess']
         result_data = ['heavy', 'sad', 'soft', 'crabby', 'light', 'arty', 'edgy']
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, word, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', word=word, result=result):
-                self.assertEqual(remove_suffix_ness(word), result,
-                                 msg=f'Expected: {result} but got a different word instead.')
+        for variant, (word, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', word=word, expected=expected):
+                actual_result = remove_suffix_ness(word)
+                error_message = (f'Called remove_suffix_ness("{word}"). '
+                                 f'The function returned "{actual_result}", '
+                                 f'but the tests expected "{expected}" after the '
+                                 'suffix was removed.')
+
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_adjective_to_verb(self):
@@ -86,9 +114,13 @@ class LittleSistersVocabTest(unittest.TestCase):
         index_data = [-2, -1, 3, 3, -2, -3, 5, 2, 1]
         result_data = ['brighten', 'darken', 'harden', 'soften',
                        'lighten', 'dampen', 'shorten', 'weaken', 'blacken']
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, sentence, index, result in zip(number_of_variants, input_data, index_data, result_data):
-            with self.subTest(f'variation #{variant}', sentence=sentence, index=index, result=result):
-                self.assertEqual(adjective_to_verb(sentence, index), result,
-                                 msg=f'Expected: {result} but got a different word instead.')
+        for variant, (sentence, index, expected) in enumerate(zip(input_data, index_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', sentence=sentence, index=index, expected=expected):
+                actual_result = adjective_to_verb(sentence, index)
+                error_message = (f'Called adjective_to_verb("{sentence}", {index}). '
+                                 f'The function returned "{actual_result}", but the tests '
+                                 f'expected "{expected}" as the verb for '
+                                 f'the word at index {index}.')
+
+                self.assertEqual(actual_result, expected, msg=error_message)


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes.