### PR TITLE
[Tisbury Treasure Hunt]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -7,6 +7,6 @@ The elements of a tuple can be iterated over using the `for item in <tuple>` con
 If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
 Like any sequence, elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
 
-[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
 [mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
@@ -4,7 +4,7 @@
   ],
   "contributors": [
     "cmccandless",
-    "bethanyg"
+    "BethanyG"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/hints.md
@@ -3,9 +3,9 @@
 ## General
 
 
-[Tuples][tuples] are immutable [sequence Types][sequence types] that can contain any data type.
-Tuples are [iterable][iterable], and elements within tuples can be accessed via [bracket notation][bracket notation], using a zero-based index from the left, or -1 from the right.
-Other [Common Sequence Operations][common sequence operations] can also be used when working with tuples.
+- [Tuples][tuples] are immutable [sequence Types][sequence types] that can contain any data type.
+- Tuples are [iterable][iterable].  If you need indexes as well as values, use [`enumerate()`][enumerate]
+- Elements within tuples can be accessed via [bracket notation][bracket notation], using a zero-based index from the left, or -1 from the right. Other [Common Sequence Operations][common sequence operations] can also be used when working with tuples.
 
 ## 1. Extract coordinates
 
@@ -35,14 +35,15 @@ Other [Common Sequence Operations][common sequence operations] can also be used 
 - There are multiple textual formatting options available via Pythons [`format specification mini-language`][format specification mini-language].
 
 
-[tuples]: https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences
-[sequence types]: https://docs.python.org/3/library/stdtypes.html#typesseq
-[iterable]: https://docs.python.org/3/glossary.html#term-iterable
 [bracket notation]: https://stackoverflow.com/questions/30250282/whats-the-difference-between-the-square-bracket-and-dot-notations-in-python
-[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
-[class tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
 [class str]: https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str
-[str.format]: https://docs.python.org/3/library/stdtypes.html#str.format
+[class tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
+[common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+[enumerate]: https://docs.python.org/3/library/functions.html#enumerate
 [f-strings]: https://docs.python.org/3/tutorial/inputoutput.html#formatted-string-literals
 [format specification mini-language]: https://docs.python.org/3/library/string.html#format-specification-mini-language
+[iterable]: https://docs.python.org/3/glossary.html#term-iterable
+[sequence types]: https://docs.python.org/3/library/stdtypes.html#typesseq
+[str.format]: https://docs.python.org/3/library/stdtypes.html#str.format
 [testing membership]: https://docs.python.org/3/reference/expressions.html#membership-test-operations
+[tuples]: https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
@@ -3,9 +3,11 @@
 In Python, a [tuple][tuple] is an _immutable_ collection of items in _sequence_.
 Like most collections, `tuples` can hold any (or multiple) data type(s) -- including other `tuples`.
 Tuples support all [common sequence operations][common sequence operations], but **do not** support [mutable sequence operations][mutable sequence operations].
+
 The elements of a tuple can be iterated over using the `for item in <tuple>` construct.
 If both element index and value are needed, `for index, item in enumerate(<tuple>)` can be used.
 Like any sequence, elements within `tuples` can be accessed via _bracket notation_ using a `0-based index` number from the left or a `-1-based index` number from the right.
+Tuples can also be copied in whole or in part using slice notation (_`<tuple>[<start>:<stop>:<step>]`_).
 
 
 ## Tuple Construction
@@ -140,5 +142,5 @@ True
 ```
 
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
-[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple
 [mutable sequence operations]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+[tuple]: https://docs.python.org/3/library/stdtypes.html#tuple

--- a/exercises/concept/tisbury-treasure-hunt/.meta/config.json
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/config.json
@@ -1,6 +1,6 @@
 {
   "authors": [
-    "bethanyg"
+    "BethanyG"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/tisbury-treasure-hunt/tuples_test.py
+++ b/exercises/concept/tisbury-treasure-hunt/tuples_test.py
@@ -1,6 +1,10 @@
 import unittest
 import pytest
-from tuples import get_coordinate, convert_coordinate, compare_records, create_record, clean_up
+from tuples import (get_coordinate,
+                    convert_coordinate,
+                    compare_records,
+                    create_record,
+                    clean_up)
 
 
 class TisburyTreasureTest(unittest.TestCase):
@@ -22,15 +26,20 @@ class TisburyTreasureTest(unittest.TestCase):
                       ('Silver Seahorse', '4E')]
 
         result_data = ['2A', '4B', '1C', '6D', '7E', '7F', '6A', '8A', '5B', '8C', '1F', '3D', '4E']
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, item, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', item=item, result=result):
-                self.assertEqual(get_coordinate(item), result)
+        for variant, (item, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', item=item, expected=expected):
+                actual_result = get_coordinate(item)
+                error_message = (f'Called get_coordinate({item}). '
+                                f'The function returned "{actual_result}", but '
+                                f'the tests expected "{expected}" as the coordinates.')
+
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_convert_coordinate(self):
-        input_data = ['2A', '4B', '1C', '6D', '7E', '7F', '6A', '8A', '5B', '8C', '1F', '3D', '4E']
+        input_data = ['2A', '4B', '1C', '6D', '7E', '7F',
+                      '6A', '8A', '5B', '8C', '1F', '3D', '4E']
         result_data = [('2', 'A'),
                        ('4', 'B'),
                        ('1', 'C'),
@@ -45,11 +54,14 @@ class TisburyTreasureTest(unittest.TestCase):
                        ('3', 'D'),
                        ('4', 'E')]
 
-        number_of_variants = range(1, len(input_data) + 1)
+        for variant, (item, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', item=item, expected=expected):
+                actual_result = convert_coordinate(item)
+                error_message = (f'Called convert_coordinate({item}). '
+                                 f'The function returned {actual_result}, but the '
+                                 f'tests expected {expected} as the converted coordinate.')
 
-        for variant, item, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', item=item, result=result):
-                self.assertEqual(convert_coordinate(item), result)
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_compare_records(self):
@@ -66,11 +78,15 @@ class TisburyTreasureTest(unittest.TestCase):
                 (('Carved Wooden Elephant', '8C'), ('Abandoned Lighthouse', ('4', 'B'), 'Blue'))
         ]
         result_data = [True, True, True, True, True, False, False, False, False, False]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, item, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', item=item, result=result):
-                self.assertEqual(compare_records(item[0], item[1]), result)
+        for variant, (item, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', item=item, expected=expected):
+                actual_result = compare_records(item[0], item[1])
+                error_message = (f'Called compare_records({item[0]}, {item[1]}). '
+                                 f'The function returned {actual_result}, but the '
+                                 f'tests expected {expected}.')
+
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_create_record(self):
@@ -99,11 +115,15 @@ class TisburyTreasureTest(unittest.TestCase):
                 'not a match'
         ]
 
-        number_of_variants = range(1, len(input_data) + 1)
+        for variant, (item, expected) in enumerate(zip(input_data, result_data), start=1):
+            with self.subTest(f'variation #{variant}', item=item, expected=expected):
+                actual_result = create_record(item[0], item[1])
+                error_message = (f'Called create_record({item[0]},{item[1]}). '
+                                 f'The function returned '
+                                 f'{actual_result}, but the tests expected '
+                                 f'{expected} for the record.')
 
-        for variant, item, result in zip(number_of_variants, input_data, result_data):
-            with self.subTest(f'variation #{variant}', item=item, result=result):
-                self.assertEqual(create_record(item[0], item[1]), result)
+                self.assertEqual(actual_result, expected, msg=error_message)
 
     @pytest.mark.task(taskno=5)
     def test_clean_up(self):


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes.