### PR TITLE
[Ghost Gobble Arcade Game]: Modified Test Error Messages & Touched Up Docs

### DIFF
--- a/concepts/bools/about.md
+++ b/concepts/bools/about.md
@@ -1,6 +1,6 @@
 # About
 
-Python represents True and False values with the [bool][bool] type.
+Python represents true and false values with the [`bool`][bools] type, which is a subtype of `int`.
  There are only two Boolean values in this type: `True` and `False`.
   These values can be assigned to a variable and combined with the [Boolean operators][boolean-operators] (`and`, `or`, `not`):
 
@@ -139,3 +139,5 @@ It is considered a [Python anti-pattern][comparing to true in the wrong way] to 
 [Boolean-operators]: https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not
 [comparing to true in the wrong way]: https://docs.quantifiedcode.com/python-anti-patterns/readability/comparison_to_true.html
 [comparisons]: https://docs.python.org/3/library/stdtypes.html#comparisons
+
+[bools]: https://docs.python.org/3/library/stdtypes.html#typebool

--- a/concepts/bools/introduction.md
+++ b/concepts/bools/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Python represents true and false values with the `bool` type.
+Python represents true and false values with the [`bool`][bools] type, which is a subtype of `int`.
  There are only two values under that type: `True` and `False`.
   These values can be bound to a variable:
 
@@ -21,3 +21,5 @@ We can evaluate Boolean expressions using the `and`, `or`, and `not` operators.
 >>> true_variable = not False
 >>> false_variable = not True
 ```
+
+[bools]: https://docs.python.org/3/library/stdtypes.html#typebool

--- a/exercises/concept/ghost-gobble-arcade-game/.docs/hints.md
+++ b/exercises/concept/ghost-gobble-arcade-game/.docs/hints.md
@@ -2,6 +2,7 @@
 
 ## General
 
+- For an overview, this section of the Python documentation: [Truth Value Testing][stdlib-bools] might help.
 - Don't worry about how the arguments are _derived_, focus on combining the arguments to return the intended result.
 
 ## 1. Define if Pac-Man can eat a ghost
@@ -20,6 +21,6 @@
 
 - You can use the [Boolean][boolean] [operators][Boolean-operators] to combine arguments for a result.
 
-[boolean]: https://docs.python.org/3/library/stdtypes.html#truth
 [Boolean-operators]: https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not
-
+[boolean]: https://docs.python.org/3/library/stdtypes.html#truth
+[stdlib-bools]: https://docs.python.org/3/library/stdtypes.html#truth-value-testing

--- a/exercises/concept/ghost-gobble-arcade-game/.docs/introduction.md
+++ b/exercises/concept/ghost-gobble-arcade-game/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Python represents true and false values with the `bool` type.
+Python represents true and false values with the [`bool`][bools] type, which is a subtype of `int`.
  There are only two values in this type: `True` and `False`.
   These values can be bound to a variable:
 
@@ -21,3 +21,5 @@ We can evaluate Boolean expressions using the `and`, `or`, and `not` operators:
 >>> true_variable = not False
 >>> false_variable = not True
 ```
+
+[bools]: https://docs.python.org/3/library/stdtypes.html#typebool

--- a/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
+++ b/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
@@ -4,7 +4,7 @@
   ],
   "contributors": [
     "cmccandless",
-    "bethanyg"
+    "BethanyG"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/ghost-gobble-arcade-game/arcade_game_test.py
+++ b/exercises/concept/ghost-gobble-arcade-game/arcade_game_test.py
@@ -7,104 +7,138 @@ class GhostGobbleGameTest(unittest.TestCase):
 
     @pytest.mark.task(taskno=1)
     def test_ghost_gets_eaten(self):
-        self.assertIs(
-            eat_ghost(True, True),
-            True,
-            msg="ghost should get eaten"
-        )
+        actual_result = eat_ghost(True, True)
+        error_message = ('Called eat_ghost(True, True).'
+                        f'The function returned {actual_result}, but the '
+                        f'tests expected that the ghost gets eaten (True).')
+
+        self.assertIs(actual_result, True, msg=error_message)
 
     @pytest.mark.task(taskno=1)
     def test_ghost_does_not_get_eaten_because_no_power_pellet_active(self):
-        self.assertIs(
-            eat_ghost(False, True),
-            False,
-            msg="ghost does not get eaten because no power pellet active"
-        )
+        actual_result = eat_ghost(False, True)
+        error_message = ('Called eat_ghost(False, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'ghost **does not** get eaten because '
+                         'no power pellet was active.')
+
+        self.assertIs(actual_result, False, msg=error_message)
 
     @pytest.mark.task(taskno=1)
     def test_ghost_does_not_get_eaten_because_not_touching_ghost(self):
-        self.assertIs(
-            eat_ghost(True, False),
-            False,
-            msg="ghost does not get eaten because not touching ghost"
-        )
+        actual_result = eat_ghost(True, False)
+        error_message = ('Called eat_ghost(True, False).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'ghost **does not** get eaten because '
+                         'the player was not touching the ghost.')
+
+        self.assertIs(actual_result, False, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_score_when_eating_dot(self):
-        self.assertIs(
-          score(False, True),
-          True,
-          msg="score when eating dot"
-        )
+        actual_result = score(False, True)
+        error_message = ('Called score(False, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player scores because they were touching a dot.')
+
+        self.assertIs(actual_result, True, msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_score_when_eating_power_pellet(self):
-        self.assertIs(
-            score(True, False),
-            True,
-            msg="score when eating power pellet"
-        )
+        actual_result = score(True, False)
+        error_message = ('Called score(True, False).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player scores because they '
+                         'were touching a power pellet.')
+
+        self.assertIs(actual_result,True,msg=error_message)
 
     @pytest.mark.task(taskno=2)
     def test_no_score_when_nothing_eaten(self):
-        self.assertIs(
-            score(False, False),
-            False,
-            msg="no score when nothing eaten"
-        )
+        actual_result = score(False, False)
+        error_message = ('Called score(False, False).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player **does not** score because they '
+                         'were not touching anything.')
+        self.assertIs(actual_result, False,msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_lose_if_touching_a_ghost_without_a_power_pellet_active(self):
+        actual_result = lose(False, True)
+        error_message = ('Called lose(False, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player loses because they touched a '
+                         'ghost without a power pellet activated.')
         self.assertIs(
-            lose(False, True),
-            True,
-            msg="lose if touching a ghost without a power pellet active"
-        )
+            actual_result, True, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_dont_lose_if_touching_a_ghost_with_a_power_pellet_active(self):
-        self.assertIs(
-            lose(True, True),
-            False,
-            msg="don't lose if touching a ghost with a power pellet active"
-        )
+        actual_result = lose(True, True)
+        error_message = ('Called lose(True, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player **does not** lose because when they touched a '
+                         'ghost, a power pellet was active.')
+
+        self.assertIs(actual_result, False, msg=error_message)
 
     @pytest.mark.task(taskno=3)
     def test_dont_lose_if_not_touching_a_ghost(self):
-        self.assertIs(
-            lose(True, False),
-            False,
-            msg="don't lose if not touching a ghost"
-        )
+        actual_result = lose(True, False)
+        error_message = ('Called lose(True, False).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player **does not** lose because they were '
+                         'not touching a ghost.')
+
+        self.assertIs(actual_result, False, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_win_if_all_dots_eaten(self):
-        self.assertIs(
-            win(True, False, False),
-            True,
-            msg="win if all dots eaten"
-        )
+        actual_result = win(True, False, False)
+        error_message = ('Called win(True, False, False).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player wins because all the dots were eaten.')
+
+        self.assertIs(actual_result, True, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_dont_win_if_all_dots_eaten_but_touching_a_ghost(self):
-        self.assertIs(
-            win(True, False, True),
-            False,
-            msg="don't win if all dots eaten, but touching a ghost"
-        )
+        actual_result = win(True, False, True)
+        error_message = ('Called win(True, False, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the '
+                         'player **does not** win, because '
+                         'the player was touching a ghost.')
+
+        self.assertIs(actual_result, False, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_win_if_all_dots_eaten_and_touching_a_ghost_with_a_power_pellet_active(self):
-        self.assertIs(
-            win(True, True, True),
-            True,
-            msg="win if all dots eaten and touching a ghost with a power pellet active"
-        )
+        actual_result = win(True, True, True)
+        error_message = ('Called win(True, True, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the player wins, '
+                         f'because a power pellet was active when they '
+                         f'touched a ghost.')
+
+        self.assertIs(actual_result, True, msg=error_message)
 
     @pytest.mark.task(taskno=4)
     def test_dont_win_if_not_all_dots_eaten(self):
-        self.assertIs(
-            win(False, True, True),
-            False,
-            msg="don't win if not all dots eaten and touching a ghost with a power pellet active"
-        )
+        actual_result = win(False, True, True)
+        error_message = ('Called win(False, True, True).'
+                         f'The function returned {actual_result}, but the '
+                         f'tests expected that the player **does not** win, '
+                         f'because the player did not eat all of the dots.')
+
+        self.assertIs(actual_result, False, msg=error_message)
+


### PR DESCRIPTION
Given the [modifications to the runner](https://github.com/exercism/python-test-runner/pull/114) that remove the test data from the subtests headlines in the UI, the error messages for failed tests and subtests needed modification.  New error messages now include the function with the arguments it is called with, in addition to the actual result and the expected result.

Also did a quick sweep of other documents to see if there were additional links needed or other small edits and typo fixes.