### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   housekeeping:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
         ./bin/template_status.py -v -p .problem-specifications
 
   canonical_sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: housekeeping
     strategy:
       matrix:

--- a/.github/workflows/issue-commenter.yml
+++ b/.github/workflows/issue-commenter.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   comment-on-new-issue:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Comments for every NEW issue.
     steps:
       - name: Checkout

--- a/.github/workflows/pr-commenter.yml
+++ b/.github/workflows/pr-commenter.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   pr-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: exercism/pr-commenter-action@v1.5.1
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-runner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Run test-runner


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.