### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,10 +14,10 @@ jobs:
   housekeeping:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
       with:
         python-version: 3.11.2
 
@@ -55,9 +55,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, 3.10.6, 3.11.2]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/issue-commenter.yml
+++ b/.github/workflows/issue-commenter.yml
@@ -9,16 +9,16 @@ jobs:
     name: Comments for every NEW issue.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Read issue-comment.md
         id: issue-comment
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b
         with:
           path: .github/issue-comment.md
 
       - name: Base comment
-        uses: jd-0001/gh-action-comment-on-new-issue@v2.0.3
+        uses: jd-0001/gh-action-comment-on-new-issue@c443e1151cc69b146fd6918cc983ec1bd27ab254
         with:
           message: "${{ steps.issue-comment.outputs.content }}"
           ignore-label: ":anger: prickle"

--- a/.github/workflows/pr-commenter.yml
+++ b/.github/workflows/pr-commenter.yml
@@ -6,7 +6,7 @@ jobs:
   pr-comment:
     runs-on: ubuntu-22.04
     steps:
-      - uses: exercism/pr-commenter-action@v1.5.1
+      - uses: exercism/pr-commenter-action@085ef62d2a541a112c3ade1d24deea83665ea186
         with:
           github-token: "${{ github.token }}"
           config-file: ".github/pr-commenter.yml"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 21

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -10,6 +10,6 @@ jobs:
   test-runner:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Run test-runner
         run: docker-compose run test-runner


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.