### PR TITLE
Clarification of the task and function description

### DIFF
--- a/exercises/concept/meltdown-mitigation/.docs/instructions.md
+++ b/exercises/concept/meltdown-mitigation/.docs/instructions.md
@@ -18,7 +18,7 @@ A reactor is said to be critical if it satisfies the following conditions:
 - The number of neutrons emitted per second is greater than 500.
 - The product of temperature and neutrons emitted per second is less than 500000.
 
-Implement the function `is_criticality_balanced()` that takes `temperature` measured in kelvin and `neutrons_emitted` as parameters, and returns `True` if the criticality conditions are met, `False` if not.
+Implement the function `is_criticality_balanced()` that takes `temperature` measured in kelvin and `neutrons_emitted` as parameters, and returns `True` if all of the criticality conditions are met, `False` if not.
 
 ```python
 >>> is_criticality_balanced(750, 600)

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -8,7 +8,7 @@ def is_criticality_balanced(temperature, neutrons_emitted):
     :param neutrons_emitted: int or float - number of neutrons emitted per second.
     :return: bool - is criticality balanced?
 
-    A reactor is said to be critical if it satisfies the following conditions:
+    A reactor is said to be critical if it satisfies all of the following conditions:
     - The temperature is less than 800 K.
     - The number of neutrons emitted per second is greater than 500.
     - The product of temperature and neutrons emitted per second is less than 500000.

--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -8,7 +8,7 @@ def is_criticality_balanced(temperature, neutrons_emitted):
     :param neutrons_emitted: int or float - number of neutrons emitted per second.
     :return: bool - is criticality balanced?
 
-    A reactor is said to be critical if it satisfies the following conditions:
+    A reactor is said to be critical if it satisfies all of the following conditions:
     - The temperature is less than 800 K.
     - The number of neutrons emitted per second is greater than 500.
     - The product of temperature and neutrons emitted per second is less than 500000.


### PR DESCRIPTION
This PR improves the description of the task and the function `is_criticality_balanced()`.
The task and description of the function did not precisely state that all conditions have to be met so people could think that the function should return `True` if just one of the conditions was satisfied.
I have added more clarification to the description so there are no doubts what is the correct logic for the function.