### PR TITLE
[Leap Performance Article]: Swapped HTML Syntax for Markdown Syntax for svg Image.

### DIFF
--- a/exercises/practice/leap/.articles/performance/content.md
+++ b/exercises/practice/leap/.articles/performance/content.md
@@ -19,7 +19,8 @@ All methods are "fast", but the difference may be easier to see graphically.
 **Note**: The y-axis values in the chart have a `1e-7` multiplier.
  All run times are sub-microsecond.
 
-  <img src="https://assets.exercism.org/images/tracks/python/leap/leap_timeit_bar_plot-light.svg" alt="Grouped Bar Chart showing execution timings for 4 leap approaches using the years 1900, 200, 2019, and 202 as input data. Described under the heading Timings for approaches by input year.">
+!["Grouped Bar Chart showing execution timings for 4 leap approaches using the years 1900, 200, 2019, and 202 as input data. Described under the heading Timings for approaches by input year."](https://assets.exercism.org/images/tracks/python/leap/leap_timeit_bar_plot-light.svg)
+
 
 ### Timings for approaches by input year
 


### PR DESCRIPTION
The site requires this to be in markdown syntax for proper processing.