### PR TITLE
Clarify that in Python there is a week descriptor called 'fifth'

### DIFF
--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,5 +1,9 @@
 # Instructions append
 
+## How this Exercise is Structured in Python
+
+There is another week descriptor, `fifth`, for the fifth weekday of the month, if there is one.  If there is not, you should raise an exception.
+
 ## Customizing and Raising Exceptions
 
 Sometimes it is necessary to both [customize](https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions) and [`raise`](https://docs.python.org/3/tutorial/errors.html#raising-exceptions) exceptions in your code. When you do this, you should always include a **meaningful error message** to indicate what the source of the error is. This makes your code more readable and helps significantly with debugging.

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -2,7 +2,8 @@
 
 ## How this Exercise is Structured in Python
 
-There is another week descriptor, `fifth`, for the fifth weekday of the month, if there is one.  If there is not, you should raise an exception.
+We have added an additional week descriptor (`fifth`) for the fifth weekday of the month, if there is one.  
+If there is not a fifth weekday in a month, you should raise an exception.
 
 ## Customizing and Raising Exceptions
 


### PR DESCRIPTION
Add a clarification to the docs that in Python there is a week descriptor called `fifth` that should be the fifth weekday of the month, if one exists. 