### PR TITLE
[Cater-Waiter/Sets]: Fixed Superset/subset Operator & Operator Descriptions

### DIFF
--- a/concepts/sets/about.md
+++ b/concepts/sets/about.md
@@ -172,7 +172,7 @@ Traceback (most recent call last):
 
 Sets have methods that generally mimic [mathematical set operations][mathematical-sets].
 Most (_not all_) of these methods have an [operator][operator] equivalent.
-Methods generally take any `iterable` as an argument, while operators require that both things being compared are `sets` or `frozensets`.
+Methods generally take any `iterable` as an argument, while operators require that both sides of the operation are `sets` or `frozensets`.
 
 
 ### Membership Testing Between Sets
@@ -266,7 +266,7 @@ False
 False
 
 # A set is always a loose superset of itself.
->>> set(animals) <= set(animals)
+>>> set(animals) >= set(animals)
 True
 ```
 

--- a/exercises/concept/cater-waiter/.docs/introduction.md
+++ b/exercises/concept/cater-waiter/.docs/introduction.md
@@ -114,7 +114,7 @@ TypeError: unhashable type: 'set'
 
 Sets have methods that generally mimic [mathematical set operations][mathematical-sets].
 Most (_not all_) of these methods have an [operator][operator] equivalent.
-Methods generally take any `iterable` as an argument, while operators require that both things being compared are `sets` or `frozensets`.
+Methods generally take any `iterable` as an argument, while operators require that both sides of the operation are `sets` or `frozensets`.
 
 
 ### Disjoint Sets
@@ -212,7 +212,7 @@ False
 False
 
 # A set is always a loose superset of itself.
->>> set(animals) <= set(animals)
+>>> set(animals) >= set(animals)
 True
 ```
 


### PR DESCRIPTION
Per (closed) [PR 3639](https://github.com/exercism/python/pull/3639) & (closed) [PR 3638](https://github.com/exercism/python/pull/3638/files), changed `introduction.md` for the `Cater Waiter` exercise and `about.md` for the `Sets` concept.