### PR TITLE
[Black Jack]: ✏️ Updates to instructions.

### DIFF
--- a/exercises/concept/black-jack/.docs/instructions.md
+++ b/exercises/concept/black-jack/.docs/instructions.md
@@ -67,7 +67,7 @@ Define the `value_of_ace(<card_one>, <card_two>)` function with parameters `card
 Your function will have to decide if the upcoming ace will get a value of 1 or a value of 11, and return that value.
 Remember: the value of the hand with the ace needs to be as high as possible _without_ going over 21.
 
-**Hint**: if we already have an ace in hand then its value would be 11.
+**Hint**: if we already have an ace in hand, then the upcoming ace value would be 1.
 
 ```python
 >>> value_of_ace('6', 'K')

--- a/exercises/concept/black-jack/.docs/instructions.md
+++ b/exercises/concept/black-jack/.docs/instructions.md
@@ -67,7 +67,7 @@ Define the `value_of_ace(<card_one>, <card_two>)` function with parameters `card
 Your function will have to decide if the upcoming ace will get a value of 1 or a value of 11, and return that value.
 Remember: the value of the hand with the ace needs to be as high as possible _without_ going over 21.
 
-**Hint**: if we already have an ace in hand, then the upcoming ace value would be 1.
+**Hint**: if we already have an ace in hand, then the value for the upcoming ace would be 1.
 
 ```python
 >>> value_of_ace('6', 'K')


### PR DESCRIPTION
Previously discussed in the [forum](https://forum.exercism.org/t/suggested-changes-to-python-learning-exercise-black-jack-instructions/10436).

The instructions on the exercise [black_jack](https://exercism.org/tracks/python/exercises/black-jack) might be improved.
It could be better to refer to the value of the upcoming ace instead of the value of those in hand since this doesn't apply if we have more than one ace in hand.

Current instructions:
 `Hint: if we already have an ace in hand then its value would be 11.`

Proposed instructions:
 `Hint: if we already have an ace in hand, then the value for the upcoming ace would be 1.`

Sources: "[...] and aces count as either 1 or 11 according to the player's choice." from [Wikipedia](https://en.wikipedia.org/wiki/Blackjack?lang=en#Rules_of_play_at_casinos).