### PR TITLE
[Resistor Color Expert]: Change `test_blue_grey_white_red_and_brown` to `test_blue_grey_white_brown_and_brown`

### DIFF
--- a/exercises/practice/resistor-color-expert/resistor_color_expert_test.py
+++ b/exercises/practice/resistor-color-expert/resistor_color_expert_test.py
@@ -35,7 +35,7 @@ class ResistorColorExpertTest(unittest.TestCase):
             resistor_label(["red", "green", "yellow", "yellow", "brown"]), "2.54 megaohms ±1%"
         )
 
-    def test_blue_grey_white_red_and_brown(self):
+    def test_blue_grey_white_brown_and_brown(self):
         self.assertEqual(
             resistor_label(["blue", "grey", "white", "brown", "brown"]), "6.89 kiloohms ±1%"
         )


### PR DESCRIPTION
Per [issue on forum](https://forum.exercism.org/t/python-resistor-color-expert/10587).