### PR TITLE
[Essays] Fix a typo in the exercise introduction

### DIFF
--- a/concepts/string-methods/about.md
+++ b/concepts/string-methods/about.md
@@ -43,7 +43,7 @@ There may also be [locale][locale] rules in place for a language or character se
 
 ```python
 >>> man_in_hat_th = 'ผู้ชายใส่หมวก'
->>> man_in_hat_ru = 'mужчина в шляпе'
+>>> man_in_hat_ru = 'мужчина в шляпе'
 >>> man_in_hat_ko = '모자를 쓴 남자'
 >>> man_in_hat_en = 'the man in the hat.'
 

--- a/exercises/concept/little-sisters-essay/.docs/introduction.md
+++ b/exercises/concept/little-sisters-essay/.docs/introduction.md
@@ -22,7 +22,7 @@ There may also be [locale][locale] rules in place for a language or character se
 
 ```python
 man_in_hat_th = 'ผู้ชายใส่หมวก'
-man_in_hat_ru = 'mужчина в шляпе'
+man_in_hat_ru = 'мужчина в шляпе'
 man_in_hat_ko = '모자를 쓴 남자'
 man_in_hat_en = 'the man in the hat.'
 


### PR DESCRIPTION
Just a fix for a small typo in examples.

---

Before: _**m**ужчина_ (`m` was latin/roman letter).
After: _**м**ужчина_ (`м` is now cyrillic, as expected).