### PR TITLE
[Card Games] Update 'approx_average_is_average' docstring summary

### DIFF
--- a/exercises/concept/card-games/.meta/exemplar.py
+++ b/exercises/concept/card-games/.meta/exemplar.py
@@ -47,7 +47,7 @@ def card_average(hand):
 
 
 def approx_average_is_average(hand):
-    """Return if an average is using (first + last index values ) OR ('middle' card) == calculated average.
+    """Return if the (average of first and last card values) OR ('middle' card) == calculated average.
 
     :param hand: list - cards in hand.
     :return: bool - does one of the approximate averages equal the `true average`?

--- a/exercises/concept/card-games/lists.py
+++ b/exercises/concept/card-games/lists.py
@@ -47,7 +47,7 @@ def card_average(hand):
 
 
 def approx_average_is_average(hand):
-    """Return if an average is using (first + last index values ) OR ('middle' card) == calculated average.
+    """Return if the (average of first and last card values) OR ('middle' card) == calculated average.
 
     :param hand: list - cards in hand.
     :return: bool - does one of the approximate averages equal the `true average`?


### PR DESCRIPTION
Improve docstring summary of `approx_average_is_average` function to be more clear. This is a fix for https://github.com/exercism/python/issues/3674.

### A story behind
1. Initially I've started an implementation of `approx_average_is_average` function based on docstring.
2. Wrote the function, run tests and found the implementation doesn't work.
3. Then read instructions and found inconsistencies between docstring and instructions (see the screenshot below).

### Screenshot

<img width="1212" alt="Screen Shot 2024-04-14 at 8 01 37 PM" src="https://github.com/exercism/python/assets/5333431/465fa9f6-561e-4df1-a3e6-349584d7d37c">
