### PR TITLE
[Mecha Munch Management]: Fix hint for task #5 (send_to_store)

### DIFF
--- a/exercises/concept/mecha-munch-management/.docs/hints.md
+++ b/exercises/concept/mecha-munch-management/.docs/hints.md
@@ -38,7 +38,7 @@ The dictionary section of the [official tutorial][dicts-docs] and the mapping ty
 - What method would you call to get an [iterable view of just the keys][keys] of the dictionary?
 - Remember that you can get the `value` of a given key by using `<dict name>[<key_name>]` syntax.
 - If you had a `list` or a `tuple`, what [`built-in`][builtins] function might you use to sort them?
-- Remember that the `built-in` function can take an optional `reversed=true` argument.
+- Remember that the `built-in` function can take an optional `reverse=True` argument.
 
 ## 6. Update the Store Inventory to Reflect what a User Has Ordered.
 


### PR DESCRIPTION
Fixes the following typos in hints for task no. 5 (`Send User Shopping Cart to Store for Fulfillment`):
1. Keyword argument should be `reverse`, not `reversed` (reference: [official documentation](https://docs.python.org/3/library/functions.html#sorted));
2. Boolean value should be `True`, not `true`.

**Related issue**: #3685.


### Proposed change
| Currently | Suggested |
| --- | --- |
| `reversed=true` | `reverse=True` |

### Screenshots
<img width="1113" alt="Screen Shot 2024-04-22 at 8 44 21 PM" src="https://github.com/exercism/python/assets/5333431/b7f9a057-c495-478a-987e-0cf8a8750859">

----
#### Official documentation:
<img width="613" alt="Screen Shot 2024-04-22 at 8 50 57 PM" src="https://github.com/exercism/python/assets/5333431/4e432086-483a-497b-b468-ccba4ef52d4b">