### PR TITLE
Queen Attack - Improve clarity of errors

### DIFF
--- a/exercises/practice/queen-attack/.meta/example.py
+++ b/exercises/practice/queen-attack/.meta/example.py
@@ -1,11 +1,11 @@
 class Queen:
     def __init__(self, row, column):
         if row < 0:
-            raise ValueError('row not positive')
+            raise ValueError('row is negative')
         if not 0 <= row <= 7:
             raise ValueError('row not on board')
         if column < 0:
-            raise ValueError('column not positive')
+            raise ValueError('column is negative')
         if not 0 <= column <= 7:
             raise ValueError('column not on board')
         self.row = row

--- a/exercises/practice/queen-attack/queen_attack_test.py
+++ b/exercises/practice/queen-attack/queen_attack_test.py
@@ -18,7 +18,7 @@ class QueenAttackTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             Queen(-2, 2)
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "row not positive")
+        self.assertEqual(err.exception.args[0], "row is negative")
 
     def test_queen_must_have_row_on_board(self):
         with self.assertRaises(ValueError) as err:
@@ -30,7 +30,7 @@ class QueenAttackTest(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             Queen(2, -2)
         self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "column not positive")
+        self.assertEqual(err.exception.args[0], "column is negative")
 
     def test_queen_must_have_column_on_board(self):
         with self.assertRaises(ValueError) as err:


### PR DESCRIPTION
The errors for negative rows and columns states that row/columns must be positive, but zero is a valid value and zero is not positive. If we change the language from "row/column not positive" to "row/column is negative" then the error will correctly describe the error case.