### PR TITLE
[POV] Update instructions.append.md & Remove Error Message Examples

### DIFF
--- a/exercises/practice/pov/.docs/instructions.append.md
+++ b/exercises/practice/pov/.docs/instructions.append.md
@@ -6,12 +6,4 @@ Sometimes it is necessary to [raise an exception](https://docs.python.org/3/tuto
 
 This particular exercise requires that you use the [raise statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) to "throw" multiple `ValueErrors` if the `Tree()` class is passed a tree that cannot be reoriented, or a path cannot be found between a `start node` and an `end node`. The tests will only pass if you both `raise` the `exception` and include a message with it.
 
-To raise a `ValueError` with a message, write the message as an argument to the `exception` type:
-
-```python
-# when a tree cannot be oriented to a new node POV
-raise ValueError("Tree could not be reoriented")
-
-#when a path cannot be found between a start and end node on the tree.
-raise ValueError("No path found")
-```
+Please check the tests and their expected results carefully.


### PR DESCRIPTION
Per [this discussion](https://forum.exercism.org/t/wrong-error-message-for-pov-to-path-test-case-when-source-not-found/11601/4) on the forum.  Given the difficulty of the exercise, the examples were removed and a reminder to check the expected results in the tests was added.