### PR TITLE
remove extra space

### DIFF
--- a/exercises/concept/inventory-management/.docs/introduction.md
+++ b/exercises/concept/inventory-management/.docs/introduction.md
@@ -120,7 +120,7 @@ KeyError: 'name'
 
 ## Looping through/Iterating over a Dictionary
 
-Looping through a dictionary using `for item in dict` or `while item` will iterate over only the _keys _ by default.
+Looping through a dictionary using `for item in dict` or `while item` will iterate over only the _keys_ by default.
 You can access the _values_ within the same loop by using _square brackets_:
 
 ```python


### PR DESCRIPTION
an extra space made the markdown fail displaying _keys_ in italics:
![image](https://github.com/user-attachments/assets/2edbf86d-6c46-47d6-9899-bf5c278f5e5a)
