### PR TITLE
[Mecha Munch Management]: Corrected Duplicate "Eggs" `dict` Key in Instructions & Tests 

### DIFF
--- a/exercises/concept/mecha-munch-management/.docs/instructions.md
+++ b/exercises/concept/mecha-munch-management/.docs/instructions.md
@@ -59,10 +59,10 @@ The function should return the new/updated "ideas" dictionary.
 ```python
 >>> update_recipes({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
                     'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
-(('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Eggs': 2, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),))
+(('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),))
 ...
 
-{'Banana Bread' : {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Eggs': 2, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
+{'Banana Bread' : {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
  'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}}
 
 >>> update_recipes({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},

--- a/exercises/concept/mecha-munch-management/dict_methods_test.py
+++ b/exercises/concept/mecha-munch-management/dict_methods_test.py
@@ -54,7 +54,7 @@ class MechaMunchManagementTest(unittest.TestCase):
         input_data = [
                         ({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
                           'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
-                        (('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Eggs': 2, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),)),
+                        (('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),)),
 
                         ({'Apple Pie': {'Apple': 1, 'Pie Crust': 1, 'Cream Custard': 1},
                           'Blueberry Pie': {'Blueberries': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
@@ -70,7 +70,7 @@ class MechaMunchManagementTest(unittest.TestCase):
                      ]
 
         output_data = [
-                        {'Banana Bread': {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Eggs': 2, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
+                        {'Banana Bread': {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
                          'Raspberry Pie': {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
                         {'Apple Pie': {'Apple': 1, 'Pie Crust': 1, 'Cream Custard': 1},
                         'Blueberry Pie': {'Blueberries': 2, 'Pie Crust': 1, 'Cream Custard': 1}},


### PR DESCRIPTION
Per discussion on the [forum](https://forum.exercism.org/t/testing-data-in-mecha-munch-management-dict-methods-py-task3/12638.), removed the duplicate "Eggs" `dict` key from **Task 3** example code in `instructions.md`, and from the input data in **Task 3** tests.  