### PR TITLE
[Transpose & generate_tests.py]: Added `join` env Function & Changed Template

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -204,6 +204,8 @@ def regex_find(s: str, find: str) -> List[Any]:
 def regex_split(s: str, find: str) -> List[str]:
     return re.split(find, s)
 
+def join_test_inputs(test_inputs: list) -> str:
+    return "\n".join(test_inputs)
 
 def filter_test_cases(cases: List[TypeJSON], opts: TestsTOML) -> List[TypeJSON]:
     """
@@ -409,6 +411,7 @@ def generate(
     env.filters["regex_replace"] = regex_replace
     env.filters["regex_find"] = regex_find
     env.filters["regex_split"] = regex_split
+    env.filters["join_test_inputs"] = join_test_inputs
     env.filters["zip"] = zip
     env.filters["parse_datetime"] = parse_datetime
     env.filters["escape_invalid_escapes"] = escape_invalid_escapes

--- a/exercises/practice/transpose/.meta/template.j2
+++ b/exercises/practice/transpose/.meta/template.j2
@@ -5,9 +5,16 @@
 
 class {{ exercise | camel_case }}Test(unittest.TestCase):
     {% for case in cases -%}
-    def test_{{ case["description"] | to_snake }}(self):
-        lines = {{ case["input"]["lines"] }}
-        expected = {{ case["expected"] }}
-        self.assertEqual({{ case["property"] }}("\n".join(lines)), "\n".join(expected))
+  def test_{{ case["description"] | to_snake }}(self):
+        {%- if case["input"]["lines"] | length > 0 %}
+        text = "{{+ case["input"]["lines"] | join_test_inputs | replace('\n','\\n') }}"
+        expected = "{{+ case["expected"] | join_test_inputs | replace('\n','\\n') }}"
 
+
+        {%- else %}
+        text = ""
+        expected = ""
+        {%- endif %}
+
+        self.assertEqual({{ case["property"] }}(text), expected)
     {% endfor %}

--- a/exercises/practice/transpose/transpose.py
+++ b/exercises/practice/transpose/transpose.py
@@ -1,2 +1,2 @@
-def transpose(lines):
+def transpose(text):
     pass

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/transpose/canonical-data.json
-# File last updated on 2023-07-19
+# File last updated on 2024-08-26
 
 import unittest
 
@@ -11,113 +11,73 @@ from transpose import (
 
 class TransposeTest(unittest.TestCase):
     def test_empty_string(self):
-        lines = []
-        expected = []
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = ""
+        expected = ""
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_two_characters_in_a_row(self):
-        lines = ["A1"]
-        expected = ["A", "1"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "A1"
+        expected = "A\n1"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_two_characters_in_a_column(self):
-        lines = ["A", "1"]
-        expected = ["A1"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "A\n1"
+        expected = "A1"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_simple(self):
-        lines = ["ABC", "123"]
-        expected = ["A1", "B2", "C3"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "ABC\n123"
+        expected = "A1\nB2\nC3"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_single_line(self):
-        lines = ["Single line."]
-        expected = ["S", "i", "n", "g", "l", "e", " ", "l", "i", "n", "e", "."]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "Single line."
+        expected = "S\ni\nn\ng\nl\ne\n \nl\ni\nn\ne\n."
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_first_line_longer_than_second_line(self):
-        lines = ["The fourth line.", "The fifth line."]
-        expected = [
-            "TT",
-            "hh",
-            "ee",
-            "  ",
-            "ff",
-            "oi",
-            "uf",
-            "rt",
-            "th",
-            "h ",
-            " l",
-            "li",
-            "in",
-            "ne",
-            "e.",
-            ".",
-        ]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "The fourth line.\nThe fifth line."
+        expected = "TT\nhh\nee\n  \nff\noi\nuf\nrt\nth\nh \n l\nli\nin\nne\ne.\n."
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_second_line_longer_than_first_line(self):
-        lines = ["The first line.", "The second line."]
-        expected = [
-            "TT",
-            "hh",
-            "ee",
-            "  ",
-            "fs",
-            "ie",
-            "rc",
-            "so",
-            "tn",
-            " d",
-            "l ",
-            "il",
-            "ni",
-            "en",
-            ".e",
-            " .",
-        ]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "The first line.\nThe second line."
+        expected = "TT\nhh\nee\n  \nfs\nie\nrc\nso\ntn\n d\nl \nil\nni\nen\n.e\n ."
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_mixed_line_length(self):
-        lines = ["The longest line.", "A long line.", "A longer line.", "A line."]
-        expected = [
-            "TAAA",
-            "h   ",
-            "elll",
-            " ooi",
-            "lnnn",
-            "ogge",
-            "n e.",
-            "glr",
-            "ei ",
-            "snl",
-            "tei",
-            " .n",
-            "l e",
-            "i .",
-            "n",
-            "e",
-            ".",
-        ]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "The longest line.\nA long line.\nA longer line.\nA line."
+        expected = "TAAA\nh   \nelll\n ooi\nlnnn\nogge\nn e.\nglr\nei \nsnl\ntei\n .n\nl e\ni .\nn\ne\n."
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_square(self):
-        lines = ["HEART", "EMBER", "ABUSE", "RESIN", "TREND"]
-        expected = ["HEART", "EMBER", "ABUSE", "RESIN", "TREND"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
+        expected = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_rectangle(self):
-        lines = ["FRACTURE", "OUTLINED", "BLOOMING", "SEPTETTE"]
-        expected = ["FOBS", "RULE", "ATOP", "CLOT", "TIME", "UNIT", "RENT", "EDGE"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "FRACTURE\nOUTLINED\nBLOOMING\nSEPTETTE"
+        expected = "FOBS\nRULE\nATOP\nCLOT\nTIME\nUNIT\nRENT\nEDGE"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_triangle(self):
-        lines = ["T", "EE", "AAA", "SSSS", "EEEEE", "RRRRRR"]
-        expected = ["TEASER", " EASER", "  ASER", "   SER", "    ER", "     R"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "T\nEE\nAAA\nSSSS\nEEEEE\nRRRRRR"
+        expected = "TEASER\n EASER\n  ASER\n   SER\n    ER\n     R"
+
+        self.assertEqual(transpose(lines), expected)
 
     def test_jagged_triangle(self):
-        lines = ["11", "2", "3333", "444", "555555", "66666"]
-        expected = ["123456", "1 3456", "  3456", "  3 56", "    56", "    5"]
-        self.assertEqual(transpose("\n".join(lines)), "\n".join(expected))
+        lines = "11\n2\n3333\n444\n555555\n66666"
+        expected = "123456\n1 3456\n  3456\n  3 56\n    56\n    5"
+
+        self.assertEqual(transpose(lines), expected)

--- a/exercises/practice/transpose/transpose_test.py
+++ b/exercises/practice/transpose/transpose_test.py
@@ -11,73 +11,73 @@ from transpose import (
 
 class TransposeTest(unittest.TestCase):
     def test_empty_string(self):
-        lines = ""
+        text = ""
         expected = ""
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_two_characters_in_a_row(self):
-        lines = "A1"
+        text = "A1"
         expected = "A\n1"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_two_characters_in_a_column(self):
-        lines = "A\n1"
+        text = "A\n1"
         expected = "A1"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_simple(self):
-        lines = "ABC\n123"
+        text = "ABC\n123"
         expected = "A1\nB2\nC3"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_single_line(self):
-        lines = "Single line."
+        text = "Single line."
         expected = "S\ni\nn\ng\nl\ne\n \nl\ni\nn\ne\n."
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_first_line_longer_than_second_line(self):
-        lines = "The fourth line.\nThe fifth line."
+        text = "The fourth line.\nThe fifth line."
         expected = "TT\nhh\nee\n  \nff\noi\nuf\nrt\nth\nh \n l\nli\nin\nne\ne.\n."
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_second_line_longer_than_first_line(self):
-        lines = "The first line.\nThe second line."
+        text = "The first line.\nThe second line."
         expected = "TT\nhh\nee\n  \nfs\nie\nrc\nso\ntn\n d\nl \nil\nni\nen\n.e\n ."
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_mixed_line_length(self):
-        lines = "The longest line.\nA long line.\nA longer line.\nA line."
+        text = "The longest line.\nA long line.\nA longer line.\nA line."
         expected = "TAAA\nh   \nelll\n ooi\nlnnn\nogge\nn e.\nglr\nei \nsnl\ntei\n .n\nl e\ni .\nn\ne\n."
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_square(self):
-        lines = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
+        text = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
         expected = "HEART\nEMBER\nABUSE\nRESIN\nTREND"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_rectangle(self):
-        lines = "FRACTURE\nOUTLINED\nBLOOMING\nSEPTETTE"
+        text = "FRACTURE\nOUTLINED\nBLOOMING\nSEPTETTE"
         expected = "FOBS\nRULE\nATOP\nCLOT\nTIME\nUNIT\nRENT\nEDGE"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_triangle(self):
-        lines = "T\nEE\nAAA\nSSSS\nEEEEE\nRRRRRR"
+        text = "T\nEE\nAAA\nSSSS\nEEEEE\nRRRRRR"
         expected = "TEASER\n EASER\n  ASER\n   SER\n    ER\n     R"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)
 
     def test_jagged_triangle(self):
-        lines = "11\n2\n3333\n444\n555555\n66666"
+        text = "11\n2\n3333\n444\n555555\n66666"
         expected = "123456\n1 3456\n  3456\n  3 56\n    56\n    5"
 
-        self.assertEqual(transpose(lines), expected)
+        self.assertEqual(transpose(text), expected)


### PR DESCRIPTION
As a result of the discussion [here in the forum](https://forum.exercism.org/t/in-transpose-excercise-there-is-a-mistake-in-tests/12307/9) and the previously logged issue [here in GitHub](https://github.com/exercism/python/issues/3136), decided to alter the `JinJa2` template for this exercise, so that the test case input was "pre joined" prior to verifying it in the test case.  

This is to avoid any ambiguity around whether the function input is intended to be a `list` or a `str` (_the intent from [problem specs](https://github.com/exercism/problem-specifications/blob/main/exercises/transpose/canonical-data.json#L4-L6) is that the inputs are `str`s_).

[x] Changed `generate_tests.py` to add the `join_test_inputs()` function & make it available in the template environment.
[x] Changed the `JinJa2` template to use the pre-join functionality, and to preserve the `\n` characters.
[x] Changed the stub to reflect renaming `lines` to `text` for the input parameter.
[x] Regenerated a new test file & tested `example.py` against it.