### PR TITLE
[Meltdown Mitigation & Conditionals Concept]: Adjusted `if-elif-else` Examples & Hints.

### DIFF
--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -8,7 +8,6 @@ Python 3.10 introduces a variant case-switch statement called `pattern matching`
 Conditional statements use expressions that must resolve to `True` or `False` -- either by returning a `bool` directly, or by evaluating ["truthy" or "falsy"][truth value testing].
 
 
-
 ```python
 x = 10
 y = 5
@@ -61,13 +60,15 @@ else:
 
 >>> def classic_fizzbuzz(number):
         if number % 3 == 0 and number % 5 == 0:
-            return 'FizzBuzz!'
+            say = 'FizzBuzz!'
         elif number % 5 == 0:
-            return 'Buzz!'
+            say = 'Buzz!'
         elif number % 3 == 0:
-            return 'Fizz!'
+            say = 'Fizz!'
         else:
-            return str(number)
+            say = str(number)
+        
+        return say
 
 >>> classic_fizzbuzz(15)
 'FizzBuzz!'
@@ -76,19 +77,44 @@ else:
 '13'
 ```
 
+As an alternative, the example above can be re-written to only use `if` statements with `returns`.
+However, re-writing in this way might obscure that the conditions are intended to be [_mutually exclusive_][mutually-exclusive] and could lead to future bugs or maintenance issues.
+
+
+```python
+>>> def classic_fizzbuzz(number):
+        if number % 3 == 0 and number % 5 == 0:
+            return 'FizzBuzz!'
+        if number % 5 == 0:
+            return 'Buzz!'
+        if number % 3 == 0:
+            return 'Fizz!'
+        
+        return str(number)
+
+>>> classic_fizzbuzz(15)
+'FizzBuzz!'
+
+>>> classic_fizzbuzz(13)
+'13'
+```
+
+
 Conditionals can also be nested.
 
 ```python
 >>> def driving_status(driver_age, test_score):
         if test_score >= 80: 
             if 18 > driver_age >= 16:
-                return "Student driver, needs supervision."
+                status = "Student driver, needs supervision."
             elif driver_age == 18:
-                return "Permitted driver, on probation."
+                satus = "Permitted driver, on probation."
             elif driver_age > 18:
-                return "Fully licensed driver."
+                status = "Fully licensed driver."
         else:
-            return "Unlicensed!"
+             status = "Unlicensed!"
+        
+        return status
 
 
 >>> driving_status(63, 78)
@@ -151,8 +177,9 @@ This is Truthy.
 Nope. It's Falsey.
 ```
 
-[if statement]: https://docs.python.org/3/reference/compound_stmts.html#the-if-statement
-[control flow tools]: https://docs.python.org/3/tutorial/controlflow.html#more-control-flow-tools
-[truth value testing]: https://docs.python.org/3/library/stdtypes.html#truth-value-testing
 [boolean operations]: https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not
 [comparisons]: https://docs.python.org/3/library/stdtypes.html#comparisons
+[control flow tools]: https://docs.python.org/3/tutorial/controlflow.html#more-control-flow-tools
+[if statement]: https://docs.python.org/3/reference/compound_stmts.html#the-if-statement
+[mutually-exclusive]: https://stackoverflow.com/a/22783232
+[truth value testing]: https://docs.python.org/3/library/stdtypes.html#truth-value-testing

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -45,10 +45,8 @@ z = 20
 
 # The elif statement allows for the checking of more conditions.
 if x > y > z:
-
     print("x is greater than y and z")
 elif y > x > z:
-
     print("y is greater than x and z")
 else:
     print("z is greater than x and y")
@@ -59,16 +57,17 @@ else:
 [Boolean operations][boolean operations] and [comparisons][comparisons] can be combined with conditionals for more complex testing:
 
 ```python
-
 >>> def classic_fizzbuzz(number):
         if number % 3 == 0 and number % 5 == 0:
-            return 'FizzBuzz!'
+            say = 'FizzBuzz!'
         elif number % 5 == 0:
-            return 'Buzz!'
+            say = 'Buzz!'
         elif number % 3 == 0:
-            return 'Fizz!'
+            say = 'Fizz!'
         else:
-            return str(number)
+            say = str(number)
+        
+        return say
 
 >>> classic_fizzbuzz(15)
 'FizzBuzz!'

--- a/exercises/concept/meltdown-mitigation/.docs/hints.md
+++ b/exercises/concept/meltdown-mitigation/.docs/hints.md
@@ -30,13 +30,15 @@
 
 - Comparison operators can be combined and used with conditionals.
 - Any number of `elif` statements can be used as decision "branches".
-- Each "branch" can have a separate `return`
+- Each "branch" can have a separate `return`, although it might be considered "bad form" by linting tools.
+- If the linter complains, consider assigning the output of a branch to a common variable, and then `return`ing that variable.
 
 ## 3. Fail Safe Mechanism
 
 - Comparison operators can be combined and used with conditionals.
 - Any number of `elif` statements can be used as decision "branches".
-- Each "branch" can have a separate `return`
+- Each "branch" can have a separate `return`, although it might be considered "bad form" by linting tools.
+- If the linter complains, consider assigning the output of a branch to a common variable, and then `return`ing that variable.
 
 
 [boolean operations]: https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not

--- a/exercises/concept/meltdown-mitigation/.docs/introduction.md
+++ b/exercises/concept/meltdown-mitigation/.docs/introduction.md
@@ -56,16 +56,17 @@ else:
 [Boolean operations][boolean operations] and [comparisons][comparisons] can be combined with conditionals for more complex testing:
 
 ```python
-
 >>> def classic_fizzbuzz(number):
         if number % 3 == 0 and number % 5 == 0:
-            return 'FizzBuzz!'
+            say = 'FizzBuzz!'
         elif number % 5 == 0:
-            return 'Buzz!'
+            say = 'Buzz!'
         elif number % 3 == 0:
-            return 'Fizz!'
+            say = 'Fizz!'
         else:
-            return str(number)
+            say = str(number)
+        
+        return say
 
 >>> classic_fizzbuzz(15)
 'FizzBuzz!'

--- a/exercises/concept/meltdown-mitigation/.meta/exemplar.py
+++ b/exercises/concept/meltdown-mitigation/.meta/exemplar.py
@@ -45,7 +45,6 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 
     generated_power = voltage * current
     percentage_range = (generated_power / theoretical_max_power) * 100
-    efficiency_level = 'unknown'
 
     if 80 <= percentage_range <= 100:
         efficiency_level = 'green'


### PR DESCRIPTION
Per discussion on the [forum](https://forum.exercism.org/t/pylint-returning-r1705-no-else-return-in-meltdown-mitigation-spoiler/12463), and the linked [SO Post](https://stackoverflow.com/questions/22782785/when-to-use-if-vs-elif-in-python/22783232#22783232), adjusted the `introduction.md` and `about.md` files as well as the `hints.md` and  `exemplar.py` file connected to the `Meltdown Mitigation` exercise.