### PR TITLE
[Cater-Waiter & Sets Concept]: Typos and `emdash` changes.

### DIFF
--- a/concepts/sets/about.md
+++ b/concepts/sets/about.md
@@ -1,8 +1,8 @@
 # Sets
 
 A [`set`][type-set] is a _mutable_ and _unordered_ collection of [_hashable_][hashable] objects.
-Set members must be distinct -- duplicate items are not allowed.
-They can hold multiple different data types and even nested structures like a `tuple` of `tuples` -- as long as all elements can be _hashed_.
+Set members must be distinct — duplicate items are not allowed.
+They can hold multiple different data types and even nested structures like a `tuple` of `tuples` — as long as all elements can be _hashed_.
 Sets also come in an immutable [`frozensets`][type-frozenset] flavor.
 
 Sets are most commonly used to quickly remove duplicates from other data structures or item groupings.
@@ -360,7 +360,7 @@ The operator version of this method is `<set> - <other set 1> - <other set 2> - 
  'Goose Berries', 'Strawberries'}
 
 # Operators require sets.
->>> berries_and_veggies - just_berries
+>>> berries_and_veggies - berries
 {'Artichokes','Asparagus','Broccoli','Kale',
 'Ramps','Rhubarb','Walking Onions','Watercress'}
 ```

--- a/concepts/sets/introduction.md
+++ b/concepts/sets/introduction.md
@@ -1,8 +1,8 @@
 # Sets
 
 A [`set`][type-set] is a _mutable_ and _unordered_ collection of [_hashable_][hashable] objects.
-Set members must be distinct -- duplicate items are not allowed.
-They can hold multiple different data types and even nested structures like a `tuple` of `tuples` -- as long as all elements can be _hashed_.
+Set members must be distinct — duplicate items are not allowed.
+They can hold multiple different data types and even nested structures like a `tuple` of `tuples` — as long as all elements can be _hashed_.
 Sets also come in an immutable [`frozensets`][type-frozenset] flavor.
 
 Sets are most commonly used to quickly remove duplicates from other data structures or item groupings.

--- a/exercises/concept/cater-waiter/.docs/instructions.md
+++ b/exercises/concept/cater-waiter/.docs/instructions.md
@@ -4,7 +4,7 @@ You and your business partners operate a small catering company. You've just agr
 
 ## 1. Clean up Dish Ingredients
 
-The event recipes were added from various sources and their ingredients appear to have duplicate (_or more_) entries -- you don't want to end up purchasing excess items!
+The event recipes were added from various sources and their ingredients appear to have duplicate (_or more_) entries — you don't want to end up purchasing excess items!
  Before the shopping and cooking can commence, each dish's ingredient list needs to be "cleaned".
 
 Implement the `clean_ingredients(<dish_name>, <dish_ingredients>)` function that takes the name of a dish and a `list` of ingredients.
@@ -138,5 +138,5 @@ from sets_categories_data import example_dishes, EXAMPLE_INTERSECTION
 
 >>> singleton_ingredients(example_dishes, EXAMPLE_INTERSECTION)
 ...
-{'vegetable oil', 'vegetable stock', 'barley malt', 'tofu', 'fresh basil', 'lemon', 'ginger', 'honey', 'spaghetti', 'cornstarch', 'yeast', 'red onion', 'breadcrumbs', 'mixed herbs', 'garlic powder', 'celeriac', 'lemon zest', 'sunflower oil', 'mushrooms', 'silken tofu', 'smoked tofu', 'bell pepper', 'cashews', 'oregano', 'tomatoes', 'parsley', 'red pepper flakes', 'rosemary'}
+{'garlic powder', 'sunflower oil', 'mixed herbs', 'cornstarch', 'celeriac', 'honey', 'mushrooms', 'bell pepper', 'rosemary', 'parsley', 'lemon', 'yeast', 'vegetable oil', 'vegetable stock', 'silken tofu', 'tofu', 'cashews', 'lemon zest', 'smoked tofu', 'spaghetti', 'ginger', 'breadcrumbs', 'tomatoes', 'barley malt', 'red pepper flakes', 'oregano', 'red onion', 'fresh basil'}
 ```

--- a/exercises/concept/cater-waiter/.docs/introduction.md
+++ b/exercises/concept/cater-waiter/.docs/introduction.md
@@ -1,8 +1,8 @@
 # Sets
 
-A [`set`][type-set] is a _mutable_ and _unordered_ collection of [_hashable_][hashable] objects.
-Set members must be distinct -- duplicate items are not allowed.
-They can hold multiple different data types and even nested structures like a `tuple` of `tuples` -- as long as all elements can be _hashed_.
+A [`set`][type-set] is a _mutable_ and unordered_ collection of [_hashable_][hashable] objects.
+Set members must be distinct — duplicate items are not allowed.
+They can hold multiple different data types and even nested structures like a `tuple` of `tuples` — as long as all elements can be _hashed_.
 Sets also come in an immutable [`frozensets`][type-frozenset] flavor.
 
 Sets are most commonly used to quickly remove duplicates from other data structures or item groupings.
@@ -332,7 +332,7 @@ The operator version of this method is `<set> - <other set 1> - <other set 2> - 
  'Goose Berries', 'Strawberries'}
 
 # Operators require sets.
->>> berries_and_veggies - just_berries
+>>> berries_and_veggies - berries
 {'Artichokes','Asparagus','Broccoli','Kale',
 'Ramps','Rhubarb','Walking Onions','Watercress'}
 ```

--- a/exercises/concept/cater-waiter/sets.py
+++ b/exercises/concept/cater-waiter/sets.py
@@ -43,7 +43,7 @@ def categorize_dish(dish_name, dish_ingredients):
     """Categorize `dish_name` based on `dish_ingredients`.
 
     :param dish_name: str - dish to be categorized.
-    :param dish_ingredients: list - ingredients for the dish.
+    :param dish_ingredients: set - ingredients for the dish.
     :return: str - the dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).


### PR DESCRIPTION
Per [forum discussion](http://forum.exercism.org/t/cater-waiter-exercise-variable-definition-missing/13293):

1.  Corrected `just_berries` variable typo in `cater-waiter/introduction.md`, `sets/introduction.md`, and, `sets/about.md`
2.  Changed `emdash`  representation from a double Hyphen to the `U+2014`/`ALT + 0151` character in `cater-waiter/introduction.md`, `sets/introduction.md`, and, `sets/about.md`.
3.  Changed the function signature in `sets.py` to be a `set` and not a `list` of ingredients.