### PR TITLE
Update pov_test.py

### DIFF
--- a/exercises/practice/pov/pov_test.py
+++ b/exercises/practice/pov/pov_test.py
@@ -166,7 +166,7 @@ class PovTest(unittest.TestCase):
             tree.path_to("nonexistent", "x")
         self.assertEqual(type(err.exception), ValueError)
 
-        self.assertEqual(err.exception.args[0], "Tree could not be reoriented")
+        self.assertEqual(err.exception.args[0], "No path found")
 
     # Custom Utility Functions
     def assertTreeEquals(self, result, expected):


### PR DESCRIPTION
The test results as written were inconsistent.  ValueErrors in the from_pov method return "Tree could not be reoriented".   ValueErrors in the path_to method should say "No path found".

I noticed this when trying to submit the exercise.