### PR TITLE
[Chaitana's Colossal Coaster] / [List Methods]: Change instructions to not return a copy

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
+++ b/exercises/concept/chaitanas-colossal-coaster/.docs/instructions.md
@@ -134,7 +134,7 @@ You should update the `list` and also `return` the name of the person who was re
 For administrative purposes, you need to get all the names in a given queue in alphabetical order.
 
 
-Define the `sorted_names()` function that takes 1 argument,  `queue`, (the `list` of people standing in the queue), and returns a `sorted` copy of the `list`.
+Define the `sorted_names()` function that takes 1 argument,  `queue`, (the `list` of people standing in the queue), and returns the `sorted` `list`.
 
 
 ```python


### PR DESCRIPTION
While returning a copy (not altering the original) makes more sense in the provided setting, this is:
* not tested.
* encourages just using the `sorted()` function instead of the `copy()` and `sort()` methods I suspect we want to see in this exercise - as it introduces the list method concept..

If we want to test for the returned value being a copy, keeping the original intact, this might be the corrected test:

```python
@pytest.mark.task(taskno=7)
    def test_sorted_names(self):
        test_data = ["Steve", "Ultron", "Natasha", "Rocket"]
        test_data_copy = test_data.copy()
        expected = ["Natasha", "Rocket", "Steve", "Ultron"]
        actual_result = sorted_names(test_data)

        error_message = (
            f"Called sorted_names({test_data})."
            f"The function returned {actual_result}, but the tests "
            f"expected {expected}."
        )

        self.assertListEqual(actual_result, expected, msg=error_message)
        self.assertListEqual(
            test_data,
            test_data_copy,
            msg="Function should not modify the original list",
        )
```