### PR TITLE
[Chaitana's Colossal Coaster] / [List Methods] Remove unused variable assignment in list_methods_test.py

### DIFF
--- a/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
+++ b/exercises/concept/chaitanas-colossal-coaster/list_methods_test.py
@@ -165,7 +165,7 @@ class ListMethodsTest(unittest.TestCase):
         for variant, (input, modified) in enumerate(test_data, start=1):
             with self.subTest(f'variation #{variant}', input=input, modified=modified):
                 unmodified = deepcopy(input)
-                actual_result = remove_the_last_person(input)
+                remove_the_last_person(input)
                 expected_queue = modified
 
                 error_message = (f'\nCalled remove_the_last_person({unmodified}).\n'


### PR DESCRIPTION
Semantically covered by the prior test, so the variable is not needed.

Consequentially, the assigned variable is not used in this test. To not generate warnings, I suggest to not assign the return value at all.