### PR TITLE
[Simple Linked List]: Remove Extraneous Periods from Links in `hints.md` & `instructions.append.md`

### DIFF
--- a/exercises/practice/simple-linked-list/.docs/hints.md
+++ b/exercises/practice/simple-linked-list/.docs/hints.md
@@ -13,7 +13,7 @@
 In order for _custom objects_ to support `len()`, the special method [`__len__`][__len__] needs to be defined.
 - Iteration in Python is supported for most sequence, container, or collection type objects.
 In order for a _custom_ object to support looping or re-ordering, the special method `__iter__` needs to be defined.
-[Implementing an iterator for a class.][implementing iterators] can help show you how.
+[Implementing an iterator for a class][implementing iterators] can help show you how.
 
 [Baeldung: The Stack Data Structure]: https://www.baeldung.com/cs/stack-data-structure
 [Koder Dojo Coding an ADS Stack in Python]: https://www.koderdojo.com/blog/coding-a-stack-abstract-data-structure-using-linked-list-in-python

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -46,7 +46,7 @@ For details on implementing special or "dunder" methods in Python, see [Python D
 ## Building an Iterator
 
 To support looping through or reversing your `LinkedList`, you will need to implement the `__iter__` special method.
-See [implementing an iterator for a class.][custom iterators] for implementation details.
+See [implementing an iterator for a class][custom iterators] for implementation details.
 
 <br>
 
@@ -56,7 +56,7 @@ Sometimes it is necessary to both [customize][customize errors] and [`raise`][ra
 When you do this, you should always include a **meaningful error message** to indicate what the source of the error is.
 This makes your code more readable and helps significantly with debugging.
 
-Custom exceptions can be created through new exception classes (see [`classes`][classes tutorial] for more detail.) that are typically subclasses of [`Exception`][exception base class].
+Custom exceptions can be created through new exception classes (see [`classes`][classes tutorial] for more detail) that are typically subclasses of [`Exception`][exception base class].
 
 For situations where you know the error source will be a derivative of a certain exception _type_, you can choose to inherit from one of the [`built in error types`][built-in errors] under the _Exception_ class.
 When raising the error, you should still include a meaningful message.


### PR DESCRIPTION
Removed three extraneous periods that were included mid-sentence, once within a parenthetical.