### PR TITLE
[Sieve]: Update content.md for Comprehension Approach

### DIFF
--- a/exercises/practice/sieve/.approaches/comprehensions/content.md
+++ b/exercises/practice/sieve/.approaches/comprehensions/content.md
@@ -27,7 +27,8 @@ def primes(limit):
             if all(number % divisor != 0 for divisor in range(2, number))]
 ```
 
-This second example using a `list-comprehension` with `all()` is certainly concise and _relatively_ readable, but the performance is again quite poor.
+This second example using a `list-comprehension` with `all()` is certainly concise and _relatively_ readable, but it uses **`%`** (_which the instructions ask you not to use_) and the performance is again quite poor.
+
 
 This is not quite a fully nested loop (_there is a short-circuit when `all()` evaluates to `False`_), but it is by no means "performant".
 In this case, scaling with input size is intermediate between linear and quadratic, so not quite as bad as the first example.


### PR DESCRIPTION
Added language about the disallowed `%` operator to the Comprehensions approach.

See [this forum discussion ](https://forum.exercism.org/t/sieve-instructions-disagree-with-dig-deeper/15470) for details.  I was unable to rewrite this without the modulus, but felt it was important to include as a counter example.  Using `%` makes the code _look cleaner_, but doesn't actually confer any advantage over the first example in the file.