### PR TITLE
[Wordy]: Removed "President" Test Case & Regenerated Test file  

### DIFF
--- a/exercises/practice/wordy/.approaches/introduction.md
+++ b/exercises/practice/wordy/.approaches/introduction.md
@@ -54,8 +54,11 @@ For question cleaning, [`str.removeprefix`][removeprefix] and
 'Supercalifragilistic'
 
 
-#The two methods can be chained to remove both a suffix and prefix in one line.
->>> 'Supercalifragilisticexpialidocious'.removesuffix('expialidocious').removeprefix('Super')
+#The two methods can be chained to remove both a suffix and prefix in "one line".
+#The line has been broken up here for better display.
+>>> ('Supercalifragilisticexpialidocious'
+     .removesuffix('expialidocious')
+     .removeprefix('Super'))
 'califragilistic'
 ```
 

--- a/exercises/practice/wordy/.meta/tests.toml
+++ b/exercises/practice/wordy/.meta/tests.toml
@@ -52,6 +52,7 @@ description = "unknown operation"
 
 [8a7e85a8-9e7b-4d46-868f-6d759f4648f8]
 description = "Non math question"
+include = false
 
 [42d78b5f-dbd7-4cdb-8b30-00f794bb24cf]
 description = "reject problem missing an operand"

--- a/exercises/practice/wordy/wordy_test.py
+++ b/exercises/practice/wordy/wordy_test.py
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
-# File last updated on 2023-07-19
+# File last updated on 2025-02-15
 
 import unittest
 
@@ -58,12 +58,6 @@ class WordyTest(unittest.TestCase):
     def test_unknown_operation(self):
         with self.assertRaises(ValueError) as err:
             answer("What is 52 cubed?")
-        self.assertEqual(type(err.exception), ValueError)
-        self.assertEqual(err.exception.args[0], "unknown operation")
-
-    def test_non_math_question(self):
-        with self.assertRaises(ValueError) as err:
-            answer("Who is the President of the United States?")
         self.assertEqual(type(err.exception), ValueError)
         self.assertEqual(err.exception.args[0], "unknown operation")
 


### PR DESCRIPTION
Also corrected formatting in approaches introduction.

See [forum discussion](https://forum.exercism.org/t/wordy-tests-require-non-meaningful-error-messages/15473/6) for additional details.