### PR TITLE
[Resistor Color Expert]: Fixed up Instructions & Introduction

### DIFF
--- a/exercises/practice/resistor-color-expert/.docs/instructions.md
+++ b/exercises/practice/resistor-color-expert/.docs/instructions.md
@@ -15,7 +15,7 @@ The color bands are encoded as follows:
 - grey: 8
 - white: 9
 
-In [`Resistor Color Trio`][resistor-color-trio-exercie] you decoded the first three color bands.
+In [`Resistor Color Trio`][resistor-color-trio-exercise] you decoded the first three color bands.
 For instance: orange-orange-brown translated to the main value `330`.
 In this exercise you will need to add _tolerance_ to the mix.
 Tolerance is the maximum amount that a value can be above or below the main value.
@@ -79,4 +79,4 @@ So an input `list` of `["orange", "orange", "blue", "red"]` should return:
 
 "33 megaohms ±2%"
 
-[resistor-color-trio-exercie]: https://exercism.org/tracks/python/exercises/resistor-color-trio
+[resistor-color-trio-exercise]: https://exercism.org/tracks/python/exercises/resistor-color-trio

--- a/exercises/practice/resistor-color-expert/.docs/instructions.md
+++ b/exercises/practice/resistor-color-expert/.docs/instructions.md
@@ -1,7 +1,7 @@
 # Instructions
 
 In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
-The program will take a 1, 4, or 5 colors as input, and outputs the correct value, in ohms.
+The program will take 1, 4, or 5 colors as input and output the correct value in ohms.
 The color bands are encoded as follows:
 
 - black: 0
@@ -57,7 +57,8 @@ Examples:
 There are also one band resistors.
 One band resistors only have the color black with a value of 0.
 
-This exercise is about translating an input `list` of resistor band colors into a label:
+
+Your program should translate an input `list` of resistor band colors into a label:
 
 "... ohms ...%"
 

--- a/exercises/practice/resistor-color-expert/.docs/instructions.md
+++ b/exercises/practice/resistor-color-expert/.docs/instructions.md
@@ -1,36 +1,36 @@
 # Instructions
 
 In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
-The program will take 1, 4, or 5 colors as input, and outputs the correct value, in ohms.
+The program will take a 1, 4, or 5 colors as input, and outputs the correct value, in ohms.
 The color bands are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
-In `resistor-color trio` you decoded the first three colors.
+In [`Resistor Color Trio`][resistor-color-trio-exercie] you decoded the first three color bands.
 For instance: orange-orange-brown translated to the main value `330`.
 In this exercise you will need to add _tolerance_ to the mix.
 Tolerance is the maximum amount that a value can be above or below the main value.
-For example, if the last band is green, the maximum tolerance will be ±0.5%.
+For example, if the last band is green, the maximum tolerance will be `±0.5%`.
 
 The tolerance band will have one of these values:
 
-- Grey - 0.05%
-- Violet - 0.1%
-- Blue - 0.25%
-- Green - 0.5%
-- Brown - 1%
-- Red - 2%
-- Gold - 5%
-- Silver - 10%
+- grey - 0.05%
+- violet - 0.1%
+- blue - 0.25%
+- green - 0.5%
+- brown - 1%
+- red - 2%
+- gold - 5%
+- silver - 10%
 
 The four-band resistor is built up like this:
 
@@ -38,10 +38,10 @@ The four-band resistor is built up like this:
 | ------- | ------- | ---------- | --------- |
 | Value_1 | Value_2 | Multiplier | Tolerance |
 
-Meaning
+Examples:
 
-- orange-orange-brown-green would be 330 ohms with a ±0.5% tolerance.
-- orange-orange-red-grey would be 3300 ohms with ±0.05% tolerance.
+- orange-orange-brown-green would be `330` ohms with a `±0.5%` tolerance.
+- orange-orange-red-grey would be `3300` ohms with `±0.05%` tolerance.
 
 The difference between a four and five-band resistor is that the five-band resistor has an extra band to indicate a more precise value.
 
@@ -49,31 +49,33 @@ The difference between a four and five-band resistor is that the five-band resis
 | ------- | ------- | ------- | ---------- | --------- |
 | Value_1 | Value_2 | Value_3 | Multiplier | Tolerance |
 
-Meaning
+Examples:
 
-- orange-orange-orange-black-green would be 333 ohms with a ±0.5% tolerance.
-- orange-red-orange-blue-violet would be 323M ohms with a ±0.10 tolerance.
+- orange-orange-orange-black-green would be `333` ohms with a `±0.5%` tolerance.
+- orange-red-orange-blue-violet would be `323M` ohms with a `±0.10` tolerance.
 
 There are also one band resistors.
 One band resistors only have the color black with a value of 0.
 
-This exercise is about translating the resistor band colors into a label:
+This exercise is about translating an input `list` of resistor band colors into a label:
 
 "... ohms ...%"
 
-So an input of "orange", "orange", "black", "green" should return:
+So an input `list` of `["orange", "orange", "black", "green"]` should return:
 
 "33 ohms ±0.5%"
 
 When there are more than a thousand ohms, we say "kiloohms".
  That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
 
-So an input of "orange", "orange", "orange", "grey" should return:
+So an input `list` of `["orange", "orange", "orange", "grey"]` should return:
 
 "33 kiloohms ±0.05%"
 
 When there are more than a million ohms, we say "megaohms".
 
-So an input of "orange", "orange", "blue", "red" should return:
+So an input `list` of `["orange", "orange", "blue", "red"]` should return:
 
 "33 megaohms ±2%"
+
+[resistor-color-trio-exercie]: https://exercism.org/tracks/python/exercises/resistor-color-trio

--- a/exercises/practice/resistor-color-expert/.docs/introduction.md
+++ b/exercises/practice/resistor-color-expert/.docs/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
-Like the previous [`Resistor Color Duo`][resistor-color-duo-exercise] and [`Resistor Color Trio`][resistor-color-trio-exercie] exercises, you will be translating resistor color bands to human-readable labels.
+Like the previous [`Resistor Color Duo`][resistor-color-duo-exercise] and [`Resistor Color Trio`][resistor-color-trio-exercise] exercises, you will be translating resistor color bands to human-readable labels.
 
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
@@ -11,4 +11,4 @@ Like the previous [`Resistor Color Duo`][resistor-color-duo-exercise] and [`Resi
 
 
 [resistor-color-duo-exercise]: https://exercism.org/tracks/python/exercises/resistor-color-duo
-[resistor-color-trio-exercie]: https://exercism.org/tracks/python/exercises/resistor-color-trio
+[resistor-color-trio-exercise]: https://exercism.org/tracks/python/exercises/resistor-color-trio

--- a/exercises/practice/resistor-color-expert/.docs/introduction.md
+++ b/exercises/practice/resistor-color-expert/.docs/introduction.md
@@ -1,10 +1,14 @@
 # Introduction
 
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
-Like the previous `Resistor Color Duo` and `Resistor Color Trio` exercises, you will be translating resistor color bands to human-readable labels.
+Like the previous [`Resistor Color Duo`][resistor-color-duo-exercise] and [`Resistor Color Trio`][resistor-color-trio-exercie] exercises, you will be translating resistor color bands to human-readable labels.
 
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
   To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
 - Each band acts as a digit of a number.
   For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+
+[resistor-color-duo-exercise]: https://exercism.org/tracks/python/exercises/resistor-color-duo
+[resistor-color-trio-exercie]: https://exercism.org/tracks/python/exercises/resistor-color-trio


### PR DESCRIPTION
Forum discussion [here](https://forum.exercism.org/t/minor-formatting-issues-for-resistor-color-expert/15775).

-  links to Resistor Color Duo and Resistor color Trio.
- Lower-cased band names in instructions
- Clarified later examples to be `lists` for the function inputs,