### PR TITLE
[Mecha Munch Management]: Fix Typo in instructions.md

### DIFF
--- a/exercises/concept/mecha-munch-management/.docs/instructions.md
+++ b/exercises/concept/mecha-munch-management/.docs/instructions.md
@@ -62,7 +62,7 @@ The function should return the new/updated "ideas" dictionary.
 (('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),))
 ...
 
-{'Banana Bread' : {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
+{'Banana Bread' : {'Banana': 4,  'Apple': 1, 'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
  'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}}
 
 >>> update_recipes({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},


### PR DESCRIPTION
`'Apple': 1` was missing from results dict on Task 3 examples.