### PR TITLE
[Mecha Munch Management] Fixed typos in Instructions, Introduction, & Stub File

### DIFF
--- a/exercises/concept/mecha-munch-management/.docs/instructions.md
+++ b/exercises/concept/mecha-munch-management/.docs/instructions.md
@@ -57,24 +57,28 @@ Create the function `update_recipes(<ideas>, <recipe_updates>)` that takes an "i
 The function should return the new/updated "ideas" dictionary.
 
 ```python
->>> update_recipes({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
-                    'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
-(('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),))
+>>>update_recipes(
+    {'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
+     'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}},
+    (('Banana Bread', {'Banana': 4,  'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}),)
+    )
 ...
 
-{'Banana Bread' : {'Banana': 4,  'Apple': 1, 'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3},
- 'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}}
+{'Banana Bread': {'Banana': 4, 'Walnuts': 2, 'Flour': 1, 'Butter': 1, 'Milk': 2, 'Eggs': 3}, 
+ 'Raspberry Pie': {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1}}
 
->>> update_recipes({'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
-                    'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1},
-                    'Pasta Primavera': {'Eggs': 1, 'Carrots': 1, 'Spinach': 2, 'Tomatoes': 3, 'Parmesan': 2, 'Milk': 1, 'Onion': 1}},
-[('Raspberry Pie', {'Raspberry': 3, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1, 'Whipped Cream': 2}),
-('Pasta Primavera', {'Eggs': 1, 'Mixed Veggies': 2, 'Parmesan': 2, 'Milk': 1, 'Spinach': 1, 'Bread Crumbs': 1}),
-('Blueberry Crumble', {'Blueberries': 2, 'Whipped Creme': 2, 'Granola Topping': 2, 'Yogurt': 3})])
+>>> update_recipes(
+    {'Banana Bread' : {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
+    'Raspberry Pie' : {'Raspberry': 1, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1},
+    'Pasta Primavera': {'Eggs': 1, 'Carrots': 1, 'Spinach': 2, 'Tomatoes': 3, 'Parmesan': 2, 'Milk': 1, 'Onion': 1}},
+    [('Raspberry Pie', {'Raspberry': 3, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1, 'Whipped Cream': 2}),
+    ('Pasta Primavera', {'Eggs': 1, 'Mixed Veggies': 2, 'Parmesan': 2, 'Milk': 1, 'Spinach': 1, 'Bread Crumbs': 1}),
+    ('Blueberry Crumble', {'Blueberries': 2, 'Whipped Creme': 2, 'Granola Topping': 2, 'Yogurt': 3})]
+    )
 ...
 
-{'Banana Bread': {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1},
- 'Raspberry Pie': {'Raspberry': 3, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1, 'Whipped Cream': 2},
+{'Banana Bread': {'Banana': 1, 'Apple': 1, 'Walnuts': 1, 'Flour': 1, 'Eggs': 2, 'Butter': 1}, 
+ 'Raspberry Pie': {'Raspberry': 3, 'Orange': 1, 'Pie Crust': 1, 'Cream Custard': 1, 'Whipped Cream': 2}, 
  'Pasta Primavera': {'Eggs': 1, 'Mixed Veggies': 2, 'Parmesan': 2, 'Milk': 1, 'Spinach': 1, 'Bread Crumbs': 1},
  'Blueberry Crumble': {'Blueberries': 2, 'Whipped Creme': 2, 'Granola Topping': 2, 'Yogurt': 3}}
 ```

--- a/exercises/concept/mecha-munch-management/.docs/introduction.md
+++ b/exercises/concept/mecha-munch-management/.docs/introduction.md
@@ -87,7 +87,7 @@ This allows keys, values, or (`key`, `value`) pairs to be iterated over in Last-
 ```python
 >>> palette_II = {'Factory Stone Purple': '#7c677f', 'Green Treeline': '#478559', 'Purple baseline': '#161748'}
 
-# Iterating in insertion order 
+# Iterating in insertion order (First in, first out)
 >>> for item in palette_II.items():
 ...     print(item)
 ...
@@ -96,7 +96,7 @@ This allows keys, values, or (`key`, `value`) pairs to be iterated over in Last-
 ('Purple baseline', '#161748')
 
 
-# Iterating in the reverse direction.
+# Iterating in the reverse direction. (Last in, first out)
 >>> for item in reversed(palette_II.items()):
 ...    print (item)
 ...
@@ -108,12 +108,12 @@ This allows keys, values, or (`key`, `value`) pairs to be iterated over in Last-
 ## Sorting a Dictionary
 
 Dictionaries do not have a built-in sorting method.
-However, it is possible to sort a `dict` _view_ using the built-in function `sorted()` with `.items()`.
+However, it is possible to sort a `dict` _view_ using the built-in function `sorted()` with `dict.items()`.
 The sorted view can then be used to create a new dictionary.
-Like iteration, the default sort is over dictionary `keys`.
+Like iteration, the default sort is over the dictionary `keys`.
 
 ```python
-# Default ordering for a dictionary is last in, first out (LIFO).
+# Default ordering for a dictionary is insertion order (First in, first out).
 >>> color_palette = {'Grassy Green': '#9bc400', 
                     'Purple Mountains Majesty': '#8076a3', 
                     'Misty Mountain Pink': '#f9c5bd', 

--- a/exercises/concept/mecha-munch-management/dict_methods.py
+++ b/exercises/concept/mecha-munch-management/dict_methods.py
@@ -26,7 +26,7 @@ def update_recipes(ideas, recipe_updates):
     """Update the recipe ideas dictionary.
 
     :param ideas: dict - The "recipe ideas" dict.
-    :param recipe_updates: tuple -  with updates for the ideas section.
+    :param recipe_updates: iterable -  with updates for the ideas section.
     :return: dict - updated "recipe ideas" dict.
     """
 

--- a/exercises/concept/mecha-munch-management/dict_methods.py
+++ b/exercises/concept/mecha-munch-management/dict_methods.py
@@ -26,7 +26,7 @@ def update_recipes(ideas, recipe_updates):
     """Update the recipe ideas dictionary.
 
     :param ideas: dict - The "recipe ideas" dict.
-    :param recipe_updates: dict - dictionary with updates for the ideas section.
+    :param recipe_updates: tuple -  with updates for the ideas section.
     :return: dict - updated "recipe ideas" dict.
     """
 


### PR DESCRIPTION
- [x] Corrected `dict` typo in exercise stub to `iterable` (_test data has both nested tuples and lists_)
- [x] Corrected `LIFO` ref in code example for `Introduction.md` **Sorting a Dictionary** section.
- [x] Corrected code examples in `instructions.md` task 3 **Update Recipe "Ideas"** section. 

<br>

[Forum discussion 1](https://forum.exercism.org/t/about-task3-in-mecha-munch-management-the-1st-dict-methods-exercise-in-python/18191)
[Forum discussion 2](https://forum.exercism.org/t/inquiry-about-default-ordering-for-a-dictionary-in-python/18178)