### PR TITLE
[Little Sister's Vocab]: Fixed up Code Examples for `str.join()` & Added an Additional Hint.

### DIFF
--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -168,7 +168,7 @@ sentence = word + " " + "means" + " " + number + " in " + language + "."
 "дев'ять means nine in Ukrainian."
 ```
 
-If a `list`, `tuple`, `set` or other collection of individual strings needs to be combined into a single `str`, [`<str>.join(<iterable>)`][str-join], is a better option:
+If a `list`, `tuple`, `set` or other collection of individual strings needs to be combined into a single `str`, [`<str>.join(<iterable>)`][str-join] is a better option:
 
 
 ```python

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -206,7 +206,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 >>> separator.join(under_words)
 'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
 
-# The seperator can be composed different ways, as long as the result is a string.
+# The separator can be composed different ways, as long as the result is a string.
 >>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
 >>> separator = ' 🌟 ' + upper_words[0] #this becomes one string, similar to ' ⤴️ under'.
 >>> separator.join(upper_words)

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -9,7 +9,7 @@ The Python docs also provide a very detailed [unicode HOWTO][unicode how-to] tha
 Strings implement all [common sequence operations][common sequence operations] and can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
  Individual code points (_strings of length 1_) can be referenced by `0-based index` number from the left, or `-1-based index` number from the right.
 
-Strings can be concatenated with `+`, or via `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting and assembly options.
+Strings can be concatenated with `+`, or via `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting, assembly, and templating options.
 
 
 A `str` literal can be declared via single `'` or double `"` quotes. The escape `\` character is available as needed.
@@ -173,7 +173,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 ```python
 # str.join() makes a new string from the iterables elements.
->>> chickens = ["hen", "egg", "rooster"]
+>>> chickens = ["hen", "egg", "rooster"] #lists are iterable
 >>> ' '.join(chickens)
 'hen egg rooster'
 
@@ -183,6 +183,34 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 >>> ' 🌿 '.join(chickens)
 'hen 🌿 egg 🌿 rooster'
+
+
+# Any iterable can be used as input.
+>>> flowers = ("rose", "daisy", "carnation")  #tuples are iterable
+>>> '*-*'.join(flowers)
+'rose*-*daisy*-*carnation'
+
+>>> flowers = {"rose", "daisy", "carnation"}  #sets are iterable, but output order is not guaranteed.
+>>> '*-*'.join(flowers)
+'rose*-*carnation*-*daisy'
+
+>>> phrase = "This is my string"  #strings are iterable, but be careful!
+>>> '..'.join(phrase)
+'T..h..i..s.. ..i..s.. ..m..y.. ..s..t..r..i..n..g'
+
+
+# Separators are inserted **between** elements, but can be any string (including spaces).
+# This can be exploited for interesting effects.
+>>> under_words = ['under', 'current', 'sea', 'pin', 'dog', 'lay']
+>>> separator = ' ⤴️ under' #note the leading space, but no trailing space.
+>>> separator.join(under_words)
+'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
+
+# The seperator can be composed different ways, as long as the result is a string.
+>>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
+>>> separator = ' 🌟 ' + upper_words[0] #this becomes one string, similar to ' ⤴️ under'.
+>>> separator.join(upper_words)
+ 'upper 🌟 uppercrust 🌟 uppercase 🌟 upperclassmen 🌟 uppermost 🌟 uppercut'
 ```
 
 Strings support all [common sequence operations][common sequence operations].
@@ -194,7 +222,9 @@ Indexes _with_ items can be iterated through in a loop via `for index, item in e
 
 >>> exercise = 'လေ့ကျင့်'
 
-# Note that there are more code points than perceived glyphs or characters
+# Note that there are more code points than perceived glyphs or characters.
+# Care should be used when iterating over languages that use
+# combining characters, or when dealing with emoji.
 >>> for code_point in exercise:
 ...    print(code_point)
 ...

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -173,7 +173,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 ```python
 # str.join() makes a new string from the iterables elements.
->>> chickens = ["hen", "egg", "rooster"] #lists are iterable
+>>> chickens = ["hen", "egg", "rooster"] # Lists are iterable.
 >>> ' '.join(chickens)
 'hen egg rooster'
 
@@ -186,15 +186,15 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 
 # Any iterable can be used as input.
->>> flowers = ("rose", "daisy", "carnation")  #tuples are iterable
+>>> flowers = ("rose", "daisy", "carnation")  # Tuples are iterable.
 >>> '*-*'.join(flowers)
 'rose*-*daisy*-*carnation'
 
->>> flowers = {"rose", "daisy", "carnation"}  #sets are iterable, but output order is not guaranteed.
+>>> flowers = {"rose", "daisy", "carnation"}  # Sets are iterable, but output order is not guaranteed.
 >>> '*-*'.join(flowers)
 'rose*-*carnation*-*daisy'
 
->>> phrase = "This is my string"  #strings are iterable, but be careful!
+>>> phrase = "This is my string"  # Strings are iterable, but be careful!
 >>> '..'.join(phrase)
 'T..h..i..s.. ..i..s.. ..m..y.. ..s..t..r..i..n..g'
 
@@ -202,13 +202,13 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 # Separators are inserted **between** elements, but can be any string (including spaces).
 # This can be exploited for interesting effects.
 >>> under_words = ['under', 'current', 'sea', 'pin', 'dog', 'lay']
->>> separator = ' ⤴️ under' #note the leading space, but no trailing space.
+>>> separator = ' ⤴️ under' # note the leading space, but no trailing space.
 >>> separator.join(under_words)
 'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
 
 # The separator can be composed different ways, as long as the result is a string.
 >>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
->>> separator = ' 🌟 ' + upper_words[0] #this becomes one string, similar to ' ⤴️ under'.
+>>> separator = ' 🌟 ' + upper_words[0] # this becomes one string, similar to ' ⤴️ under'.
 >>> separator.join(upper_words)
  'upper 🌟 uppercrust 🌟 uppercase 🌟 upperclassmen 🌟 uppermost 🌟 uppercut'
 ```

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -202,13 +202,13 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 # Separators are inserted **between** elements, but can be any string (including spaces).
 # This can be exploited for interesting effects.
 >>> under_words = ['under', 'current', 'sea', 'pin', 'dog', 'lay']
->>> separator = ' ⤴️ under' # note the leading space, but no trailing space.
+>>> separator = ' ⤴️ under' # Note the leading space, but no trailing space.
 >>> separator.join(under_words)
 'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
 
 # The separator can be composed different ways, as long as the result is a string.
 >>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
->>> separator = ' 🌟 ' + upper_words[0] # this becomes one string, similar to ' ⤴️ under'.
+>>> separator = ' 🌟 ' + upper_words[0] # This becomes one string, similar to ' ⤴️ under'.
 >>> separator.join(upper_words)
  'upper 🌟 uppercrust 🌟 uppercase 🌟 upperclassmen 🌟 uppermost 🌟 uppercut'
 ```

--- a/exercises/concept/little-sisters-vocab/.docs/hints.md
+++ b/exercises/concept/little-sisters-vocab/.docs/hints.md
@@ -16,6 +16,7 @@ There's four activities in the assignment, each with a set of text or words to w
 
 - Believe it or not, [`str.join()`][str-join] is all you need here.
 - Like [`str.split()`][str-split]`, `str.join()` can take an arbitrary-length string, made up of any unicode code points.
+- The tests will be feeding your function a `list`.  There will be no need to alter this list, provided you use `.join()` correctly.
 
 ## 3. Remove a suffix from a word
 

--- a/exercises/concept/little-sisters-vocab/.docs/hints.md
+++ b/exercises/concept/little-sisters-vocab/.docs/hints.md
@@ -14,9 +14,11 @@ There's four activities in the assignment, each with a set of text or words to w
 
 ## 2. Add prefixes to word groups
 
-- Believe it or not, [`str.join()`][str-join] is all you need here.
-- Like [`str.split()`][str-split]`, `str.join()` can take an arbitrary-length string, made up of any unicode code points.
-- The tests will be feeding your function a `list`.  There will be no need to alter this list, provided you use `.join()` correctly.
+- Believe it or not, [`str.join()`][str-join] is all you need here.  **A loop is not required**.
+- The tests will be feeding your function a `list`.  There will be no need to alter this `list` if you can figure out a good delimiter string.
+- Remember that delimiter strings go between elements and "glue" them together into a single string. Delimiters are inserted _without_ space, although you can include space characters within them.
+- Like [`str.split()`][str-split], `str.join()` can process an arbitrary-length string, made up of any unicode code points. _Unlike_ `str.split()`, it can also process arbitrary-length iterables like `list`, `tuple`, and `set`.
+
 
 ## 3. Remove a suffix from a word
 

--- a/exercises/concept/little-sisters-vocab/.docs/instructions.md
+++ b/exercises/concept/little-sisters-vocab/.docs/instructions.md
@@ -40,6 +40,9 @@ Implement the `make_word_groups(<vocab_words>)` function that takes a `vocab_wor
  `[<prefix>, <word_1>, <word_2> .... <word_n>]`, and returns a string with the prefix applied to each word that looks like:
   `'<prefix> :: <prefix><word_1> :: <prefix><word_2> :: <prefix><word_n>'`.
 
+Creating a `for` or `while` loop to process the input is not needed here.
+Think carefully about which string methods (and delimiters) you could use instead.
+
 
 ```python
 >>> make_word_groups(['en', 'close', 'joy', 'lighten'])

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -50,7 +50,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 ```python
 # str.join() makes a new string from the iterables elements.
->>> chickens = ["hen", "egg", "rooster"] #lists are iterable
+>>> chickens = ["hen", "egg", "rooster"] # Lists are iterable.
 >>> ' '.join(chickens)
 'hen egg rooster'
 
@@ -63,15 +63,15 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 
 # Any iterable can be used as input.
->>> flowers = ("rose", "daisy", "carnation")  #tuples are iterable
+>>> flowers = ("rose", "daisy", "carnation")  # Tuples are iterable.
 >>> '*-*'.join(flowers)
 'rose*-*daisy*-*carnation'
 
->>> flowers = {"rose", "daisy", "carnation"}  #sets are iterable, but output order is not guaranteed.
+>>> flowers = {"rose", "daisy", "carnation"}  # Sets are iterable, but output order is not guaranteed.
 >>> '*-*'.join(flowers)
 'rose*-*carnation*-*daisy'
 
->>> phrase = "This is my string"  #strings are iterable, but be careful!
+>>> phrase = "This is my string"  # Strings are iterable, but be careful!
 >>> '..'.join(phrase)
 'T..h..i..s.. ..i..s.. ..m..y.. ..s..t..r..i..n..g'
 

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -50,7 +50,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 ```python
 # str.join() makes a new string from the iterables elements.
->>> chickens = ["hen", "egg", "rooster"]
+>>> chickens = ["hen", "egg", "rooster"] #lists are iterable
 >>> ' '.join(chickens)
 'hen egg rooster'
 
@@ -60,7 +60,36 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 
 >>> ' 🌿 '.join(chickens)
 'hen 🌿 egg 🌿 rooster'
+
+
+# Any iterable can be used as input.
+>>> flowers = ("rose", "daisy", "carnation")  #tuples are iterable
+>>> '*-*'.join(flowers)
+'rose*-*daisy*-*carnation'
+
+>>> flowers = {"rose", "daisy", "carnation"}  #sets are iterable, but output order is not guaranteed.
+>>> '*-*'.join(flowers)
+'rose*-*carnation*-*daisy'
+
+>>> phrase = "This is my string"  #strings are iterable, but be careful!
+>>> '..'.join(phrase)
+'T..h..i..s.. ..i..s.. ..m..y.. ..s..t..r..i..n..g'
+
+
+# Separators are inserted **between** elements, but can be any string (including spaces).
+# This can be exploited for interesting effects.
+>>> under_words = ['under', 'current', 'sea', 'pin', 'dog', 'lay']
+>>> separator = ' ⤴️ under'
+>>> separator.join(under_words)
+'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
+
+# The seperator can be composed different ways, as long as the result is a string.
+>>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
+>>> separator = ' 🌟 ' + upper_words[0]
+>>> separator.join(upper_words)
+ 'upper 🌟 uppercrust 🌟 uppercase 🌟 upperclassmen 🌟 uppermost 🌟 uppercut'
 ```
+
 
 Code points within a `str` can be referenced by `0-based index` number from the left:
 

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -90,7 +90,6 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
  'upper 🌟 uppercrust 🌟 uppercase 🌟 upperclassmen 🌟 uppermost 🌟 uppercut'
 ```
 
-
 Code points within a `str` can be referenced by `0-based index` number from the left:
 
 
@@ -123,7 +122,6 @@ creative = '창의적인'
 '인'
 
 ```
-
 
 There is no separate “character” or "rune" type in Python, so indexing a string produces a new `str` of length 1:
 
@@ -197,7 +195,6 @@ Strings can also be broken into smaller strings via [`<str>.split(<separator>)`]
 ...
 ['feline', 'four-footed', 'ferocious', 'furry']
 ```
-
 
 Separators for `<str>.split()` can be more than one character.
 The **whole string** is used for split matching.

--- a/exercises/concept/little-sisters-vocab/.docs/introduction.md
+++ b/exercises/concept/little-sisters-vocab/.docs/introduction.md
@@ -83,7 +83,7 @@ If a `list`, `tuple`, `set` or other collection of individual strings needs to b
 >>> separator.join(under_words)
 'under ⤴️ undercurrent ⤴️ undersea ⤴️ underpin ⤴️ underdog ⤴️ underlay'
 
-# The seperator can be composed different ways, as long as the result is a string.
+# The separator can be composed different ways, as long as the result is a string.
 >>> upper_words = ['upper', 'crust', 'case', 'classmen', 'most', 'cut']
 >>> separator = ' 🌟 ' + upper_words[0]
 >>> separator.join(upper_words)


### PR DESCRIPTION
Per [forum discussion](https://forum.exercism.org/t/loops-usage-on-little-sister-vocab-before-its-teached/19389/3).