### PR TITLE
Update ellens-alien-game test to prevent returning an empty list from the factory

### DIFF
--- a/exercises/concept/ellens-alien-game/classes_test.py
+++ b/exercises/concept/ellens-alien-game/classes_test.py
@@ -199,6 +199,9 @@ class ClassesTest(unittest.TestCase):
         test_data = [(-2, 6), (1, 5), (-4, -3)]
         actual_result = new_aliens_collection(test_data)
 
+        length_error_message = f"Expected {len(test_data)} Aliens, got {len(actual_result)}"
+        self.assertEqual(len(actual_result), len(test_data), msg=length_error_message)
+
         error_message = "new_aliens_collection() must return a list of Alien objects."
 
         for obj in actual_result:


### PR DESCRIPTION
I recognize that community contributions are not being accepted, and expect this PR to be automatically closed (as [the docs say it will be](https://github.com/exercism/python/blob/61dbb3a46b802b2263c4f6c41a28a5706b85eaaf/CONTRIBUTING.md#-did-you-write-a-patch-that-fixes-a-bug))

> Until the pause on contributions ends, all PRs from the larger community will be automatically closed with a note.

I'm publishing it anyway so I have something to link to in the community thread

-----

Before this change, you can pass the tests for `new_aliens_collection` by returning an empty list. After this change, the returned list must have the same length as the input list (so you create the same number of Aliens as the input asks for).


Here is a sample solution that passes all the tests (but incorrectly returns an empty list from the factory method)

```
"""Solution to Ellen's Alien Game exercise."""


class Alien:
    """Create an Alien object with location x_coordinate and y_coordinate.

    Attributes
    ----------
    (class)total_aliens_created: int
    x_coordinate: int - Position on the x-axis.
    y_coordinate: int - Position on the y-axis.
    health: int - Number of health points.

    Methods
    -------
    hit(): Decrement Alien health by one point.
    is_alive(): Return a boolean for if Alien is alive (if health is > 0).
    teleport(new_x_coordinate, new_y_coordinate): Move Alien object to new coordinates.
    collision_detection(other): Implementation TBD.
    """

    total_aliens_created = 0

    def __init__(self, x_coordinate, y_coordinate):
        Alien.total_aliens_created += 1
        self.x_coordinate = x_coordinate
        self.y_coordinate = y_coordinate
        self.health = 3

    def collision_detection(self, x):
        pass

    def hit(self):
        self.health -= 1

    def teleport(self, x, y):
        self.x_coordinate = x
        self.y_coordinate = y

    def is_alive(self):
        return self.health > 0

#TODO:  create the new_aliens_collection() function below to call your Alien class with a list of coordinates.

def new_aliens_collection(x):
    return []

```

I would have expected a test failure, but got none (all tests passing).

After this change, the above code causes one test to fail:

```
FAILED classes_test.py::ClassesTest::test_new_aliens_collection - AssertionError: 0 != 3 : Expected 3 Aliens, got 0
```

After this change, as expected, when the `new_aliens_collection` method is implemented, the tests pass