### PR TITLE
test: add case for odd starting value in Collatz sequence

### DIFF
--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.py
@@ -22,6 +22,9 @@ class CollatzConjectureTest(unittest.TestCase):
     def test_large_number_of_even_and_odd_steps(self):
         self.assertEqual(steps(1000000), 152)
 
+    def test_odd_number_start(self):
+        self.assertEqual(steps(25), 23)    
+
     def test_zero_is_an_error(self):
         with self.assertRaises(ValueError) as err:
             steps(0)


### PR DESCRIPTION
**Overview**
Adds a missing test case for handling odd-number Collatz inputs.

**Motivation**
Odd starts (like 25) help surface an easy mistake: using / produces floats, which breaks the integer sequence. 
Using // keeps the logic consistent.
This test highlights the issue, and I suggest recommending // in the implementation

**Changes**
Added test_odd_number_start to verify steps(25) == 23.