### PR TITLE
robot-name approach: fix typos, minor rephasing/improvements

### DIFF
--- a/exercises/practice/robot-name/.approaches/introduction.md
+++ b/exercises/practice/robot-name/.approaches/introduction.md
@@ -4,7 +4,7 @@ Robot Name in Python is an interesting exercise for practicing randomness.
 
 ## General Guidance
 
-Two ways immediately come to mind: generate all the possible names and then return them sequentially, or generate a random name and ensure that it's not been previously used.
+Two ways immediately come to mind: generate all the possible names and then return them sequentially, or generate a random name and ensure that it has not been previously used.
 
 Randomness can be a little, well, random, so **it's very easy to have an incorrect solution and still pass the tests**. It's strongly recommended to submit your solution for Code Review.
 
@@ -29,6 +29,7 @@ class Robot(object):
     def reset(self):
         self.name = next(NAMES)
 ```
+
 Note that selecting randomly from the list of all names would be incorrect, as there's a possibility of the name being repeated.
 For more detail and explanation of the code, [read here][approach-mass-name-generation].
 
@@ -38,6 +39,7 @@ Another approach is to generate the name on the fly and add it to a cache or a s
 
 
 A possible way to implement this:
+
 ```python
 from string import ascii_uppercase, digits
 from random import choices

--- a/exercises/practice/robot-name/.approaches/mass-name-generation/content.md
+++ b/exercises/practice/robot-name/.approaches/mass-name-generation/content.md
@@ -26,6 +26,7 @@ class Robot(object):
 
 The first few lines of the mass name generation uses [`itertools.product`][itertools-product].
 The resultant code is a simplification of:
+
 ```python
 letter_pairs = (''.join((l1, l2)) for l1 in ascii_uppercase for l2 in ascii_uppercase)
 numbers = (str(i).zfill(3) for i in range(1000))

--- a/exercises/practice/robot-name/.approaches/name-on-the-fly/content.md
+++ b/exercises/practice/robot-name/.approaches/name-on-the-fly/content.md
@@ -3,6 +3,7 @@
 We generate the name on the fly and add it to a cache or a store, checking to make sure that the generated name has not been used previously.
 
 A possible way to implement this:
+
 ```python
 from string import ascii_uppercase, digits
 from random import choices
@@ -23,6 +24,7 @@ class Robot:
     def __init__(self):
         self.reset()
 ```
+
 We use a `set` for the cache as it has a low access time, and because we do not need the preservation of order or the ability to access by index.
 
 Using `choices` is one of the many ways to generate the name.
@@ -31,6 +33,7 @@ The first is shorter, and best utilizes the Python standard library.
 
 As we are using a `while` loop to check for the name generation, it is convenient to store the local `name` using the [walrus operator][walrus-operator].
 It's also possible to find the name once before the loop, and then find it again inside the loop, but that would be an unnecessary repetition:
+
 ```python
 def reset(self):
     name = self.__get_name()
@@ -39,7 +42,9 @@ def reset(self):
     cache.add(name)
     self.name = name
 ```
+
 A helper method ([private][private-helper-methods] in this case) makes your code cleaner, but it's equally valid to have the code in the loop itself:
+
 ```python
 def reset(self):
     while (name := ''.join(choices(ascii_uppercase, k=2) + choices(digits, k=3))) in cache:


### PR DESCRIPTION
- Fixed a few typos.
- Rephrased here and there where I subjectively thought it useful. Please let me know if they're undesirable.
- Expanded some contractions - this might help non-native speakers.
- When another approach is mentioned, added link to it - hopefully this is useful rather than an distraction
- I thought the explanation about the alternative to using the walrus operator was not clear, so rephrased and added a code snippet. I hope this is useful.

Additionally, the phrase

```markdown
We call `reset` from `__init__` - it is syntactically valid to do it the other way around, but it is not considered good practice to call [dunder methods][dunder-methods] directly.
```
seems misleading to me: calling `__init__` from other methods seems to me significantly worse than calling other dunder methods, as it may lead to future bugs.
Arguably, for tooling support, we should assign to `self.name` in `__init__()` explicitly:

```python
def __init__(self):
    self.name = self._get_new_name()
def reset(self):
    self.name = self._get_new_name()
def _get_new_name(self):
     ...  # what reset() did
```

but this looks ugly and confusing.