### PR TITLE
[D&D Character] fix typos in approaches

### DIFF
--- a/exercises/practice/dnd-character/.approaches/introduction.md
+++ b/exercises/practice/dnd-character/.approaches/introduction.md
@@ -229,7 +229,7 @@ class Character:
         self.hitpoints = modifier(self.constitution) + 10
 ```
 
-Listing out each ability vs looping through and using `setatter()` has identical results for the object.
+Listing out each ability vs looping through and using `setattr()` has identical results for the object.
 Both calculate a score for an ability and write that ability + score into the object attribute dictionary when an object is instantiated from the class.
 
 
@@ -241,7 +241,7 @@ More variations are possible, but these cover most of the main decision differen
 - [One `ability` method][approach-ability-method]
 - [Dice roll static method][approach-dice-roll-static-method]
 - [Dice roll stand-alone method][approach-stand-alone-dice-roll-function]
-- [Loop and `setatter()` in `__init__`][approach-loop-and-setattr-in-init]
+- [Loop and `setattr()` in `__init__`][approach-loop-and-setattr-in-init]
 
 
 [approach-ability-method]: https://exercism.org/tracks/python/exercises/dnd-character/approaches/ability-method

--- a/exercises/practice/dnd-character/.approaches/loop-and-setattr-in-init/content.md
+++ b/exercises/practice/dnd-character/.approaches/loop-and-setattr-in-init/content.md
@@ -28,7 +28,7 @@ def modifier(constitution):
 
 
 This approach uses a `tuple` to hold character attributes in a [`class variable`][class-variable] or `class attribute`.
-Since this variable is common to all instances of the class, it can be looped through during object initialization to create instance variables and assign them values using [`setattr][setattr].
+Since this variable is common to all instances of the class, it can be looped through during object initialization to create instance variables and assign them values using [`setattr`][setattr].
 
 This strategy has several benefits:
 1.  The `__init__`  is less verbose and the abilities are easier to maintain.
@@ -75,7 +75,7 @@ Making the character attributes a constant has the advantage of being visible to
 This also avoids having to reference the Character class when using or modifying the abilities and could help with clarity and maintenance in the larger program.
 However, modifying the abilities in this context would also be visible at the module level, and could have wide or unintended consequences, so should be commented/documented carefully.
 
-The remainder of the class body is the same as in the [dice roll static method][approach-dice-roll-static-method] approach (_as is the variant below_).
+The remainder of the class body is the same as in the [dice roll static method][approach-dice-roll-static-method] approach.
 
 
 [approach-dice-roll-static-method]: https://exercism.org/tracks/python/exercises/dnd-character/approaches/dice-roll-static-method


### PR DESCRIPTION
As you said: 

> So we'll see all the typos shortly....

This is the first tranche. There seems to be something cursed about `setattr`.

Where I removed the bit that says `(_as is the variant below_)` on the last line of that document, I wondered if the whole paragraph is repeated needlessly? Line 78 duplicates line 41.