### PR TITLE
[Strings and String-Methods]: Reworked Examples and Docs.

### DIFF
--- a/concepts/string-methods/about.md
+++ b/concepts/string-methods/about.md
@@ -5,7 +5,8 @@ This may include letters, diacritical marks, positioning characters, numbers, cu
 
 Strings implement all [common sequence operations][common sequence operations] and can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
  Individual code points (_strings of length 1_) can be referenced by `0-based index` number from the left, or `-1-based index` number from the right.
-  Strings can be concatenated with `+`, or via `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting and assembly options.
+
+  Strings can be concatenated using `<str> + <other str>` or `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting and assembly options.
 
  To further work with strings, Python provides a rich set of [string methods][str-methods] for searching, cleaning, transforming, translating, and many other operations.
 

--- a/concepts/string-methods/introduction.md
+++ b/concepts/string-methods/introduction.md
@@ -4,9 +4,10 @@ A `str` in Python is an [immutable sequence][text sequence] of [Unicode code poi
 These may include letters, diacritical marks, positioning characters, numbers, currency symbols, emoji, punctuation, various spaces, line breaks, and more.
 
 Strings implement all [common sequence operations][common sequence operations] and can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
-They can be concatenated with `+`, or via `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting and assembly options.
+They can be concatenated using `<str> + <other str>` or `<str>.join(<iterable>)`, split with `<str>.split(<separator>)`, and offer multiple formatting and assembly options.
 
 To further work with strings, Python provides a rich set of [string methods][str-methods] that can assist with searching, cleaning, transforming, translating, and many other operations.
+
 Being _immutable_, a `str` object's value in memory doesn't change; methods that appear to modify a string return a new copy or instance of that `str` object.
 
 [common sequence operations]: https://docs.python.org/3/library/stdtypes.html#common-sequence-operations

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -9,10 +9,10 @@ The Python docs also provide a very detailed [unicode HOWTO][unicode how-to] tha
 Strings implement all [common sequence operations][common sequence operations] and can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
  Individual code points (_strings of length 1_) can be referenced by `0-based index` number from the left, or `-1-based index` number from the right.
 
-Strings can be concatenated with `+`, or via `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting, assembly, and templating options.
+Strings can be concatenated with `<str> + <other str>`, or `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple formatting, assembly, and templating options.
 
 
-A `str` literal can be declared via single `'` or double `"` quotes. The escape `\` character is available as needed.
+A `str` literal can be declared using single `'` or double `"` quotes. The escape `\` character is available as needed.
 
 ```python
 

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -5,7 +5,7 @@ These could include letters, diacritical marks, positioning characters, numbers,
 
 Strings implement all [common sequence operations][common sequence operations], and can be iterated through using `for item in <string>` or `for index, item in enumerate(<string>)` syntax.
 
-Strings can be concatenated with `+`, or via `<str>.join()`, split via `<str>.split(<separator>)`, and offer multiple types of formatting, interpolation, and templating.
+Strings can be concatenated with `<str> + <other str>`, or `<str>.join(<iterable>)`, split via `<str>.split(<separator>)`, and offer multiple types of formatting, interpolation, and templating.
 
 Being immutable, a `str` object's value in memory doesn't change; methods that appear to modify a string return a new copy or instance of `str`.
 

--- a/exercises/concept/little-sisters-essay/.docs/introduction.md
+++ b/exercises/concept/little-sisters-essay/.docs/introduction.md
@@ -3,10 +3,11 @@
 The `str` class offers [many useful methods][str methods] for working with and composing strings.
 These include searching, cleaning, splitting, transforming, translating, and many other techniques.
 
-Strings are [immutable sequences][text sequence] of [Unicode code points][unicode code points] -- individual "characters" or code points (_strings of length 1_) can be referenced by `0-based index` number from the left, or `-1-based index` number from the right.
+Strings are [sequences][text sequence] of [Unicode code points][unicode code points] -- individual "characters" or code points (_strings of length 1_) can be referenced by `0-based index` number from the left, or `-1-based index` number from the right.
+Strings implement all [common sequence operations][common sequence operations].
 
-Strings can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
-They can be concatenated using the `+` operator or via `<string>.join(<iterable>)` and implement all [common sequence operations][common sequence operations].
+They can be iterated through using `for item in <str>` or `for index, item in enumerate(<str>)` syntax.
+They can also be concatenated using `<str> + <other str>` or `<str>.join(<iterable>)`.
 
 Strings are _immutable_, meaning the value of a `str` object in memory cannot change.
 Functions or methods that operate on a `str` (_like the ones we are learning about here_) will return a new `instance` of that `str` object instead of modifying the original `str`.


### PR DESCRIPTION
Prompted by discussion around [this forum post](https://forum.exercism.org/t/string-methods-concept-little-sisters-essay-exercise-confusing-sentences/47653), re-read and tweaked the `strings` and `string-formatting` docs, as well as the `little-sisters-essay` introduction.md.