### PR TITLE
[Conditionals Concept Exercise]: Updated stub docstrings for `meltdown-mitigation`

### DIFF
--- a/exercises/concept/meltdown-mitigation/conditionals.py
+++ b/exercises/concept/meltdown-mitigation/conditionals.py
@@ -4,14 +4,19 @@
 def is_criticality_balanced(temperature, neutrons_emitted):
     """Verify criticality is balanced.
 
-    :param temperature: int or float - temperature value in kelvin.
-    :param neutrons_emitted: int or float - number of neutrons emitted per second.
-    :return: bool - is criticality balanced?
+    Parameters:
+        temperature (int or float): The temperature value in kelvin.
+        neutrons_emitted (int or float): The number of neutrons emitted per second.
 
-    A reactor is said to be balanced in criticality if it satisfies the following conditions:
-    - The temperature is less than 800 K.
-    - The number of neutrons emitted per second is greater than 500.
-    - The product of temperature and neutrons emitted per second is less than 500000.
+    Returns:
+        bool: Is criticality balanced?
+
+    Note:
+        A reactor is said to be balanced in criticality if it satisfies the following conditions:
+            - The temperature is less than 800 K.
+            - The number of neutrons emitted per second is greater than 500.
+            - The product of temperature and neutrons emitted per second is less than 500000.
+
     """
 
     pass
@@ -20,21 +25,24 @@ def is_criticality_balanced(temperature, neutrons_emitted):
 def reactor_efficiency(voltage, current, theoretical_max_power):
     """Assess reactor efficiency zone.
 
-    :param voltage: int or float - voltage value.
-    :param current: int or float - current value.
-    :param theoretical_max_power: int or float - power that corresponds to a 100% efficiency.
-    :return: str - one of ('green', 'orange', 'red', or 'black').
+    Parameters:
+        voltage (int or float): Voltage value.
+        current (int or float): Current value.
+        theoretical_max_power (int or float): The power level that corresponds to a 100% efficiency.
 
-    Efficiency can be grouped into 4 bands:
+    Returns:
+        str: One of ('green', 'orange', 'red', or 'black').
 
-    1. green -> efficiency of 80% or more,
-    2. orange -> efficiency of less than 80% but at least 60%,
-    3. red -> efficiency below 60%, but still 30% or more,
-    4. black ->  less than 30% efficient.
+    Note:
+        Efficiency can be grouped into 4 bands:
+            1. green -> efficiency of 80% or more,
+            2. orange -> efficiency of less than 80% but at least 60%,
+            3. red -> efficiency below 60%, but still 30% or more,
+            4. black ->  less than 30% efficient.
 
-    The percentage value is calculated as
-    (generated power/ theoretical max power)*100
-    where generated power = voltage * current
+        The percentage value is calculated as
+        (generated power/ theoretical max power)*100
+        where generated power = voltage * current
     """
 
     pass
@@ -43,14 +51,18 @@ def reactor_efficiency(voltage, current, theoretical_max_power):
 def fail_safe(temperature, neutrons_produced_per_second, threshold):
     """Assess and return status code for the reactor.
 
-    :param temperature: int or float - value of the temperature in kelvin.
-    :param neutrons_produced_per_second: int or float - neutron flux.
-    :param threshold: int or float - threshold for category.
-    :return: str - one of ('LOW', 'NORMAL', 'DANGER').
+    Parameters:
+        temperature (int or float): The value of the temperature in kelvin.
+        neutrons_produced_per_second (int or float): The neutron flux.
+        threshold (int or float): The threshold for the category.
 
-    1. 'LOW' -> `temperature * neutrons per second` < 90% of `threshold`
-    2. 'NORMAL' -> `temperature * neutrons per second` +/- 10% of `threshold`
-    3. 'DANGER' -> `temperature * neutrons per second` is not in the above-stated ranges
+    Returns:
+        str: One of ('LOW', 'NORMAL', 'DANGER').
+
+    Note:
+        1. 'LOW' -> `temperature * neutrons per second` < 90% of `threshold`
+        2. 'NORMAL' -> `temperature * neutrons per second` +/- 10% of `threshold`
+        3. 'DANGER' -> `temperature * neutrons per second` is not in the above-stated ranges
     """
 
     pass


### PR DESCRIPTION
Update stub docstrings to follow Google style (as set out by [Sphinx](https://www.sphinx-doc.org/en/master/index.html)).  For more info, see [napoleon for sphinx](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#module-sphinx.ext.napoleon) examples.