### PR TITLE
[Sets Concept Exercise]: Reformatted docstrings in `cater-waiter`

### DIFF
--- a/exercises/concept/cater-waiter/sets.py
+++ b/exercises/concept/cater-waiter/sets.py
@@ -13,9 +13,12 @@ from sets_categories_data import (VEGAN,
 def clean_ingredients(dish_name, dish_ingredients):
     """Remove duplicates from `dish_ingredients`.
 
-    :param dish_name: str - containing the dish name.
-    :param dish_ingredients: list - dish ingredients.
-    :return: tuple - containing (dish_name, ingredient set).
+    Parameters:
+        dish_name (str):  The name of the dish.
+        dish_ingredients (list): The ingredients for the dish.
+
+    Returns:
+        tuple: Containing (dish_name, ingredient set).
 
     This function should return a `tuple` with the name of the dish as the first item,
     followed by the de-duped `set` of ingredients as the second item.
@@ -27,13 +30,15 @@ def clean_ingredients(dish_name, dish_ingredients):
 def check_drinks(drink_name, drink_ingredients):
     """Append "Cocktail" (alcohol)  or "Mocktail" (no alcohol) to `drink_name`, based on `drink_ingredients`.
 
-    :param drink_name: str - name of the drink.
-    :param drink_ingredients: list - ingredients in the drink.
-    :return: str - drink_name appended with "Mocktail" or "Cocktail".
+    Parameters:
+        drink_name (str): Name of the drink.
+        drink_ingredients (list): Ingredients in the drink.
+
+    Returns:
+        str: drink_name appended with "Mocktail" or "Cocktail".
 
     The function should return the name of the drink followed by "Mocktail" (non-alcoholic) and drink
     name followed by "Cocktail" (includes alcohol).
-
     """
 
     pass
@@ -42,14 +47,16 @@ def check_drinks(drink_name, drink_ingredients):
 def categorize_dish(dish_name, dish_ingredients):
     """Categorize `dish_name` based on `dish_ingredients`.
 
-    :param dish_name: str - dish to be categorized.
-    :param dish_ingredients: set - ingredients for the dish.
-    :return: str - the dish name appended with ": <CATEGORY>".
+    Parameters:
+        dish_name (str): The dish to be categorized.
+        dish_ingredients (set): The ingredients for the dish.
+
+    Returns:
+        str: TThe dish name appended with ": <CATEGORY>".
 
     This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
     `<CATEGORY>` can be any one of  (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
     All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
-
     """
 
     pass
@@ -58,8 +65,11 @@ def categorize_dish(dish_name, dish_ingredients):
 def tag_special_ingredients(dish):
     """Compare `dish` ingredients to `SPECIAL_INGREDIENTS`.
 
-    :param dish: tuple - of (dish name, list of dish ingredients).
-    :return: tuple - containing (dish name, dish special ingredients).
+    Parameters:
+        dish (tuple): (dish name, list of dish ingredients).
+
+    Returns:
+        tuple: Containing (dish name, dish special ingredients).
 
     Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
     For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
@@ -72,8 +82,11 @@ def tag_special_ingredients(dish):
 def compile_ingredients(dishes):
     """Create a master list of ingredients.
 
-    :param dishes: list - of dish ingredient sets.
-    :return: set - of ingredients compiled from `dishes`.
+    Parameters:
+        dishes (list): Dish ingredient sets.
+
+    Returns:
+        set: Ingredients compiled from `dishes`.
 
     This function should return a `set` of all ingredients from all listed dishes.
     """
@@ -84,9 +97,12 @@ def compile_ingredients(dishes):
 def separate_appetizers(dishes, appetizers):
     """Determine which `dishes` are designated `appetizers` and remove them.
 
-    :param dishes: list - of dish names.
-    :param appetizers: list - of appetizer names.
-    :return: list - of dish names that do not appear on appetizer list.
+    Parameters:
+        dishes (list): Group of dish names.
+        appetizers (list): Group of appetizer names.
+
+    Returns:
+        list: Group of dish names that do not appear on appetizer list.
 
     The function should return the list of dish names with appetizer names removed.
     Either list could contain duplicates and may require de-duping.
@@ -98,9 +114,12 @@ def separate_appetizers(dishes, appetizers):
 def singleton_ingredients(dishes, intersection):
     """Determine which `dishes` have a singleton ingredient (an ingredient that only appears once across dishes).
 
-    :param dishes: list - of ingredient sets.
-    :param intersection: constant - can be one of `<CATEGORY>_INTERSECTIONS` constants imported from `sets_categories_data.py`.
-    :return: set - containing singleton ingredients.
+    Parameters:
+        dishes (list): Group of ingredient sets.
+        intersection (constant): Can be one of `<CATEGORY>_INTERSECTIONS` constants imported from `sets_categories_data.py`.
+
+    Returns:
+        set: Containing singleton ingredients.
 
     Each dish is represented by a `set` of its ingredients.
 


### PR DESCRIPTION
Update stub docstrings to follow Google style (as set out by [Sphinx](https://www.sphinx-doc.org/en/master/index.html)).  For more info, see [napoleon for sphinx](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#module-sphinx.ext.napoleon) examples.