### PR TITLE
fix: correct docstring formatting in locomotive-engineer exercise

### DIFF
--- a/exercises/concept/locomotive-engineer/locomotive_engineer.py
+++ b/exercises/concept/locomotive-engineer/locomotive_engineer.py
@@ -18,7 +18,7 @@ def fix_list_of_wagons(each_wagons_id, missing_wagons):
 
     Parameters:
         each_wagons_id (list[int]): The list of wagons.
-        missing_wagons (list[int]) The list of missing wagons.
+        missing_wagons (list[int]): The list of missing wagons.
 
     Returns:
         list[int]: The corrected list of wagons.
@@ -31,7 +31,7 @@ def add_missing_stops(route):
 
     Parameters:
         route (dict): The dict of routing information.
-        (dict): arbitrary number of stops.
+        route (dict): Arbitrary number of stops.
 
     Returns:
         dict: The updated route dictionary.
@@ -56,9 +56,9 @@ def fix_wagon_depot(wagons_rows):
     """Fix the list of rows of wagons.
 
     Parameters:
-        wagons_rows (list[tuple]) The list of rows of wagons.
+        wagons_rows (list[tuple]): The list of rows of wagons.
 
     Returns:
-        list[tuple]: the list of rows of wagons.
+        list[tuple]: The list of rows of wagons.
     """
     pass


### PR DESCRIPTION
## Summary

Fix docstring formatting issues in `exercises/concept/locomotive-engineer/locomotive_engineer.py`:

- Line 21: Add missing colon after `missing_wagons (list[int])`
- Line 34: Add missing parameter name `route` before `(dict)`
- Line 59: Add missing colon after `wagons_rows (list[tuple])`
- Line 62: Capitalize "The list of rows of wagons"

Reported in issue #4165.

## Test Plan

- [x] File reviewed and all 4 docstring issues corrected