### PR TITLE
[Lists and Comparisons]:  Typo & Formatting Corrections for `black-jack` and `card-games`

### DIFF
--- a/concepts/comparisons/about.md
+++ b/concepts/comparisons/about.md
@@ -13,7 +13,7 @@ The table below shows the most common Python comparison operators:
 | `<=`     | "less than or equal to"    | `a <= b` is `True` if `a < b` or `a == b` in value                        |
 | `!=`     | "not equal to"             | `a != b` is `True` if `a == b` is `False`                                 |
 | `is`     | "identity"                 | `a is b` is `True` if **_and only if_** `a` and `b` are the same _object_ |
-| `is not` | "negated identity"         | `a is not b` is `True` if `a` and `b` are **not** the same _object_       |
+| `is not` | "negated identity"         | `a is not b` is `True` if  **_and only if_** `a` and `b` are **not** the same _object_       |
 | `in`     | "containment test"         | `a in b` is `True` if `a` is member, subset, or element of `b`            |
 | `not in` | "negated containment test" | `a not in b` is `True` if `a` is not a member, subset, or element of `b`  |
 
@@ -146,7 +146,7 @@ True
 
 Comparison operators can be chained _arbitrarily_.
 Note that the evaluation of an expression takes place from `left` to `right`.
-For example, `x < y <= z` is equivalent to `x < y` `and` `y <= z`, except that `y` is evaluated **only once**.
+For example, `x < y <= z` is equivalent to `x < y and y <= z`, except that `y` is evaluated **only once**.
 In both cases, `z` is _not_ evaluated **at all** when `x < y` is found to be `False`.
 This is often called `short-circuit evaluation` - the evaluation stops if the truth value of the expression has already been determined.
 
@@ -180,7 +180,7 @@ Due to their singleton status, `None` and `NotImplemented` should always be comp
 See the Python reference docs on [value comparisons][value comparisons none] and [PEP8][PEP8 programming recommendations] for more details on this convention.
 
 ```python
->>> 
+
 # A list of favorite numbers.
 >>> my_fav_numbers = [1, 2, 3]
 
@@ -218,7 +218,7 @@ The operators `in` and `not in` test for _membership_.
 For string and bytes types, `<name> in <fullname>` is `True` _**if and only if**_ `<name>` is a substring of `<fullname>`.
 
 ```python
->>> 
+
 # A set of lucky numbers.
 >>> lucky_numbers = {11, 22, 33}
 >>> 22 in lucky_numbers

--- a/concepts/comparisons/introduction.md
+++ b/concepts/comparisons/introduction.md
@@ -13,7 +13,7 @@ The table below shows the most common Python comparison operators:
 | `<=`     | "less than or equal to"    | `a <= b` is `True` if `a < b` or `a == b` in value                        |
 | `!=`     | "not equal to"             | `a != b` is `True` if `a == b` is `False`                                 |
 | `is`     | "identity"                 | `a is b` is `True` if **_and only if_** `a` and `b` are the same _object_ |
-| `is not` | "negated identity"         | `a is not b` is `True` if `a` and `b` are **not** the same _object_       |
+| `is not` | "negated identity"         | `a is not b` is `True` if  **_and only if_** `a` and `b` are **not** the same _object_       |
 | `in`     | "containment test"         | `a in b` is `True` if `a` is member, subset, or element of `b`            |
 | `not in` | "negated containment test" | `a not in b` is `True` if `a` is not a member, subset, or element of `b`  |
 

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -49,14 +49,14 @@ For readability, line breaks can be used when there are many elements or nested 
 
 ```python
 >>> lots_of_entries = [
-...       "Rose",
-...       "Sunflower",
-...       "Poppy",
-...       "Pansy",
-...       "Tulip",
-...       "Fuchsia",
-...       "Cyclamen",
-...       "Lavender"
+...    "Rose",
+...    "Sunflower",
+...    "Poppy",
+...    "Pansy",
+...    "Tulip",
+...    "Fuchsia",
+...    "Cyclamen",
+...    "Lavender"
 ...    ]
 
 >>> lots_of_entries
@@ -65,9 +65,9 @@ For readability, line breaks can be used when there are many elements or nested 
 
 # Each data structure is on its own line to help clarify what they are.
 >>> nested_data_structures = [
-...       {"fish": "gold", "monkey": "brown", "parrot": "grey"},
-...       ("fish", "mammal", "bird"),
-...       ['water', 'jungle', 'sky']
+...    {"fish": "gold", "monkey": "brown", "parrot": "grey"},
+...    ("fish", "mammal", "bird"),
+...    ['water', 'jungle', 'sky']
 ...    ]
 
 >>> nested_data_structures

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -57,7 +57,7 @@ For readability, line breaks can be used when there are many elements or nested 
 ...    "Fuchsia",
 ...    "Cyclamen",
 ...    "Lavender"
-...    ]
+... ]
 
 >>> lots_of_entries
 ['Rose', 'Sunflower', 'Poppy', 'Pansy', 'Tulip', 'Fuchsia', 'Cyclamen', 'Lavender']
@@ -68,7 +68,7 @@ For readability, line breaks can be used when there are many elements or nested 
 ...    {"fish": "gold", "monkey": "brown", "parrot": "grey"},
 ...    ("fish", "mammal", "bird"),
 ...    ['water', 'jungle', 'sky']
-...    ]
+... ]
 
 >>> nested_data_structures
 [{'fish': 'gold', 'monkey': 'brown', 'parrot': 'grey'}, ('fish', 'mammal', 'bird'), ['water', 'jungle', 'sky']]

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -49,15 +49,15 @@ For readability, line breaks can be used when there are many elements or nested 
 
 ```python
 >>> lots_of_entries = [
-      "Rose",
-      "Sunflower",
-      "Poppy",
-      "Pansy",
-      "Tulip",
-      "Fuchsia",
-      "Cyclamen",
-      "Lavender"
-   ]
+...       "Rose",
+...       "Sunflower",
+...       "Poppy",
+...       "Pansy",
+...       "Tulip",
+...       "Fuchsia",
+...       "Cyclamen",
+...       "Lavender"
+...    ]
 
 >>> lots_of_entries
 ['Rose', 'Sunflower', 'Poppy', 'Pansy', 'Tulip', 'Fuchsia', 'Cyclamen', 'Lavender']
@@ -65,10 +65,10 @@ For readability, line breaks can be used when there are many elements or nested 
 
 # Each data structure is on its own line to help clarify what they are.
 >>> nested_data_structures = [
-      {"fish": "gold", "monkey": "brown", "parrot": "grey"},
-      ("fish", "mammal", "bird"),
-      ['water', 'jungle', 'sky']
-   ]
+...       {"fish": "gold", "monkey": "brown", "parrot": "grey"},
+...       ("fish", "mammal", "bird"),
+...       ['water', 'jungle', 'sky']
+...    ]
 
 >>> nested_data_structures
 [{'fish': 'gold', 'monkey': 'brown', 'parrot': 'grey'}, ('fish', 'mammal', 'bird'), ['water', 'jungle', 'sky']]
@@ -174,7 +174,7 @@ Indexes can be from **`left`** --> **`right`** (_starting at zero_) or **`right`
 'Toast'
 ```
 
-A section of a list can be accessed via _slice notation_ (`<list>[start:stop]`).
+A section of a list can be accessed via _slice notation_ (`<list>[<start>:<stop>]`).
 A _slice_ is defined as an element sequence at position `index`, such that `start <= index < stop`.
 [_Slicing_][slice notation] returns a copy of the "sliced" items and does not modify the original `list`.
 
@@ -207,7 +207,7 @@ Lists supply an [_iterator_][iterator], and can be looped through/over in the sa
 >>> colors = ["Orange", "Green", "Grey", "Blue"]
 >>> for item in colors:
 ...     print(item)
-...
+
 Orange
 Green
 Grey
@@ -218,7 +218,7 @@ Blue
 >>> colors = ["Orange", "Green", "Grey", "Blue"]
 >>> for index, item in enumerate(colors):
 ...     print(item, ":", index)
-...
+
 Orange : 0
 Green : 1
 Grey : 2
@@ -229,7 +229,7 @@ Blue : 3
 >>> numbers_to_cube = [5, 13, 12, 16]
 >>> for number in numbers_to_cube:
 ...     print(number**3)
-...
+
 125
 2197
 1728
@@ -335,7 +335,7 @@ This reference complication becomes exacerbated when working with nested or mult
 from pprint import pprint
 
 # This will produce a game grid that is 8x8, pre-populated with zeros.
->>> game_grid = [[0]*8] *8
+>>> game_grid = [[0]*8]*8
 
 >>> pprint(game_grid)
 [[0, 0, 0, 0, 0, 0, 0, 0],

--- a/exercises/concept/black-jack/.meta/exemplar.py
+++ b/exercises/concept/black-jack/.meta/exemplar.py
@@ -12,7 +12,7 @@ def value_of_card(card):
         card (str): The given card.
 
     Returns:
-        int:  The value of a given card.  See below for values.
+        int: The value of a given card.  See below for values.
 
         1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
         2.  'A' (ace card) = 1
@@ -43,7 +43,7 @@ def higher_card(card_one, card_two):
         3.  '2' - '10' = numerical value.
 
     Returns:
-        str or tuple: The resulting Tuple contains both cards if they are of equal value.
+        str or tuple: The resulting tuple contains both cards if they are of equal value.
     """
 
     card_one_value = value_of_card(card_one)

--- a/exercises/concept/black-jack/black_jack.py
+++ b/exercises/concept/black-jack/black_jack.py
@@ -12,7 +12,7 @@ def value_of_card(card):
         card (str): The given card.
 
     Returns:
-        int:  The value of a given card.  See below for values.
+        int: The value of a given card.  See below for values.
 
         1.  'J', 'Q', or 'K' (otherwise known as "face cards") = 10
         2.  'A' (ace card) = 1
@@ -34,7 +34,7 @@ def higher_card(card_one, card_two):
         3.  '2' - '10' = numerical value.
 
     Returns:
-        str or tuple: The resulting Tuple contains both cards if they are of equal value.
+        str or tuple: The resulting tuple contains both cards if they are of equal value.
     """
 
     pass

--- a/exercises/concept/card-games/.meta/exemplar.py
+++ b/exercises/concept/card-games/.meta/exemplar.py
@@ -8,7 +8,7 @@ def get_rounds(number):
     """Create a list containing the current and next two round numbers.
 
     Parameters:
-        number (int):  The current round number.
+        number (int): The current round number.
 
     Returns:
         list: The current round number and the two that follow.
@@ -21,7 +21,7 @@ def concatenate_rounds(rounds_1, rounds_2):
     """Concatenate two lists of round numbers.
 
     Parameters:
-        rounds_1 (list):  The first rounds played.
+        rounds_1 (list): The first rounds played.
         rounds_2 (list): The second group of rounds played.
 
     Returns:
@@ -35,7 +35,7 @@ def list_contains_round(rounds, number):
     """Check if the list of rounds contains the specified number.
 
     Parameters:
-        rounds  (list): The rounds played.
+        rounds (list): The rounds played.
         number (int): The round number.
 
     Returns:

--- a/exercises/concept/card-games/lists.py
+++ b/exercises/concept/card-games/lists.py
@@ -8,7 +8,7 @@ def get_rounds(number):
     """Create a list containing the current and next two round numbers.
 
     Parameters:
-        number (int):  The current round number.
+        number (int): The current round number.
 
     Returns:
         list: The current round number and the two that follow.
@@ -21,7 +21,7 @@ def concatenate_rounds(rounds_1, rounds_2):
     """Concatenate two lists of round numbers.
 
     Parameters:
-        rounds_1 (list):  The first rounds played.
+        rounds_1 (list): The first rounds played.
         rounds_2 (list): The second group of rounds played.
 
     Returns:
@@ -35,7 +35,7 @@ def list_contains_round(rounds, number):
     """Check if the list of rounds contains the specified number.
 
     Parameters:
-        rounds  (list): The rounds played.
+        rounds (list): The rounds played.
         number (int): The round number.
 
     Returns:


### PR DESCRIPTION
See [Issue 4165](https://github.com/exercism/python/issues/4165) for more details.