### PR TITLE
[Locomotive Engineer/Unpacking]: Cleaned up Typos & Grammar in stubs, exemplar, and docs.

### DIFF
--- a/exercises/concept/locomotive-engineer/.docs/hints.md
+++ b/exercises/concept/locomotive-engineer/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- To extract multiple arguments in the function parameters so can you pack them with the `*args` operator for `list` or `tuples` or `**kwargs` for keyword-based arguments.
+- A function can be defined to take multiple arguments packaged together by using the `*args` parameter for `list` & `tuple` arguments, or the `**kwargs` parameter for dictionary/keyword-based arguments.
 - To pack or unpack use the `*` or `**` operator.
 
 ## 1. Create a list of all wagons
@@ -11,7 +11,7 @@
 
 ## 2. Fix list of wagons
 
-- Using unpacking with the `*` operator, lets you extract the first two elements of a `list` while keeping the rest intact.
+- Using unpacking with the `*` operator allows you to extract the first two elements of a `list` while keeping the rest intact.
 - To add another `list` into an existing `list`, you can use the `*` operator to "spread" the `list`.
 
 ## 3. Add missing stops
@@ -28,7 +28,7 @@
 
 ## 5. Fix the wagon depot
 
-- `zip(*iterators)` can use used to transpose a nested `list`.
+- `zip(*iterators)` can be used to transpose a nested `list`.
 - To extract data from zipped iterators, you can use a for loop.
-- you can also unpack zipped iterators using `*`.  
+- you can also unpack zipped iterators using `*`.
   `[*content] = zip(iterator_1, iterator_2)` will unzip the `tuple` produced by `zip()` into a `list`.

--- a/exercises/concept/locomotive-engineer/.meta/exemplar.py
+++ b/exercises/concept/locomotive-engineer/.meta/exemplar.py
@@ -5,10 +5,10 @@ def get_list_of_wagons(*args):
     """Return a list of wagons, given an arbitrary amount of wagon numbers.
 
     Parameters:
-       *args: An arbitrary number of wagon numbers, unpacked.
+        An arbitrary number of wagon numbers, unpacked.
 
     Returns:
-        list: A list of wagon numbers, assembled from *args..
+        list: A list of wagon numbers.
     """
 
     return list(args)
@@ -19,7 +19,7 @@ def fix_list_of_wagons(each_wagons_id, missing_wagons):
 
     Parameters:
         each_wagons_id (list[int]): The list of wagons.
-        missing_wagons (list[int]) The list of missing wagons.
+        missing_wagons (list[int]): The list of missing wagons.
 
     Returns:
         list[int]: The corrected list of wagons.
@@ -35,7 +35,7 @@ def add_missing_stops(route, **kwargs):
 
     Parameters:
         route (dict): The dict of routing information.
-        **kwargs: arbitrary number of stops.
+        (dict): An arbitrary number of stops.
 
     Returns:
         dict: The updated route dictionary.
@@ -62,10 +62,10 @@ def fix_wagon_depot(wagons_rows):
     """Fix the list of rows of wagons.
 
     Parameters:
-        wagons_rows (list[tuple]) The list of rows of wagons.
+        wagons_rows (list[list[tuple]]): The list of rows of wagons.
 
     Returns:
-        list[tuple]: the list of rows of wagons.
+        list[list[tuple]]: the list of rows of wagons.
     """
 
     [*row_one], [*row_two], [*row_three] = zip(*wagons_rows)

--- a/exercises/concept/locomotive-engineer/locomotive_engineer.py
+++ b/exercises/concept/locomotive-engineer/locomotive_engineer.py
@@ -5,7 +5,7 @@ def get_list_of_wagons():
     """Return a list of wagons, given an arbitrary amount of wagon numbers.
 
     Parameters:
-       An arbitrary number of wagon numbers, unpacked.
+        An arbitrary number of wagon numbers, unpacked.
 
     Returns:
         list: A list of wagon numbers.
@@ -18,7 +18,7 @@ def fix_list_of_wagons(each_wagons_id, missing_wagons):
 
     Parameters:
         each_wagons_id (list[int]): The list of wagons.
-        missing_wagons (list[int]) The list of missing wagons.
+        missing_wagons (list[int]): The list of missing wagons.
 
     Returns:
         list[int]: The corrected list of wagons.
@@ -31,7 +31,7 @@ def add_missing_stops(route):
 
     Parameters:
         route (dict): The dict of routing information.
-        (dict): arbitrary number of stops.
+        (dict): An arbitrary number of stops.
 
     Returns:
         dict: The updated route dictionary.
@@ -56,9 +56,9 @@ def fix_wagon_depot(wagons_rows):
     """Fix the list of rows of wagons.
 
     Parameters:
-        wagons_rows (list[tuple]) The list of rows of wagons.
+        wagons_rows (list[list[tuple]]): The list of rows of wagons.
 
     Returns:
-        list[tuple]: the list of rows of wagons.
+        list[list[tuple]]: the list of rows of wagons.
     """
     pass


### PR DESCRIPTION
See [Issue 4165](https://github.com/exercism/python/issues/4165) for more details.