### PR TITLE
[Tests.md]: Change Curly Brackets to Angled in Command Examples

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -13,32 +13,32 @@ Extended information can be found in our website [Python testing guide][Python t
 
 ### Running Tests
 
-To run the included tests, navigate to the folder where the exercise is stored using `cd` in your terminal (_replace `{exercise-folder-location}` below with your path_).
+To run the included tests, navigate to the folder where the exercise is stored using `cd` in your terminal (_replace `<exercise-folder-location>` below with your path_).
 Test files usually end in `_test.py`, and are the same tests that run on the website when a solution is uploaded.
 
 Linux/MacOS
 ```bash
-$ cd {path/to/exercise-folder-location}
+$ cd <path/to/exercise-folder-location>
 ```
 
 Windows
 ```powershell
-PS C:\Users\foobar> cd {path\to\exercise-folder-location}
+PS C:\Users\foobar> cd <path\to\exercise-folder-location>
 ```
 
 <br>
 
-Next, run the `pytest` command in your terminal, replacing `{exercise_test.py}` with the name of the test file:
+Next, run the `pytest` command in your terminal, replacing `<exercise_test.py>` with the name of the test file:
 
 Linux/MacOS
 ```bash
-$ python3 -m pytest -o markers=task {exercise_test.py}
+$ python3 -m pytest -o markers=task <exercise_test.py>
 ==================== 7 passed in 0.08s ====================
 ```
 
 Windows
 ```powershell
-PS C:\Users\foobar> py -m pytest -o markers=task {exercise_test.py}
+PS C:\Users\foobar> py -m pytest -o markers=task <exercise_test.py>
 ==================== 7 passed in 0.08s ====================
 ```
 


### PR DESCRIPTION
Solves the other half of [this forum issue](https://forum.exercism.org/t/cannot-run-pytest-in-windows/13946) by changing brackets in the downloaded file `exercises/shared/.docs/tests.md` from curly to angled.